### PR TITLE
added atx update to container start

### DIFF
--- a/scaled-execution-containers/container/entrypoint.sh
+++ b/scaled-execution-containers/container/entrypoint.sh
@@ -307,6 +307,14 @@ fi
 # ============================================================================
 
 
+# Update ATX CLI to latest version
+log "Updating AWS Transform CLI to latest version..."
+if retry atx update; then
+    log "ATX CLI updated successfully"
+else
+    log "Warning: ATX CLI update failed, continuing with installed version"
+fi
+
 # Download source code if provided
 if [[ -n "$SOURCE" ]]; then
     log "Downloading source code..."


### PR DESCRIPTION
*Description of changes:* added atx update to container start to ensure the latest atx version is being used. Logs from startup: 

2026-03-27T14:44:59.046000+00:00 atx/default/3a5389ddeb5643f285ddf8ce1518d14c [2026-03-27T14:44:59Z] Updating AWS Transform CLI to latest version...
2026-03-27T14:44:59.421000+00:00 atx/default/3a5389ddeb5643f285ddf8ce1518d14c Checking for updates...
2026-03-27T14:44:59.504000+00:00 atx/default/3a5389ddeb5643f285ddf8ce1518d14c ✓ You are already running 1.6.0
2026-03-27T14:44:59.504000+00:00 atx/default/3a5389ddeb5643f285ddf8ce1518d14c Use --force to reinstall the current version.
2026-03-27T14:44:59.516000+00:00 atx/default/3a5389ddeb5643f285ddf8ce1518d14c [2026-03-27T14:44:59Z] ATX CLI updated successfully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
