### PR TITLE
Add agentic-atx-platform to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the following components:
 - **aws-managed-definitions/** - AWS-Managed Transformations that can be leveraged for your project transformations
 - **scaled-execution-bash/** - Running bulk transformations using bash scripts
 - **scaled-execution-containers/** - Scalable, production-ready infrastructure for [AWS Transform custom](https://docs.aws.amazon.com/transform/latest/userguide/custom.html) - Run AI-driven code transformations on 1000s of repositories in parallel using AWS Batch and Fargate.
+- **agentic-atx-platform/** - Agentic AI–powered replatforming platform for [AWS Transform Custom](https://docs.aws.amazon.com/transform/latest/userguide/custom.html) built on [Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html) and [Strands Agents](https://strandsagents.com/) - Automatically analyze repositories, map them to existing transformations, dynamically create missing ones from natural-language requirements, and execute them in parallel via AWS Batch. Includes a React UI with single-repo, batch CSV, and custom-transformation creation workflows.
 
 ## Getting Started
 


### PR DESCRIPTION
Add the agentic replatforming platform entry to the directory structure, highlighting AWS Transform Custom, Amazon Bedrock AgentCore, and Strands Agents with links to docs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
