### PR TITLE
fix: add --platform linux/amd64 to docker build for public ECR push

### DIFF
--- a/scaled-execution-containers/deployment/1-build-and-push.sh
+++ b/scaled-execution-containers/deployment/1-build-and-push.sh
@@ -120,9 +120,9 @@ log_info "Building container from Dockerfile..."
 cd "$PROJECT_ROOT/container"
 if [ "$FORCE_REBUILD" = true ]; then
     log_info "Using --no-cache for clean build"
-    docker build --no-cache -t "$ECR_REPO_NAME:latest" .
+    docker build --platform linux/amd64 --no-cache -t "$ECR_REPO_NAME:latest" .
 else
-    docker build -t "$ECR_REPO_NAME:latest" .
+    docker build --platform linux/amd64 -t "$ECR_REPO_NAME:latest" .
 fi
 log_success "Container built"
 


### PR DESCRIPTION
On Apple Silicon Macs, docker build defaults to arm64, causing 'exec format error' on Fargate (x86_64). This matches the CDK private build which explicitly sets Platform.LINUX_AMD64.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
