### PR TITLE
prevent check-prereqs.sh from hanging when CDK is not installed

### DIFF
--- a/scaled-execution-containers/deployment/check-prereqs.sh
+++ b/scaled-execution-containers/deployment/check-prereqs.sh
@@ -107,13 +107,12 @@ echo ""
 
 # Check AWS CDK CLI (for CDK deployment)
 echo "6. Checking AWS CDK CLI (for CDK deployment)..."
-if command -v cdk &> /dev/null || npx cdk --version &> /dev/null 2>&1; then
-    if command -v cdk &> /dev/null; then
-        CDK_VERSION=$(cdk --version 2>&1)
-    else
-        CDK_VERSION=$(npx cdk --version 2>&1)
-    fi
+if command -v cdk &> /dev/null; then
+    CDK_VERSION=$(cdk --version 2>&1)
     echo "   ✅ AWS CDK installed: $CDK_VERSION"
+elif command -v npx &> /dev/null && timeout 10 npx --no cdk --version &> /dev/null 2>&1; then
+    CDK_VERSION=$(npx --no cdk --version 2>&1)
+    echo "   ✅ AWS CDK installed (via npx): $CDK_VERSION"
 else
     echo "   ⚠️  AWS CDK is NOT installed (required for CDK deployment)"
     echo "      → Install: npm install -g aws-cdk"


### PR DESCRIPTION
*Issue #, if available:* 20

*Description of changes:* prevent check-prereqs.sh from hanging when CDK is not installed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
