### PR TITLE
Add Java x86 → AWS Graviton (ARM64) migration transformation definition

### DIFF
--- a/aws-managed-definitions/README.md
+++ b/aws-managed-definitions/README.md
@@ -8,6 +8,7 @@ Out-of-box transformation definitions provided by AWS for common migration and u
 |----------|---------------|-------------|
 | Java | [Version Upgrade](java/version-upgrade.md) | Upgrade Java applications to newer JDK versions |
 | Java | [AWS SDK v1 → v2](java/aws-sdk-v1-to-v2.md) | Migrate from AWS SDK for Java v1 to v2 |
+| Java | [x86 → Graviton](graviton-migration/java/transformation-definition_x86-to-graviton.md) | Validate and migrate Java apps to AWS Graviton (ARM64) |
 | Node.js | [Version Upgrade](nodejs/version-upgrade.md) | Upgrade Node.js applications to newer runtime versions |
 | Node.js | [AWS SDK v2 → v3](nodejs/aws-sdk-v2-to-v3.md) | Migrate from AWS SDK for JavaScript v2 to v3 |
 | Python | [Version Upgrade](python/version-upgrade.md) | Upgrade Python 3.8/3.9 Lambda applications to 3.11+ |
@@ -24,9 +25,16 @@ Out-of-box transformation definitions provided by AWS for common migration and u
 aws-managed-definitions/
 ├── comprehensive-codebase-analysis/
 │   └── codebase-analysis.md
+├── graviton-migration/
+│   └── java/
+│       ├── transformation-definition_x86-to-graviton.md
+│       └── document_references/
+│           ├── agent-scope-boundaries.md
+│           └── documentation-standards.md
 ├── java/
 │   ├── version-upgrade.md
-│   └── aws-sdk-v1-to-v2.md
+│   ├── aws-sdk-v1-to-v2.md
+│   └── x86-to-graviton.md     # stub → graviton-migration/java/
 ├── nodejs/
 │   ├── version-upgrade.md
 │   └── aws-sdk-v2-to-v3.md

--- a/aws-managed-definitions/graviton-migration/README.md
+++ b/aws-managed-definitions/graviton-migration/README.md
@@ -1,0 +1,39 @@
+# Graviton Migration Transformation Definitions
+
+Transformation definitions for migrating applications from x86 to AWS Graviton (ARM64) architecture.
+
+## Available Definitions
+
+| Language | Transformation | Description |
+|----------|---------------|-------------|
+| Java | [x86 → Graviton](java/transformation-definition_x86-to-graviton.md) | Validate and migrate Java applications to AWS Graviton (ARM64) architecture |
+
+## What These TDs Do
+
+Graviton migration TDs validate application compatibility with ARM64 architecture and make only the minimum changes required for ARM64 support. They do **not** perform general modernization, security updates, or version upgrades.
+
+### 3-Phase Workflow
+1. **Static Analysis** — Scans for native `.so` libraries, x86-only dependencies, and architecture-specific code patterns
+2. **Targeted Fixes** — Upgrades only ARM64-blocking dependencies, adds `aarch64` code paths, applies Graviton JVM flags
+3. **Validation** — Builds and tests on ARM64, classifies failures, validates container/startup behavior
+
+### Output
+Each transformation produces a structured `graviton-validation/` folder with 7 reports covering project assessment, native libraries, dependencies, code scan, JVM config, build/test results, and an executive summary.
+
+## Directory Structure
+
+```
+graviton-migration/
+└── java/
+    ├── transformation-definition_x86-to-graviton.md
+    └── document_references/
+        ├── agent-scope-boundaries.md
+        └── documentation-standards.md
+```
+
+## Reference Documents
+
+Each language TD includes reference documents in `document_references/`:
+
+- **agent-scope-boundaries.md** — Strict scope rules with decision trees ensuring only ARM64-blocking issues are addressed
+- **documentation-standards.md** — Canonical output folder structure and required report templates

--- a/aws-managed-definitions/graviton-migration/java/document_references/agent-scope-boundaries.md
+++ b/aws-managed-definitions/graviton-migration/java/document_references/agent-scope-boundaries.md
@@ -1,0 +1,247 @@
+# ARM64 Transformation - Agent Scope Boundaries
+
+## 🎯 Primary Objective
+Validate Java application compatibility with AWS Graviton (ARM64) architecture.  
+**Focus ONLY on ARM64-specific compatibility issues.**
+
+## Quick Reference: ARM64 Dependency Update Decision Tree
+
+Use this decision tree for EVERY dependency analysis:
+
+```
+Is this dependency update required for ARM64 compatibility?
+│
+├─ Does the dependency contain native code (.so, .dll, .dylib)?
+│  ├─ YES → Does current version have ARM64 binaries?
+│  │  ├─ NO → ✅ MUST UPGRADE (ARM64 native libraries missing)
+│  │  └─ YES → ✅ COMPATIBLE (has ARM64 support)
+│  └─ NO (Pure Java) → ✅ COMPATIBLE (pure Java works on all architectures)
+│
+├─ Does current version FAIL to build on ARM64?
+│  ├─ YES → Check why:
+│  │  ├─ Missing ARM64 artifacts? → ✅ MUST UPGRADE
+│  │  ├─ Architecture detection issue? → ✅ MUST UPGRADE  
+│  │  └─ Other reason? → Investigate root cause
+│  └─ NO → Continue checking...
+│
+├─ Does current version FAIL to run on ARM64?
+│  ├─ YES → Check why:
+│  │  ├─ UnsatisfiedLinkError? → ✅ MUST UPGRADE (native lib issue)
+│  │  ├─ Documented ARM64 bug? → ✅ MUST UPGRADE
+│  │  └─ Other reason? → Investigate root cause
+│  └─ NO → Continue checking...
+│
+└─ Is the only reason "old version" or "best practice"?
+   └─ YES → ❌ OUT OF SCOPE (not an ARM64 issue)
+
+RESULT:
+- If no ARM64-specific issue found → Mark COMPATIBLE, do NOT upgrade
+- If ARM64-specific issue found → Document evidence and upgrade
+```
+
+**Quick Test Questions:**
+1. ❓ Will keeping this version cause ARM64 build to fail? 
+2. ❓ Will keeping this version cause ARM64 runtime to fail?
+3. ❓ Is there documented evidence of ARM64 incompatibility?
+
+If all answers are **NO** → **Do not upgrade** (out of scope)
+
+## ✅ IN SCOPE: What to Fix
+
+### 1. Native Library Issues
+- ✅ Dependencies with x86-only `.so`/`.dll`/`.dylib` files
+- ✅ Missing ARM64 native library artifacts
+- ✅ Example: JNA 5.6.0 → 5.8.0 (lacks ARM64 .so files)
+
+### 2. Build Tool Artifacts
+- ✅ Protoc compiler missing ARM64 executables
+- ✅ Build plugins missing ARM64 classifiers
+- ✅ Example: protoc 3.3.0 → 3.21.0 (no osx-aarch_64 artifact)
+
+### 3. Architecture Detection
+- ✅ Code checking for "amd64" without "aarch64" handling
+- ✅ Build plugins not detecting ARM64 architecture
+- ✅ Example: os-maven-plugin 1.4.1 → 1.7.0 (aarch64 detection)
+
+### 4. Documented ARM64 Bugs
+- ✅ Current version has known ARM64-specific runtime failures
+- ✅ Must have issue tracker evidence or release notes
+- ✅ Example: "Version X causes crash only on ARM64"
+
+## ❌ OUT OF SCOPE: What NOT to Fix
+
+### 1. General Dependency Modernization
+- ❌ "This version is old" → NOT an ARM64 issue
+- ❌ "We should use latest" → NOT an ARM64 issue
+- ❌ "Deprecated library" → NOT an ARM64 issue
+- ❌ Example: JUnit 3.8.1 → 4.13.2 (pure Java, works on ARM64)
+
+### 2. Security Updates
+- ❌ CVE fixes or vulnerability patches
+- ❌ Example: Log4j 1.2.17 → 2.20.0 (security, not ARM64)
+
+### 3. Feature Upgrades
+- ❌ Newer features or better performance
+- ❌ API modernization
+- ❌ Example: Spring 4.x → 5.x (features, not ARM64)
+
+### 4. Java Version Changes
+- ❌ Java 8 → 11 or Java 11 → 17 upgrades
+- ❌ JDK distribution changes (OpenJDK → Corretto)
+- ❌ Exception: Session-scoped Java switching for build tooling compatibility
+
+### 5. Code Refactoring
+- ❌ Code quality improvements
+- ❌ Design pattern changes
+- ❌ Performance optimizations (except Graviton-specific JVM flags)
+
+## 🔍 Decision Tree: Should I Update This Dependency?
+
+```
+For each dependency, ask in order:
+
+1. Does it contain native code?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → Continue to #2
+
+2. Does current version have ARM64 binaries?
+   YES → Mark COMPATIBLE, do NOT update
+   NO → Continue to #3
+
+3. Will build FAIL on ARM64 without update?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → MUST UPGRADE (document evidence)
+
+4. Will runtime FAIL on ARM64 without update?
+   NO → Mark COMPATIBLE, do NOT update
+   YES → MUST UPGRADE (document evidence)
+```
+
+**Simple Rule:** If it builds and runs on ARM64 today → **DO NOT UPDATE**
+
+## 📋 Common Pure Java Libraries (Always ARM64-Compatible)
+
+These are **almost always** ARM64-compatible without updates:
+
+**Testing Frameworks:**
+- JUnit (any version - even 3.8.1 from 2004)
+- TestNG
+- Mockito  
+- Hamcrest
+- AssertJ
+
+**Logging:**
+- Log4j 1.x and 2.x
+- SLF4J
+- Logback
+- Commons-Logging
+
+**Utilities:**
+- Commons-Lang
+- Commons-Collections
+- Commons-IO
+- Guava
+
+**Serialization:**
+- Jackson
+- Gson
+- JAXB
+
+**HTTP Clients (Pure Java):**
+- Apache HttpClient
+- OkHttp (Java parts)
+
+## 🚫 Red Flags: When Agent is Going Off-Scope
+
+**Stop immediately if you see:**
+- ❌ "This version is from [old year], should update"
+- ❌ "Security vulnerability CVE-XXXX-YYYY"
+- ❌ "Best practice to use latest version"
+- ❌ "Deprecated API, should modernize"
+- ❌ "Better performance in newer version"
+- ❌ "More features in latest release"
+
+**Correct responses:**
+- ✅ "Version X lacks linux-aarch_64 artifact"
+- ✅ "UnsatisfiedLinkError on ARM64 with version X"
+- ✅ "Build fails on ARM64: missing native library"
+- ✅ "Documented ARM64 crash in issue #XXXX"
+
+## ✅ How to Document Scope Compliance
+
+### For Updates Made:
+```markdown
+## ARM64-Required Dependency Updates
+
+| Dependency | Old → New | ARM64 Issue | Evidence |
+|------------|-----------|-------------|----------|
+| protoc | 3.3.0 → 3.21.0 | Missing osx-aarch_64 artifact | Build log shows "Could not find artifact" |
+| JNA | 5.6.0 → 5.8.0 | Missing ARM64 .so files | Runtime UnsatisfiedLinkError on ARM64 |
+```
+
+### For Updates NOT Made:
+```markdown
+## Dependencies Validated as ARM64-Compatible (No Updates)
+
+| Dependency | Version | Status | Notes |
+|------------|---------|--------|-------|
+| JUnit | 3.8.1 | ✅ Compatible | Pure Java, works on ARM64. Modernization out of scope. |
+| Log4j | 1.2.17 | ✅ Compatible | Pure Java, no ARM64 issues. Security updates out of scope. |
+| Commons-Lang | 2.6 | ✅ Compatible | Pure Java library, fully ARM64-compatible. |
+```
+
+## 🎓 Learning from Past Mistakes
+
+### Case Study: JUnit 3.8.1
+
+**Initial Analysis (WRONG):**
+> "JUnit 3.8.1 is from 2004, mark as MUST UPGRADE for modern Java compatibility"
+
+**Why This Was Wrong:**
+- JUnit 3.8.1 is pure Java (no native code)
+- It builds successfully on ARM64
+- It runs successfully on ARM64 with Java 17
+- Being "old" is NOT an ARM64 compatibility issue
+
+**Correct Analysis:**
+> "JUnit 3.8.1: Pure Java library, no native dependencies, builds and runs successfully on ARM64. Status: COMPATIBLE. No update required for ARM64 compatibility. Note for user: Consider upgrading to JUnit 4/5 as part of separate modernization effort."
+
+### Case Study: Protoc 3.3.0
+
+**Analysis (CORRECT):**
+> "Protoc 3.3.0 lacks osx-aarch_64 and linux-aarch_64 artifacts in Maven Central. Build will fail on ARM64 with 'Could not resolve artifact' error. MUST UPGRADE to 3.21.0+ which includes ARM64 executables."
+
+**Why This Was Correct:**
+- Specific ARM64 artifact missing
+- Build WILL fail on ARM64
+- Evidence-based reasoning
+- Clear minimum version requirement
+
+## 🎯 Success Criteria
+
+**Transformation is successful when:**
+1. ✅ Application builds on ARM64 without errors
+2. ✅ Application runs on ARM64 without crashes
+3. ✅ All tests pass on ARM64
+4. ✅ Only ARM64-specific issues were addressed
+5. ✅ No scope creep into general modernization
+
+**Transformation has scope creep if:**
+1. ❌ Updated dependencies that already worked on ARM64
+2. ❌ Fixed security issues unrelated to ARM64
+3. ❌ Modernized code for "best practices"
+4. ❌ Upgraded Java version unnecessarily
+5. ❌ Refactored working code
+
+## 📞 When in Doubt
+
+**Ask yourself:**
+- "If I don't make this change, will ARM64 build/runtime fail?"
+- "Is there concrete evidence this current version breaks on ARM64?"
+- "Am I updating this because it's old, or because ARM64 requires it?"
+
+**If unsure:** Mark as COMPATIBLE and document reasoning. It's better to under-fix than to introduce unnecessary scope creep.
+
+---
+
+**Remember:** This is an ARM64 compatibility validation, not a general dependency modernization project. Stay focused on ARM64-specific issues only.

--- a/aws-managed-definitions/graviton-migration/java/document_references/documentation-standards.md
+++ b/aws-managed-definitions/graviton-migration/java/document_references/documentation-standards.md
@@ -1,0 +1,324 @@
+# ARM64 Transformation — Documentation Standards
+
+## Purpose
+This document defines the standard output folder structure, canonical filenames, and content requirements for all documentation produced during an ARM64 Graviton compatibility transformation. Adherence to this standard ensures consistency across transformation runs regardless of which agent executes the work.
+
+## Output Folder Structure
+
+All transformation output documents MUST be written to a single folder named `graviton-validation/` in the project root. The agent MUST create this folder and its `raw/` subfolder at the start of Phase 1 before any analysis begins.
+
+```
+<project-root>/
+└── graviton-validation/
+    ├── 00-summary.md                        # Final roll-up of all findings and exit criteria
+    ├── 01-project-assessment.md             # Project structure, deployment type, Java environment
+    ├── 02-native-library-report.md          # All .so / native library findings and resolutions
+    ├── 03-dependency-compatibility-report.md # Per-dependency ARM64 compatibility verdicts
+    ├── 04-code-scan-findings.md             # Architecture-specific code patterns detected
+    ├── 05-jvm-configuration.md              # Graviton-optimized JVM flags and profiles
+    ├── 06-build-test-results.md             # Build validation, test results, failure classification
+    └── raw/                                 # Machine-generated artifacts (not hand-authored)
+        ├── dependency-tree-full.txt         # Full dependency tree output
+        └── dependency-tree-native.txt       # Filtered tree (native-code artifacts only)
+```
+
+## Agent Instructions
+
+1. **Create `graviton-validation/` and `graviton-validation/raw/` at the start of Phase 1.** This is the first action before any analysis.
+2. **Use EXACTLY these filenames.** Do not rename, renumber, or create additional top-level files.
+3. **Write to each file progressively** as the corresponding phase completes. Do not wait until the end to produce all documentation.
+4. **Raw files go in `raw/`.** Only machine-generated command output belongs in `raw/`. Do not put authored content there.
+5. **`00-summary.md` is written last**, after all other files are complete. It references (not duplicates) the detail in files 01–06.
+6. **If a section has no findings**, include the section header with an explicit "No findings" statement. Do not omit empty sections — their absence is ambiguous.
+7. **Do not create documentation files outside `graviton-validation/`.** All transformation documentation lives in this single folder.
+
+---
+
+## File Specifications
+
+### `00-summary.md` — Transformation Summary
+
+**Created:** End of transformation (Phase 3 complete)
+**Purpose:** Single-page executive summary mapping to all exit criteria. This is the first file a reviewer reads.
+
+**Required sections:**
+```markdown
+# ARM64 Compatibility Validation — Summary
+
+## Project Overview
+- **Project Name:** <n>
+- **Deployment Type:** Containerized | Host-based | Both
+- **Java Version:** <version>
+- **JDK Distribution:** <distribution>
+- **Build Tool:** Maven <version> | Gradle <version>
+- **Multi-Module:** Yes (N modules) | No
+- **Date:** <ISO 8601>
+
+## Exit Criteria Checklist
+| # | Criterion | Status | Notes |
+|---|-----------|--------|-------|
+| 1 | Compiles on ARM64 without errors | ✅ PASS / ❌ FAIL | |
+| 2 | Native libraries load on ARM64 | ✅ PASS / ❌ FAIL | |
+| 3 | Blocking dependency updates applied | ✅ PASS / ❌ FAIL | |
+| 4 | No ARM64-specific runtime errors | ✅ PASS / ❌ FAIL | |
+| 5 | Container image builds on ARM64 | ✅ PASS / ❌ FAIL / N/A | |
+| 6 | Test suite executes on ARM64 | ✅ PASS / ❌ FAIL | |
+| 7 | No ARM64-related test failures | ✅ PASS / ❌ FAIL | |
+| 8 | Application starts on ARM64 | ✅ PASS / ❌ FAIL | |
+| 9 | JVM flags accepted without errors | ✅ PASS / ❌ FAIL | |
+
+## Changes Made
+<Brief summary of dependency updates, native library resolutions, code changes.
+Reference detail files: 02-native-library-report.md, 03-dependency-compatibility-report.md, 04-code-scan-findings.md>
+
+## Remaining Concerns
+<Any unresolved issues, user-responsibility items, or known limitations>
+```
+
+---
+
+### `01-project-assessment.md` — Project & Environment Assessment
+
+**Created:** Phase 1.1 and Phase 1.5
+**Purpose:** Records the baseline project state before any changes.
+
+**Required sections:**
+```markdown
+# Project Assessment
+
+## Deployment Type
+<Containerized | Host-based | Both>
+<Evidence: e.g., "Dockerfile found at ./Dockerfile", "systemd unit at ./deploy/app.service">
+
+## Project Structure
+- **Build Tool:** Maven | Gradle
+- **Multi-Module:** Yes | No
+- **Submodules:** <list if applicable>
+
+## Java Environment
+- **Java Version:** <exact version, e.g., 17.0.8>
+- **JDK Distribution:** <e.g., Eclipse Temurin, Amazon Corretto, OpenJDK>
+- **ARM64 Support Status:** Supported | Supported with limitations
+- **Known Graviton Issues:** None | <description>
+
+## Component Risk Categorization
+| Component | Risk Level | Rationale |
+|-----------|-----------|-----------|
+| <component> | CRITICAL / HIGH / MEDIUM / LOW | <why> |
+```
+
+---
+
+### `02-native-library-report.md` — Native Library Analysis & Resolution
+
+**Created:** Phase 1.2 (analysis), updated in Phase 2.1 (resolution)
+**Purpose:** Documents every native library found — bundled and runtime-extracted — its architecture, and how it was resolved.
+
+**Required sections:**
+```markdown
+# Native Library Report
+
+## Statically Bundled Libraries
+| Library | Source JAR/Location | Architecture | Verdict | Resolution |
+|---------|-------------------|--------------|---------|------------|
+| libfoo.so | commons-crypto-1.1.0.jar | x86_64 only | FAIL | Upgraded to 1.2.0 (includes aarch64) |
+| libbar.so | app-native/lib/ | ARM aarch64 | PASS | No action needed |
+
+## Runtime-Extracted Libraries
+| Dependency | Artifact | Extracts Native Code | ARM64 Support in Current Version | Verdict | Resolution |
+|------------|----------|---------------------|----------------------------------|---------|------------|
+| netty-transport-native-epoll | 4.1.68.Final | Yes | Yes (linux-aarch_64 classifier) | PASS | No action needed |
+| snappy-java | 1.1.7.3 | Yes | No (x86_64 only) | FAIL | Upgraded to 1.1.10.5 |
+
+## Resolution Details
+<For each FAIL or WARN, describe the resolution approach>
+
+## Pure Java Fallbacks Documented
+<List any libraries where a pure Java fallback path was chosen instead of native resolution>
+
+## No Findings
+<If no native libraries were detected, state explicitly:>
+No native libraries (bundled or runtime-extracted) detected. All dependencies are pure Java.
+```
+
+---
+
+### `03-dependency-compatibility-report.md` — Dependency ARM64 Compatibility
+
+**Created:** Phase 1.3 (analysis), updated in Phase 2.2 (resolution)
+**Purpose:** The primary dependency-by-dependency compatibility assessment.
+
+**Required sections:**
+```markdown
+# Dependency ARM64 Compatibility Report
+
+## MUST UPGRADE (Blocking)
+| Dependency | Current Version | Minimum ARM64 Version | Applied Version | ARM64 Issue | Evidence |
+|------------|----------------|----------------------|-----------------|-------------|----------|
+| net.java.dev.jna:jna | 5.6.0 | 5.8.0 | 5.14.0 | Missing ARM64 .so | UnsatisfiedLinkError on aarch64 |
+
+## RECOMMENDED UPGRADE (Non-Blocking)
+| Dependency | Current Version | Recommended Version | Reason | Action Taken |
+|------------|----------------|--------------------|---------|---|
+| <dep> | <ver> | <ver> | ARM64 perf improvement | Documented for user |
+
+## COMPATIBLE (No Action Needed)
+| Dependency | Version | Basis |
+|------------|---------|-------|
+| junit:junit | 3.8.1 | Pure Java — no native code |
+| com.google.guava:guava | 31.1-jre | Pure Java — no native code |
+
+## Transitive Dependency Resolutions
+| Transitive Dependency | Pulled In By | Issue | Resolution Method |
+|-----------------------|-------------|-------|-------------------|
+| org.xerial.snappy:snappy-java 1.1.7.3 | kafka-clients 2.7.0 | No linux-aarch64 binary | dependencyManagement override to 1.1.10.5 |
+```
+
+---
+
+### `04-code-scan-findings.md` — Architecture-Specific Code Detection
+
+**Created:** Phase 1.4, updated in Phase 2.3 (resolution)
+**Purpose:** Records all source code locations with architecture-sensitive patterns and changes applied.
+
+**Required sections:**
+```markdown
+# Architecture-Specific Code Scan
+
+## Architecture Detection Patterns Found
+| File | Line(s) | Pattern | ARM64 Handling Present | Action Required |
+|------|---------|---------|----------------------|-----------------|
+| src/.../NativeLoader.java | 42-48 | System.getProperty("os.arch") | No — only checks "amd64" | Add "aarch64" branch |
+
+## JNI/JNA Usage
+| File | Line(s) | Type | Library | ARM64 Validated |
+|------|---------|------|---------|-----------------| 
+| src/.../Bridge.java | 23 | JNA Native.load() | libbridge.so | Yes — aarch64 binary present |
+
+## Changes Applied
+<Summary of code changes made in Phase 2.3 to add ARM64 handling>
+
+## No Findings
+<If no architecture-specific code was detected, state explicitly:>
+No architecture-specific code patterns, JNI, or JNA usage detected. All code is pure Java.
+```
+
+---
+
+### `05-jvm-configuration.md` — Graviton JVM Optimization
+
+**Created:** Phase 2.5
+**Purpose:** Records the JVM flags applied, version-gated rationale, and validation results.
+
+**Required sections:**
+```markdown
+# Graviton JVM Configuration
+
+## Target Java Version
+<JDK version used for flag selection, e.g., JDK 17>
+
+## Applied JVM Flags
+| Flag | Applicable JDK Versions | Workload Type | Expected Impact |
+|------|------------------------|---------------|-----------------|
+| -XX:-TieredCompilation | 11, 17, 21+ | Moderate lock contention | Reduced compilation overhead |
+
+## Flags NOT Applied (Version-Gated)
+| Flag | Reason Not Applied |
+|------|-------------------|
+| -XX:CompilationMode=high-only | Removed in JDK 21+; project uses JDK 21 |
+
+## Flag Validation
+<Output of: java <flags> -version>
+<Confirm all flags accepted without errors>
+
+## Configuration Profiles
+<If multiple profiles were created for different workload types, list them here>
+```
+
+---
+
+### `06-build-test-results.md` — Build & Test Validation Results
+
+**Created:** Phase 3.1, 3.2, 3.3
+**Purpose:** Records all build attempts, test execution results, failure classifications, and startup checks.
+
+**Required sections:**
+```markdown
+# Build & Test Validation Results
+
+## Build Environment
+- **Architecture:** <output of `uname -m`, should be aarch64>
+- **Java Runtime:** <output of `java -version`>
+- **Build Tool:** <Maven/Gradle version>
+- **Build Environment Notes:** <any Java runtime alignment applied per Phase 3.0>
+
+## Build Attempts
+| # | Command | Result | Notes |
+|---|---------|--------|-------|
+| 1 | `./gradlew clean build` | ❌ FAIL | 3 test failures — see classification below |
+| 2 | `./gradlew clean build -x test` | ✅ PASS | Compilation successful |
+
+## Test Failure Classification
+| Test | Class | Failure Type | Root Cause | Blocking |
+|------|-------|-------------|------------|----------|
+| testDbConnection | IntegrationTest | INFRA | PostgreSQL not available | No |
+| testNativeAccel | CryptoTest | ARM64 | UnsatisfiedLinkError | Yes |
+
+## Final Build (Scoring Basis)
+- **Command:** <the final build command>
+- **Result:** ✅ PASS / ❌ FAIL
+- **Rationale:** <why this is the scoring build>
+
+## Container Validation (if applicable)
+- **Build Command:** `docker build -t app:arm64 .`
+- **Result:** ✅ PASS / ❌ FAIL
+- **Architecture Verified:** `os.arch = aarch64`
+- **JDK Verified:** <matches original distribution and version>
+
+## Startup Validation
+- **Application starts without errors:** ✅ Yes | ❌ No
+- **JVM flags accepted:** ✅ Yes | ❌ No
+- **Runtime crashes:** None | <description>
+```
+
+---
+
+### `raw/dependency-tree-full.txt`
+
+**Created:** Phase 1.1 step 2
+**Purpose:** Raw output from `mvn dependency:tree` or `./gradlew dependencies`. Kept for traceability; not hand-edited.
+
+---
+
+### `raw/dependency-tree-native.txt`
+
+**Created:** Phase 1.3 step 1
+**Purpose:** Filtered dependency tree showing only known native-code artifacts. Kept for traceability; not hand-edited.
+
+---
+
+## Mapping: Transformation Steps → Output Files
+
+| # | Transformation Step | What Is Produced | Output File |
+|---|---|---|---|
+| 1 | 1.1 step 1 — Deployment type | Containerized vs host-based | `01-project-assessment.md` |
+| 2 | 1.1 step 2 — Dependency tree generation | Raw tree output | `raw/dependency-tree-full.txt` |
+| 3 | 1.1 step 4 — Component risk categorization | CRITICAL/HIGH/MEDIUM/LOW table | `01-project-assessment.md` |
+| 4 | 1.2.1 — Statically bundled .so scan | Architecture per .so file | `02-native-library-report.md` |
+| 5 | 1.2.2 — Runtime-extracted native detection | Libraries extracting native code | `02-native-library-report.md` |
+| 6 | 1.2.3 — Tiered validation verdicts | FAIL/WARN/PASS per library | `02-native-library-report.md` |
+| 7 | 1.2.3 step 3 — Recompilation requirements | Resolution notes | `02-native-library-report.md` |
+| 8 | 1.3 step 1 — Filtered transitive tree | Native-artifact-only tree | `raw/dependency-tree-native.txt` |
+| 9 | 1.3 step 3 — Compatibility report | MUST UPGRADE / RECOMMENDED / COMPATIBLE | `03-dependency-compatibility-report.md` |
+| 10 | 1.3 step 4 — Per-dependency findings | Detailed blocks per dependency | `03-dependency-compatibility-report.md` |
+| 11 | 1.4 — Code scan | Architecture patterns, JNI/JNA usage | `04-code-scan-findings.md` |
+| 12 | 1.5 — Java version & distribution | Version and distro record | `01-project-assessment.md` |
+| 13 | 2.1 — Native library resolution | Resolution per .so, fallback decisions | `02-native-library-report.md` |
+| 14 | 2.5 step 2 — JVM flag documentation | Flags, rationale, impact | `05-jvm-configuration.md` |
+| 15 | 2.5 step 3 — Config profiles | Workload-specific flag sets | `05-jvm-configuration.md` |
+| 16 | 3.0 — Annotation processor notes | Processor/version requiring alignment | `06-build-test-results.md` |
+| 17 | 3.0 — Blocker: no compatible JDK | Requirement documentation | `06-build-test-results.md` |
+| 18 | 3.1 — Build test classification | INFRA/ARM64/PRE-EXISTING per failure | `06-build-test-results.md` |
+| 19 | 3.2 — Functional test results | All test results, classification | `06-build-test-results.md` |
+| 20 | 3.3 — Startup validation | Start/flags/crash checks | `06-build-test-results.md` |
+| 21 | Exit — Summary | Roll-up of all findings and exit criteria | `00-summary.md` |

--- a/aws-managed-definitions/graviton-migration/java/transformation-definition_x86-to-graviton.md
+++ b/aws-managed-definitions/graviton-migration/java/transformation-definition_x86-to-graviton.md
@@ -1,0 +1,1018 @@
+# Java Application AWS Graviton (ARM64) Compatibility Validation
+
+## Objective
+Validate and ensure Java application compatibility with AWS Graviton (ARM64) architecture by identifying incompatibilities, verifying native library support, and testing on ARM64 container images. This transformation focuses exclusively on ARM64 compatibility validation and does NOT manage Java version upgrades or general dependency modernization.
+
+## Summary
+This transformation validates a Java application's readiness to run on AWS Graviton instances by identifying architecture-specific incompatibilities, analyzing native library dependencies, verifying ARM64 support in critical dependencies, and testing the application on ARM64 container images. The process includes comprehensive compatibility checks, native library validation with a tiered failure policy, and performance verification on ARM64 architecture.
+
+## Entry Criteria
+1. Java application currently running on x86 architecture
+2. Source code and build scripts must be available and accessible
+3. Current Java version documented (must be compatible with ARM64 - typically JDK 8+)
+4. Build and deployment configurations (Maven/Gradle files, Dockerfiles if containerized, CI/CD pipelines)
+5. Access to ARM64 build/test environment (Graviton EC2 instances) or ARM64 container images
+6. Complete dependency list with current versions for ARM64 compatibility analysis
+7. Existing test suite that can be executed on ARM64 architecture
+
+## Implementation Steps
+
+**CRITICAL:** Java version changes are not in scope for this transformation process. Refer the user to AWS Transform Java version upgrade Transformation Definitions if a version change is required for any reason.
+
+**CRITICAL:** It is out of scope to perform code refactoring.
+
+**CRITICAL:** .gitignore and .dockerignore files must not be created or changed. Our purpose is to leave application code original.
+
+**IMPORTANT:** Executing build commands and unit tests requires Arm64 execution environment. If the execution environment is on x86, we can identify compatibility issues but cannot fully test the package. Users should execute the Transformation on a Graviton instance or alternate Arm64 environment for best results.
+
+### Documentation Setup
+
+**IMPORTANT:** Before beginning Phase 1, create the standard output folder structure. All transformation documentation MUST follow the canonical structure defined in `documentation-standards.md`. Refer to that document for required sections and content templates for each file.
+
+```bash
+mkdir -p graviton-validation/raw
+```
+
+The following files will be produced during this transformation:
+
+| File | Created During | Purpose |
+|------|---------------|---------|
+| `graviton-validation/01-project-assessment.md` | Phase 1.1, 1.5 | Project structure, deployment type, Java environment |
+| `graviton-validation/02-native-library-report.md` | Phase 1.2, updated 2.1 | Native library scan results and resolutions |
+| `graviton-validation/03-dependency-compatibility-report.md` | Phase 1.3, updated 2.2 | Per-dependency ARM64 compatibility verdicts |
+| `graviton-validation/04-code-scan-findings.md` | Phase 1.4, updated 2.3 | Architecture-specific code patterns |
+| `graviton-validation/05-jvm-configuration.md` | Phase 2.5 | Graviton JVM flags and validation |
+| `graviton-validation/06-build-test-results.md` | Phase 3.0–3.3 | Build attempts, test results, startup checks |
+| `graviton-validation/raw/dependency-tree-full.txt` | Phase 1.1 | Raw dependency tree output |
+| `graviton-validation/raw/dependency-tree-native.txt` | Phase 1.3 | Filtered native-artifact tree |
+| `graviton-validation/00-summary.md` | End of Phase 3 | Executive summary and exit criteria checklist |
+
+### Phase 1: Static Compatibility Analysis
+
+#### 1.1 Project Structure Analysis
+
+> **Output → `graviton-validation/01-project-assessment.md`** (Deployment Type, Project Structure, Component Risk sections)
+> **Output → `graviton-validation/raw/dependency-tree-full.txt`**
+
+1. **Determine Deployment Type:**
+   - Check for Dockerfile or container configuration → **Containerized deployment**
+   - Check for systemd/init scripts or direct JAR/WAR deployment → **Host-based deployment**
+   - Document deployment type to guide validation approach in Phase 3
+   - Note: Some applications may support both deployment types
+
+2. **Detect Multi-Module Project Structure:**
+   - Check for multi-module Maven project (parent POM with `<modules>` section)
+   - Check for multi-module Gradle project (`settings.gradle` or `settings.gradle.kts` with `include` directives)
+   - If multi-module: enumerate all submodules and analyze each independently
+   - Generate the full dependency tree to capture transitive dependencies:
+     ```bash
+     # Maven - full dependency tree across all modules
+     mvn dependency:tree -DoutputType=text > graviton-validation/raw/dependency-tree-full.txt
+
+     # Gradle - dependencies for all subprojects
+     ./gradlew dependencies --configuration runtimeClasspath > graviton-validation/raw/dependency-tree-full.txt
+     # Or for a specific subproject:
+     # ./gradlew :submodule-name:dependencies --configuration runtimeClasspath
+     ```
+   - Native libraries and architecture-sensitive code may reside in child modules; do NOT limit analysis to the root build file alone
+
+3. Identify key components requiring ARM64 validation:
+   - Java source code files with architecture-specific logic
+   - Build configuration files (Maven/Gradle) — including all submodule build files
+   - Native libraries and JNI components
+   - Deployment scripts and container configurations
+   - Architecture-specific code blocks
+
+4. Categorize components by ARM64 compatibility risk:
+   - **CRITICAL**: Native code (JNI/JNA), .so files, architecture-specific optimizations
+   - **HIGH**: Dependencies with known x86-only versions, crypto libraries
+   - **MEDIUM**: Build configurations, deployment scripts, architecture detection code
+   - **LOW**: Pure Java code without architecture dependencies
+
+#### 1.2 Native Library Validation (.so File Analysis)
+
+> **Output → `graviton-validation/02-native-library-report.md`** (Statically Bundled, Runtime-Extracted, Resolution Details sections)
+
+Native libraries that are incompatible with ARM64 can exist in two forms: **statically bundled** inside JAR files, and **dynamically extracted at runtime** by libraries such as JNA, Netty, or JNR. Both forms must be validated.
+
+##### 1.2.1 Statically Bundled .so File Scanning
+
+1. Scan all JAR files for native libraries, including nested JARs inside fat/uber JARs:
+   ```bash
+   # Create a temporary working directory for safe extraction
+   tmpdir=$(mktemp -d)
+   trap "rm -rf $tmpdir" EXIT
+
+   # For standard JARs
+   for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+     echo "=== Scanning: $jar ==="
+     unzip -l "$jar" 2>/dev/null | grep "\.so$"
+   done
+
+   # For Spring Boot fat JARs (nested JARs inside BOOT-INF/lib/)
+   for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+     nested=$(unzip -l "$jar" 2>/dev/null | grep "BOOT-INF/lib/.*\.jar$" | awk '{print $NF}')
+     if [ -n "$nested" ]; then
+       echo "=== Fat JAR detected: $jar ==="
+       unzip -q "$jar" -d "$tmpdir/fatjar" 2>/dev/null
+       for nested_jar in $(find "$tmpdir/fatjar/BOOT-INF/lib" -name "*.jar" 2>/dev/null); do
+         so_files=$(unzip -l "$nested_jar" 2>/dev/null | grep "\.so$")
+         if [ -n "$so_files" ]; then
+           echo "--- Nested JAR: $(basename $nested_jar) ---"
+           echo "$so_files"
+         fi
+       done
+       rm -rf "$tmpdir/fatjar"
+     fi
+   done
+
+   # For Maven Shade plugin uber JARs - scan the JAR directly
+   # (shaded JARs flatten everything into a single JAR, so the standard scan above covers them)
+
+   # Validate architecture of any discovered .so files
+   for jar in $(find . -name "*.jar" -not -path "*/build/*" -not -path "*/target/*"); do
+     unzip -q "$jar" -d "$tmpdir/extract" 2>/dev/null
+     find "$tmpdir/extract" -name "*.so" -exec file {} \;
+     rm -rf "$tmpdir/extract"
+   done
+   ```
+
+   **Fat/Uber JAR Types to Handle:**
+   - **Spring Boot fat JARs:** Native libs in nested JARs under `BOOT-INF/lib/`
+   - **Maven Shade plugin:** Flattened into single JAR; standard scan is sufficient
+   - **Gradle Shadow plugin:** Same as Maven Shade — flattened structure
+   - **WAR files:** Check `WEB-INF/lib/` for nested JARs containing native code
+
+##### 1.2.2 Runtime-Extracted Native Library Detection
+
+Some libraries do not bundle `.so` files in their JARs but instead extract or download architecture-specific native code at runtime. These must be identified through code and dependency analysis.
+
+1. Scan source code and dependencies for runtime native extraction patterns:
+   ```bash
+   # Search for runtime native library loading patterns in source code
+   grep -rn "Native.load\|Native.loadLibrary\|System.loadLibrary\|System.load(" \
+     --include="*.java" src/ || true
+
+   # Search for JNR (Java Native Runtime) usage
+   grep -rn "jnr\.\|LibraryLoader" --include="*.java" src/ || true
+
+   # Check build files for dependencies known to extract native code at runtime
+   grep -n "netty-transport-native\|netty-tcnative\|io.grpc.*netty\|conscrypt\|jnr-ffi\|jnr-posix\|leveldbjni\|rocksdbjni\|sqlite-jdbc\|lz4-java\|zstd-jni\|snappy-java" \
+     pom.xml build.gradle build.gradle.kts 2>/dev/null || true
+   ```
+
+2. **Common libraries that extract native code at runtime:**
+   - **Netty** (`netty-transport-native-epoll`, `netty-tcnative`): Extracts `.so` from JAR at runtime based on `os.arch`
+   - **Conscrypt:** TLS provider that loads native crypto libraries at runtime
+   - **RocksDB** (`rocksdbjni`): Extracts platform-specific `.so` at first use
+   - **SQLite JDBC** (`sqlite-jdbc`): Bundles and extracts native SQLite library
+   - **LZ4/Zstd/Snappy** (`lz4-java`, `zstd-jni`, `snappy-java`): Compression libraries with native accelerators
+   - **LevelDB** (`leveldbjni`): Native key-value store bindings
+
+3. For each runtime-extracting dependency identified:
+   - Check if the current version includes ARM64/aarch64 native binaries in its published JAR
+   - If ARM64 binaries are missing: flag as MUST UPGRADE in Phase 1.3
+   - If a pure Java fallback exists (e.g., Netty's NIO transport vs. native epoll): document the fallback option
+   - If no fallback and no ARM64 support: flag as blocking
+
+##### 1.2.3 Tiered Validation Policy
+
+2. Implement tiered validation policy for .so files (both bundled and runtime-extracted):
+
+   **FAIL immediately if:**
+   - .so file shows "x86-64" or "x86_64" architecture only
+   - AND no ARM64 version exists in the JAR (no aarch64/arm64 directory)
+   - AND source code is not available in the project
+   - AND user cannot provide ARM64-compatible version
+   
+   **WARN but allow to proceed if:**
+   - Multi-architecture JAR contains both x86 and ARM64 .so files
+   - Pure Java fallback implementation exists for the native functionality
+   - .so file source code is available for ARM64 recompilation
+   
+   **PASS if:**
+   - .so file shows "ARM aarch64" architecture
+   - JAR contains .so files in both `/linux/amd64/` and `/linux/aarch64/` directories
+
+3. For each x86-only .so file requiring resolution:
+   - Check if source code exists in project repository
+   - If source available: Document recompilation requirements
+   - If source unavailable: Prompt user for ARM64-compatible version
+   - Validate any provided .so file is ARM64 architecture:
+     ```bash
+     file libname.so  # Must show "ARM aarch64"
+     ```
+
+#### 1.3 Dependency ARM64 Compatibility Analysis
+
+> **Output → `graviton-validation/03-dependency-compatibility-report.md`** (all sections)
+> **Output → `graviton-validation/raw/dependency-tree-native.txt`**
+
+**IMPORTANT: Transitive Dependency Analysis**
+
+ARM64-incompatible native code can be introduced through transitive dependencies — a direct dependency that is pure Java may pull in a transitive dependency containing native code. The analysis must cover the full dependency tree, not just direct dependencies.
+
+1. Generate and inspect the full transitive dependency tree, saving the filtered output:
+   ```bash
+   # Maven - filter for known native-code artifacts
+   mvn dependency:tree -Dincludes=net.java.dev.jna,io.netty,org.xerial.snappy,org.lz4,com.github.luben,org.rocksdb,org.xerial,org.conscrypt,com.google.protobuf \
+     > graviton-validation/raw/dependency-tree-native.txt
+
+   # Gradle - search runtime classpath for native artifacts
+   ./gradlew dependencies --configuration runtimeClasspath | grep -E "jna|netty-transport-native|snappy|lz4|zstd|rocksdb|sqlite|conscrypt|protobuf|jnr|leveldbjni" \
+     > graviton-validation/raw/dependency-tree-native.txt
+   ```
+
+2. Analyze each dependency (direct AND transitive) for ARM64 compatibility (NOT general version upgrades):
+   - Identify current version in use
+   - Check if current version supports ARM64/aarch64
+   - Identify first version with ARM64 support (if current lacks it)
+   - Flag dependencies with known ARM64 issues in current version
+   - For transitive dependencies: identify which direct dependency pulls it in, as the resolution may require updating the parent dependency
+
+3. Create compatibility report with three categories:
+   
+   **MUST UPGRADE (Blocking):**
+   - Current version < first ARM64-compatible version
+   - Dependency contains x86-only native code (direct or transitive)
+   - Known critical ARM64 bugs in current version
+   
+   **RECOMMENDED UPGRADE (Non-blocking):**
+   - Current version has ARM64 support but with known performance issues
+   - Newer version has ARM64-specific optimizations
+   - Newer version has ARM64 bug fixes
+   
+   **COMPATIBLE (No action needed):**
+   - Current version fully supports ARM64
+   - No known ARM64 issues
+   - Pure Java dependency with no architecture dependencies (direct or transitive)
+
+4. Document findings:
+   ```
+   Dependency: net.java.dev.jna:jna
+   Current Version: 5.6.0
+   Status: MUST UPGRADE
+   Reason: Version 5.6.0 lacks ARM64 native libraries
+   Minimum ARM64 Version: 5.8.0
+   Recommended Version: 5.14.0 (includes ARM64 optimizations)
+
+   Dependency: org.xerial.snappy:snappy-java (transitive via org.apache.kafka:kafka-clients)
+   Current Version: 1.1.7.3
+   Status: MUST UPGRADE
+   Reason: Version 1.1.7.3 lacks linux-aarch64 native binary
+   Minimum ARM64 Version: 1.1.8.1
+   Resolution: Update snappy-java version via dependency management or exclusion+re-add
+   ```
+
+#### 1.4 Architecture-Specific Code Detection
+
+> **Output → `graviton-validation/04-code-scan-findings.md`** (Architecture Detection Patterns, JNI/JNA Usage sections)
+
+1. Scan source code for architecture detection patterns:
+   ```java
+   System.getProperty("os.arch")
+   System.getProperty("os.name")
+   Native.load()
+   System.loadLibrary()
+   ```
+
+2. Identify code blocks that:
+   - Check for "amd64" or "x86_64" without "aarch64" handling
+   - Load native libraries without architecture-aware paths
+   - Contain x86-specific optimizations or assumptions
+
+3. Flag JNI/JNA usage requiring ARM64 validation
+
+#### 1.5 Java Version Compatibility Check
+
+> **Output → `graviton-validation/01-project-assessment.md`** (Java Environment section)
+
+1. Document current Java version in use
+2. Document current JDK distribution (e.g., OpenJDK, Eclipse Temurin, Amazon Corretto, Azul Zulu, etc.)
+3. Verify Java version has ARM64 support:
+   - JDK 8: Supported (with limitations)
+   - JDK 11+: Fully supported and recommended
+4. Flag if current version has known Graviton compatibility issues
+5. **CRITICAL:** Document both the current Java VERSION and JDK DISTRIBUTION (e.g., "OpenJDK 21", "Corretto 17", "Temurin 11")
+6. **DO NOT change the JDK distribution** - if using OpenJDK, keep OpenJDK; if using Temurin, keep Temurin, etc.
+7. **DO NOT change the Java version** (no upgrades or downgrades) - maintain the exact major version currently in use
+8. All major JDK distributions support ARM64 for Java 8+, so distribution changes are NOT required for ARM64 compatibility
+
+### Phase 2: Compatibility Resolution
+
+#### 2.1 Native Library Resolution
+
+> **Output → update `graviton-validation/02-native-library-report.md`** (Resolution Details, Pure Java Fallbacks sections)
+
+1. For each x86-only .so file identified in Phase 1:
+   
+   **If source code available:**
+   - Set up ARM64 build environment
+   - Compile for ARM64/aarch64:
+     ```bash
+     # Cross-compilation
+     CC=aarch64-linux-gnu-gcc make
+     
+     # Or on ARM64 machine
+     make CFLAGS="-march=armv8-a"
+     ```
+   - Verify compiled library:
+     ```bash
+     file libname.so  # Should show "ARM aarch64"
+     ```
+   - Place in appropriate project location
+   
+   **If source code unavailable:**
+   - Prompt user: "The shared library [name.so] is compiled for x86 and source is not available. Please provide ARM64-compatible version or confirm pure Java fallback exists."
+   - Validate provided .so file architecture
+   - Document if pure Java fallback will be used
+
+2. Update native library loading logic:
+   ```java
+   // Add ARM64 support to existing x86 code
+   String arch = System.getProperty("os.arch");
+   String libName;
+   
+   if ("aarch64".equals(arch)) {
+       libName = "libchatbot-arm64.so";
+   } else if ("amd64".equals(arch) || "x86_64".equals(arch)) {
+       libName = "libchatbot-amd64.so";
+   } else {
+       throw new UnsupportedOperationException("Unsupported architecture: " + arch);
+   }
+   
+   try {
+       nativeLib = (NativeLib) Native.load(libName, NativeLib.class);
+   } catch (UnsatisfiedLinkError e) {
+       logger.warn("Native library not available, using Java fallback", e);
+       // Use pure Java implementation
+   }
+   ```
+
+#### 2.2 Dependency Compatibility Updates
+
+> **Output → update `graviton-validation/03-dependency-compatibility-report.md`** (Applied Version column in MUST UPGRADE table, Transitive Dependency Resolutions section)
+
+1. Update ONLY dependencies flagged as "MUST UPGRADE" in Phase 1:
+   ```xml
+   <!-- Example: Update JNA for ARM64 support -->
+   <dependency>
+       <groupId>net.java.dev.jna</groupId>
+       <artifactId>jna</artifactId>
+       <version>5.14.0</version> <!-- Minimum 5.8.0 for ARM64 -->
+   </dependency>
+   ```
+
+2. For transitive dependencies requiring ARM64-compatibility updates:
+   ```xml
+   <!-- Option A: Override transitive version via dependencyManagement -->
+   <dependencyManagement>
+       <dependencies>
+           <dependency>
+               <groupId>org.xerial.snappy</groupId>
+               <artifactId>snappy-java</artifactId>
+               <version>1.1.10.5</version> <!-- ARM64-compatible version -->
+           </dependency>
+       </dependencies>
+   </dependencyManagement>
+
+   <!-- Option B: Exclude and re-add with ARM64-compatible version -->
+   <dependency>
+       <groupId>org.apache.kafka</groupId>
+       <artifactId>kafka-clients</artifactId>
+       <version>${kafka.version}</version>
+       <exclusions>
+           <exclusion>
+               <groupId>org.xerial.snappy</groupId>
+               <artifactId>snappy-java</artifactId>
+           </exclusion>
+       </exclusions>
+   </dependency>
+   <dependency>
+       <groupId>org.xerial.snappy</groupId>
+       <artifactId>snappy-java</artifactId>
+       <version>1.1.10.5</version>
+   </dependency>
+   ```
+
+   For Gradle projects:
+   ```groovy
+   // Force a specific version of a transitive dependency
+   configurations.all {
+       resolutionStrategy {
+           force 'org.xerial.snappy:snappy-java:1.1.10.5'
+       }
+   }
+   ```
+
+3. For dependencies without ARM64 support:
+   - Identify pure Java alternatives
+   - Document replacement options
+   - Implement alternative if feasible
+
+4. **DO NOT upgrade** dependencies that are already ARM64-compatible
+
+#### 2.3 Architecture Detection Code Updates
+
+> **Output → update `graviton-validation/04-code-scan-findings.md`** (Changes Applied section)
+
+1. Update architecture checks to handle ARM64:
+   ```java
+   // Before
+   if (System.getProperty("os.arch").equals("amd64")) {
+       // x86-specific code
+   }
+   
+   // After
+   String arch = System.getProperty("os.arch");
+   if ("aarch64".equals(arch)) {
+       // ARM64-specific code path
+   } else if ("amd64".equals(arch) || "x86_64".equals(arch)) {
+       // x86-specific code
+   } else {
+       // Generic fallback
+   }
+   ```
+
+2. Ensure all architecture-dependent code paths include ARM64 handling
+
+#### 2.4 Build Configuration Updates
+1. Update Maven/Gradle for ARM64 support:
+   ```xml
+   <!-- Add ARM64 profile -->
+   <profiles>
+       <profile>
+           <id>arm64</id>
+           <activation>
+               <os><arch>aarch64</arch></os>
+           </activation>
+           <properties>
+               <native.arch>aarch64</native.arch>
+           </properties>
+       </profile>
+   </profiles>
+   ```
+
+2. **For containerized deployments:** Update Dockerfile for ARM64 multi-architecture support:
+
+   **Single-stage Dockerfiles:**
+   ```dockerfile
+   # IMPORTANT: Maintain the current base image and Java version if base image has no cpu architecture tags as it is multi-arch
+   FROM --platform=$BUILDPLATFORM <current-base-image>:<current-version>
+   
+   # Example: If currently using openjdk:21, keep it:
+   # FROM --platform=$BUILDPLATFORM openjdk:21
+   # 
+   # Example: If currently using eclipse-temurin:17, keep it:
+   # FROM --platform=$BUILDPLATFORM eclipse-temurin:17
+   
+   # Install architecture-specific packages
+   RUN apt-get update -y && \
+       apt-get install -y package-name
+   ```
+
+   **Multi-stage Dockerfiles:**
+   
+   Many Java applications use multi-stage Docker builds (builder stage + runtime stage). Each stage requires correct platform annotation:
+   ```dockerfile
+   # Builder stage: uses BUILDPLATFORM so build tools run natively on the host
+   FROM --platform=$BUILDPLATFORM <current-builder-image>:<current-version> AS builder
+
+   # Example: If currently using maven:3.9-eclipse-temurin-17, keep it:
+   # FROM --platform=$BUILDPLATFORM maven:3.9-eclipse-temurin-17 AS builder
+
+   WORKDIR /app
+   COPY . .
+   RUN mvn clean package -DskipTests
+
+   # Runtime stage: uses TARGETPLATFORM so the final image runs on ARM64
+   FROM --platform=$TARGETPLATFORM <current-runtime-image>:<current-version>
+
+   # Example: If currently using eclipse-temurin:17-jre, keep it:
+   # FROM --platform=$TARGETPLATFORM eclipse-temurin:17-jre
+
+   COPY --from=builder /app/target/*.jar app.jar
+   ENTRYPOINT ["java", "-jar", "app.jar"]
+   ```
+
+   **Key distinction for multi-stage builds:**
+   - **Builder stage** (`AS builder`): Use `--platform=$BUILDPLATFORM` — the build tools (Maven/Gradle, javac) should run natively on the host architecture for speed
+   - **Runtime stage** (final `FROM`): Use `--platform=$TARGETPLATFORM` — the final image must target ARM64
+   - If the original Dockerfile has no `--platform` annotations on any stage, add them following this pattern
+   - If the original Dockerfile is single-stage, use `--platform=$BUILDPLATFORM` as shown above
+
+   **Base Image Selection:** 
+   - **PRESERVE the current JDK distribution and version** (e.g., openjdk:21, eclipse-temurin:17, etc.)
+   - Do NOT change the JDK distribution or version unless specifically required for ARM64 compatibility
+   - Amazon Corretto MAY be suggested as an optional consideration for new deployments due to AWS-specific optimizations and Graviton testing, but is NOT required
+   - All major JDK distributions (OpenJDK, Eclipse Temurin, Amazon Corretto, etc.) support ARM64 for Java 8+
+
+3. **For host-based deployments:** Skip Docker configuration steps
+
+4. Configure CI/CD for ARM64 builds:
+   - Add ARM64 build agents or use emulation (for containerized deployments)
+   - Update build scripts to handle architecture parameter
+   - Configure artifact publishing for both architectures
+
+#### 2.5 Graviton-Specific JVM Optimizations
+
+> **Output → `graviton-validation/05-jvm-configuration.md`** (all sections)
+
+Apply Graviton-optimized JVM flags based on the application's Java version. Not all flags are valid across all JDK versions; applying an unsupported flag will cause JVM startup failures.
+
+**JDK 11 on Graviton:**
+```bash
+# For workloads with moderate lock contention
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+
+# For cryptographic workloads
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics
+
+# For multi-threaded applications (reduce stack size from 2MB default)
+-Xss1m
+```
+
+**JDK 17 on Graviton:**
+```bash
+# Compiler tuning for Graviton
+-XX:CICompilerCount=2
+-XX:CompilationMode=high-only
+
+# For workloads with moderate lock contention
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+
+# For cryptographic workloads
+-XX:+UnlockDiagnosticVMOptions
+-XX:+UseAESCTRIntrinsics
+
+# For multi-threaded applications
+-Xss1m
+```
+
+**JDK 21+ on Graviton:**
+```bash
+# For workloads with moderate lock contention
+-XX:-TieredCompilation
+-XX:ReservedCodeCacheSize=64M
+-XX:InitialCodeCacheSize=64M
+
+# For multi-threaded applications
+-Xss1m
+
+# NOTE: -XX:+UseAESCTRIntrinsics is enabled by default in JDK 21+ and does not need
+# to be set explicitly. Setting it with -XX:+UnlockDiagnosticVMOptions is harmless but unnecessary.
+# NOTE: -XX:CompilationMode was removed in some JDK 21+ builds. Test before applying.
+```
+
+**IMPORTANT:** Always verify flags are accepted by the target JVM before committing them:
+```bash
+# Test that all flags are valid (will exit with error if any flag is unrecognized)
+java <flags> -version
+```
+
+2. Document JVM flag changes and expected performance impact
+
+3. Create configuration profiles for different workload types
+
+### Phase 3: ARM64 Validation & Testing
+
+#### 3.0 Build Environment Preparation
+
+> **Output → `graviton-validation/06-build-test-results.md`** (Build Environment, Build Environment Notes sections)
+
+**Note:** Supported Platforms are 
+* Linux - Full support for all Linux distributions
+* macOS - Full support for macOS systems
+* Windows Subsystem for Linux (WSL) - Full support when running under WSL
+
+**CRITICAL: Java Runtime Alignment for Build Tooling Compatibility**
+
+Before executing build commands, verify that the active Java runtime is compatible with build-time tooling (annotation processors, compiler plugins, etc.) to avoid version-specific compatibility issues.
+
+**Background:**
+- Build-time tools (e.g., Lombok, annotation processors) may not support the latest Java compiler versions
+- Runtime compatibility (ability to run bytecode) ≠ Compile-time tooling compatibility
+- Example: Lombok 1.18.34 works with Java 17-21 but fails with Java 25 compiler internals
+- This is environment management, NOT a code or dependency change
+
+**Common Annotation Processors with Java Version Sensitivities:**
+- **Lombok:** Versions before 1.18.36 don't support Java 25
+- **MapStruct:** Versions before 1.5.0 may have issues with Java 17+
+- **Dagger:** Versions before 2.40 may have Java 16+ issues
+- **Auto-value:** Generally compatible but check version for Java 21+
+
+**If build fails with annotation processor errors:**
+1. Identify the processor: Check `<annotationProcessorPaths>` in pom.xml or `annotationProcessor` in build.gradle
+2. Check processor version compatibility with current Java runtime
+3. Apply Java version alignment from this section using compatible runtime
+4. Document the specific processor and version requiring aligned runtime
+
+**Detection and Temporary Adjustment:**
+
+1. **Check current Java runtime:**
+   ```bash
+   java -version
+   ```
+
+2. **Detect project target version:**
+   ```bash
+   # Maven projects
+   PROJECT_TARGET=$(grep -oP '(?<=<release>)[0-9]+' pom.xml 2>/dev/null || \
+                    grep -oP '(?<=<target>)[0-9]+' pom.xml 2>/dev/null || \
+                    grep -oP '(?<=<java.version>)[0-9]+' pom.xml 2>/dev/null)
+   
+   # Gradle projects - check multiple formats and files
+   if [ -z "$PROJECT_TARGET" ]; then
+     # Check build.gradle (Groovy DSL)
+     PROJECT_TARGET=$(grep -oP 'sourceCompatibility\s*[=:]\s*['\''"]?\K[0-9]+' build.gradle 2>/dev/null || \
+                      grep -oP 'targetCompatibility\s*[=:]\s*['\''"]?\K[0-9]+' build.gradle 2>/dev/null || \
+                      grep -oP 'JavaVersion\.VERSION_\K[0-9]+' build.gradle 2>/dev/null)
+     
+     # Check build.gradle.kts (Kotlin DSL) - including toolchain API
+     if [ -z "$PROJECT_TARGET" ]; then
+       PROJECT_TARGET=$(grep -oP 'sourceCompatibility\s*=\s*JavaVersion\.VERSION_\K[0-9]+' build.gradle.kts 2>/dev/null || \
+                        grep -oP 'targetCompatibility\s*=\s*JavaVersion\.VERSION_\K[0-9]+' build.gradle.kts 2>/dev/null || \
+                        grep -oP 'jvmToolchain\(\K[0-9]+' build.gradle.kts 2>/dev/null || \
+                        grep -oP 'languageVersion\.set\(JavaLanguageVersion\.of\(\K[0-9]+' build.gradle.kts 2>/dev/null)
+     fi
+
+     # Check build.gradle (Groovy DSL) - toolchain API
+     if [ -z "$PROJECT_TARGET" ]; then
+       PROJECT_TARGET=$(grep -oP 'jvmToolchain\s*\(\s*\K[0-9]+' build.gradle 2>/dev/null || \
+                        grep -oP 'languageVersion\s*=\s*JavaLanguageVersion\.of\(\K[0-9]+' build.gradle 2>/dev/null || \
+                        grep -oP "languageVersion\.set\s*\(\s*JavaLanguageVersion\.of\s*\(\s*\K[0-9]+" build.gradle 2>/dev/null)
+     fi
+     
+     # Check gradle.properties
+     if [ -z "$PROJECT_TARGET" ]; then
+       PROJECT_TARGET=$(grep -oP 'javaVersion\s*=\s*\K[0-9]+' gradle.properties 2>/dev/null)
+     fi
+
+     # Fallback: query Gradle directly (most reliable but requires Gradle wrapper)
+     if [ -z "$PROJECT_TARGET" ] && [ -f "./gradlew" ]; then
+       PROJECT_TARGET=$(./gradlew -q properties 2>/dev/null | grep -oP 'targetCompatibility:\s*\K[0-9]+' || true)
+     fi
+   fi
+   
+   echo "Project targets Java: $PROJECT_TARGET"
+   ```
+
+3. **If runtime version significantly exceeds target (e.g., Java 25 runtime with Java 17 target):**
+
+   **macOS Systems:**
+   ```bash
+   # List available Java versions
+   /usr/libexec/java_home -V
+   
+   # Switch to appropriate version for build session only (SAFE - session-scoped)
+   # Use subshell to isolate environment change
+   (
+     export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+     java -version  # Verify switch
+     ${BUILD_CMD} clean install  # Execute build using detected build command
+   )
+   # JAVA_HOME change does NOT persist after subshell exits
+   ```
+
+   **Linux Systems:**
+   ```bash
+   # List available Java versions
+   update-alternatives --list java 2>/dev/null || \
+   ls -1 /usr/lib/jvm/ 2>/dev/null || \
+   ls -1 /usr/java/ 2>/dev/null
+   
+   # Find appropriate Java version path
+   JAVA_21_HOME=$(find /usr/lib/jvm /usr/java -maxdepth 1 -type d -name "*java-21*" -o -name "*jdk-21*" -o -name "*corretto-21*" 2>/dev/null | head -1)
+   JAVA_17_HOME=$(find /usr/lib/jvm /usr/java -maxdepth 1 -type d -name "*java-17*" -o -name "*jdk-17*" -o -name "*corretto-17*" 2>/dev/null | head -1)
+   JAVA_11_HOME=$(find /usr/lib/jvm /usr/java -maxdepth 1 -type d -name "*java-11*" -o -name "*jdk-11*" -o -name "*corretto-11*" 2>/dev/null | head -1)
+   
+   # Use subshell for session-scoped change
+   (
+     if [ -n "$JAVA_21_HOME" ]; then
+       export JAVA_HOME="$JAVA_21_HOME"
+       echo "✓ Using Java 21: $JAVA_21_HOME"
+     elif [ -n "$JAVA_17_HOME" ]; then
+       export JAVA_HOME="$JAVA_17_HOME"
+       echo "✓ Using Java 17: $JAVA_17_HOME"
+     elif [ -n "$JAVA_11_HOME" ]; then
+       export JAVA_HOME="$JAVA_11_HOME"
+       echo "✓ Using Java 11: $JAVA_11_HOME"
+     else
+       echo "⚠️  No compatible Java LTS version found (11, 17, or 21)"
+       echo "Using current Java: $(java -version 2>&1 | head -1)"
+     fi
+     export PATH="$JAVA_HOME/bin:$PATH"
+     java -version  # Verify switch
+     ${BUILD_CMD} clean install  # Execute build using detected build command
+   )
+   ```
+
+   **SDKMAN (if installed - works on macOS and Linux):**
+   ```bash
+   # Check if SDKMAN is installed
+   if [ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
+     source "$HOME/.sdkman/bin/sdkman-init.sh"
+     
+     # List available versions
+     sdk list java
+     
+     # Use SDKMAN for session-scoped change
+     (
+       sdk use java 21.0.9-amzn  # Adjust version identifier as needed
+       java -version
+       ${BUILD_CMD} clean install
+     )
+   fi
+   ```
+
+   **WSL (Windows Subsystem for Linux):**
+   ```bash
+   # WSL uses standard Linux commands - same as Linux section above
+   # List available Java versions
+   update-alternatives --list java 2>/dev/null || \
+   ls -1 /usr/lib/jvm/ 2>/dev/null
+   
+   # Find and use appropriate Java version (same as Linux)
+   JAVA_21_HOME=$(find /usr/lib/jvm -maxdepth 1 -type d -name "*java-21*" -o -name "*jdk-21*" -o -name "*corretto-21*" 2>/dev/null | head -1)
+   
+   # Use subshell for session-scoped change
+   (
+     export JAVA_HOME="$JAVA_21_HOME"
+     export PATH="$JAVA_HOME/bin:$PATH"
+     java -version
+     ${BUILD_CMD} clean install
+   )
+   ```
+   
+   **Note:** WSL2 provides full Linux environment. If running on Windows, use WSL2 for ARM64 compatibility validation rather than native Windows tools.
+
+4. **Alternative safe approaches (works on all Unix-like systems):**
+   ```bash
+   # Single-command scope (also safe - works everywhere)
+   JAVA_HOME=/path/to/java-21 ${BUILD_CMD} clean install
+   
+   # Temporary script (also safe)
+   bash -c "export JAVA_HOME=/path/to/java-21; export PATH=\$JAVA_HOME/bin:\$PATH; ${BUILD_CMD} clean install"
+   ```
+
+**Safety Requirements:**
+
+✅ **ALLOWED (Session-scoped only):**
+- `export JAVA_HOME=...` within subshells `()`
+- Single-command environment: `JAVA_HOME=... mvn build`
+- Temporary shell scripts with `bash -c '...'`
+- SDKMAN's `sdk use` command (session-scoped by design)
+
+❌ **FORBIDDEN (Persistent changes):**
+- Writing to user profile files: `~/.zshrc`, `~/.bash_profile`, `~/.bashrc`, `~/.profile`
+- Modifying system defaults: `update-alternatives --set`, `alternatives --set`
+- Any changes that survive beyond the transformation session
+- Using SDKMAN's `sdk default` (makes permanent changes)
+
+**Verification:**
+After transformation completes, user's default `java -version` must match their pre-transformation environment.
+
+**Recommended Java Version Selection:**
+- Prefer Java 21 (latest LTS) for builds if available
+- Fall back to Java 17 (prior LTS) if 21 unavailable
+- Fall back to Java 11 (older LTS) if 17 unavailable
+- Match project target version if within 1-2 major versions of latest LTS
+- Avoid Java 22+ non-LTS versions unless specifically required
+
+**If No Compatible Java Version Found:**
+- Document the requirement: "Build requires Java [version] or Java 21/17/11 to avoid tooling compatibility issues"
+- Provide installation commands for the target platform:
+  ```bash
+  # Amazon Corretto (recommended for Graviton)
+  # macOS:
+  brew install --cask corretto@21
+  
+  # Amazon Linux 2023 / RHEL / CentOS:
+  sudo yum install java-21-amazon-corretto-devel
+  
+  # Ubuntu / Debian:
+  wget -O- https://apt.corretto.aws/corretto.key | sudo apt-key add -
+  sudo add-apt-repository 'deb https://apt.corretto.aws stable main'
+  sudo apt-get update
+  sudo apt-get install -y java-21-amazon-corretto-jdk
+  ```
+- Do NOT attempt to install Java automatically - prompt user and exit transformation
+
+#### 3.1 ARM64 Build Validation
+
+> **Output → `graviton-validation/06-build-test-results.md`** (Build Attempts, Test Failure Classification, Final Build sections)
+
+**Prerequisites:** Java runtime environment aligned per Section 3.0 above
+
+##### Build Validation Strategy
+
+1. **First attempt**: Run full build with tests
+   - Gradle: `./gradlew clean build`
+   - Maven: `mvn clean install`
+
+2. **If tests fail**, analyze root cause and classify:
+   - `INFRA` - Infrastructure/environment dependency (missing DB, Docker, env vars)
+   - `ARM64` - Architecture-related failure
+   - `PRE-EXISTING` - Existed before migration
+
+3. **If failures are INFRA or PRE-EXISTING** (not ARM64-related):
+   - Document the test failures and root cause
+   - Run build again without tests to validate compilation:
+     - Gradle: `./gradlew clean build -x test`
+     - Maven: `mvn clean install -DskipTests`
+   - This becomes the **final build** for validation purposes
+
+4. **If failures are ARM64-related**:
+   - Do NOT skip tests
+   - The build fails and requires resolution
+
+**IMPORTANT:** The final build command in the conversation log determines the build score. If test failures are infrastructure-related, the final build should be the compilation-only build (`-x test` or `-DskipTests`).
+
+##### Build Artifact Verification
+
+1. Verify build artifacts:
+   - All dependencies resolved successfully
+   - Native libraries loaded correctly
+   - No architecture-related build errors
+
+2. **For containerized deployments:** Validate container image on ARM64:
+      **IMPORTANT: Docker ENTRYPOINT Handling**
+
+   Many Java application Dockerfiles use `ENTRYPOINT ["java", "-jar", "app.jar"]`. When running 
+   validation commands like `java -version` or `./gradlew test`, you MUST override the entrypoint,
+   otherwise your command arguments get appended to the entrypoint instead of replacing it.
+
+   - ❌ Wrong: `docker run app:arm64 java -version` → runs `java -jar app.jar java -version`
+   - ✅ Correct: `docker run --entrypoint java app:arm64 -version` → runs `java -version`
+
+   Always use `--entrypoint <command>` when running validation commands against containers 
+   that have an ENTRYPOINT defined.
+   
+   ```bash
+   # Build for ARM64 architecture
+   docker buildx build --platform linux/arm64 -t app:arm64 .
+   # Or on ARM64 instance
+   docker build -t app:arm64 .
+   
+   # Validate Java version and architecture
+   # NOTE: Use --entrypoint to override Dockerfile ENTRYPOINT and run java directly
+   docker run --rm --platform linux/arm64 --entrypoint java app:arm64 -version
+   # Verify the output shows the SAME JDK distribution and version as the original application
+   # Examples of valid outputs:
+   #   - OpenJDK Runtime Environment (build 21.x.x)
+   #   - OpenJDK Runtime Environment Corretto-17.x.x
+
+   docker run --rm --platform linux/arm64 --entrypoint java app:arm64 -XshowSettings:properties -version 2>&1 | grep os.arch
+   # Should show: os.arch = aarch64
+   ```
+
+3. **For host-based deployments:** Validate on ARM64 Graviton EC2 instance:
+   ```bash
+   # Verify Java installation
+   java -version
+   # Verify the output shows the SAME JDK distribution and version as the original application
+   # Examples of valid outputs:
+   #   - OpenJDK Runtime Environment (build 21.x.x)
+   #   - OpenJDK Runtime Environment Corretto-17.x.x
+   
+   # Verify ARM64 architecture
+   java -XshowSettings:properties -version | grep os.arch
+   # Should show: os.arch = aarch64
+   
+   # Build application on ARM64 host
+   ./gradlew build
+   # or
+   mvn clean package
+   ```
+
+#### 3.2 Functional Testing on ARM64
+
+> **Output → update `graviton-validation/06-build-test-results.md`** (Test Failure Classification, Final Build sections)
+
+1. **For containerized deployments:** Execute test suite in ARM64 container:
+   ```bash
+   # NOTE: Use --entrypoint to override Dockerfile ENTRYPOINT and run build tools directly
+   docker run --rm --platform linux/arm64 --entrypoint ./gradlew app:arm64 test
+   # or
+   docker run --rm --platform linux/arm64 --entrypoint mvn app:arm64 test
+   ```
+
+2. **For host-based deployments:** Execute test suite on ARM64 Graviton EC2 instance:
+   ```bash
+   # Run tests with Gradle
+   ./gradlew test
+
+   # or with Maven
+   mvn test
+   ```
+
+3. Verify test results:
+   - Document all test results
+   - If tests fail, classify by root cause (INFRA, ARM64, PRE-EXISTING)
+   - ARM64-related failures are blocking
+   - Infrastructure and pre-existing failures are non-blocking but must be documented
+
+4. Test architecture-specific functionality:
+   - Native library loading and execution
+   - Cryptographic operations
+   - File I/O and system calls
+   - Multi-threading behavior
+
+5. **Final build for scoring purposes:**
+   - If all tests pass: The test build is the final build
+   - If tests fail due to infrastructure/pre-existing issues: 
+     - Gradle: Run `./gradlew clean build -x test` as the final build
+     - Maven: Run `mvn clean install -DskipTests` as the final build
+   - If tests fail due to ARM64 issues: Do not skip tests; the failing build is the final build
+
+#### 3.3 Startup Validation
+
+> **Output → update `graviton-validation/06-build-test-results.md`** (Startup Validation, Container Validation sections)
+
+1. Verify application stability on ARM64:
+   - Application starts without errors
+   - JVM flags are accepted without errors
+   - No immediate runtime crashes
+
+2. Recommend to user for independent performance testing:
+   - Conduct performance benchmarking based on their specific requirements
+   - Compare against their baseline metrics if available
+   - Test at production-like load levels
+   - Measure response times, throughput, and resource utilization using their tools
+
+### Phase 3 Completion: Write Summary
+
+> **Output → `graviton-validation/00-summary.md`**
+
+After all phases are complete, write the transformation summary. This file consolidates exit criteria status and references (not duplicates) the detail in files 01–06. See `documentation-standards.md` for the required template.
+
+## Validation / Exit Criteria
+
+### Critical Success Criteria (Must Pass)
+1. ✅ Application successfully compiles on ARM64 architecture without errors
+2. ✅ All native libraries load correctly on ARM64 or appropriate fallbacks function
+3. ✅ All dependencies flagged as "MUST UPGRADE" have been updated to ARM64-compatible versions
+4. ✅ No ARM64-specific runtime errors during build or test execution
+5. ✅ Container images successfully build on ARM64 architecture (if containerized)
+
+### Test Criteria
+6. ✅ Test suite executes on ARM64
+7. ✅ Test failures (if any) are classified by root cause:
+   - `INFRA` - Infrastructure/environment dependency (non-blocking)
+   - `ARM64` - Architecture-related failure (blocking)
+   - `PRE-EXISTING` - Existed before migration (non-blocking)
+8. ✅ No ARM64-related test failures
+
+**Note:** Infrastructure test failures (missing databases, Docker, environment variables, external services) do not fail the transformation. These should be documented but are non-blocking.
+
+### Startup Criteria
+9. ✅ Application starts successfully on ARM64 without crashes
+10. ✅ JVM flags are accepted without errors
+
+### Documentation Criteria
+All documentation MUST use the canonical filenames defined in `documentation-standards.md` and reside in the `graviton-validation/` folder.
+
+11. ✅ `graviton-validation/00-summary.md` — Transformation summary with exit criteria checklist
+12. ✅ `graviton-validation/01-project-assessment.md` — Project structure, deployment type, Java environment
+13. ✅ `graviton-validation/02-native-library-report.md` — Native library findings and resolutions
+14. ✅ `graviton-validation/03-dependency-compatibility-report.md` — Dependency compatibility report (including transitive dependencies)
+15. ✅ `graviton-validation/04-code-scan-findings.md` — Architecture-specific code scan results
+16. ✅ `graviton-validation/05-jvm-configuration.md` — JVM flag configuration and validation
+17. ✅ `graviton-validation/06-build-test-results.md` — Build attempts, test results, failure classification, startup validation
+18. ✅ `graviton-validation/raw/dependency-tree-full.txt` — Full dependency tree
+19. ✅ `graviton-validation/raw/dependency-tree-native.txt` — Filtered native-artifact dependency tree
+
+### User Responsibility (Out of Scope for This Transformation)
+The following should be performed by the user independently after transformation:
+- Performance benchmarking and load testing
+- Memory leak detection and extended stability testing
+- Integration testing with external services (databases, APIs, message queues)
+- CI/CD pipeline configuration for ARM64 builds
+
+## Out of Scope
+The following are explicitly OUT OF SCOPE for this transformation:
+- ❌ JDK distribution changes (e.g., OpenJDK to Corretto, Temurin to OpenJDK, etc.)
+- ❌ Java version changes (upgrades OR downgrades) - maintain current Java version
+- ❌ General dependency modernization or security updates
+- ❌ Application refactoring or code quality improvements
+- ❌ Performance optimization beyond Graviton-specific JVM flags
+- ❌ Infrastructure migration or deployment automation
+- ❌ Cost optimization analysis (beyond ARM64 compatibility validation)
+
+## Notes
+- This transformation focuses exclusively on ARM64 compatibility validation
+- All transformation documentation MUST follow `documentation-standards.md` and reside in `graviton-validation/`
+- Maintain the current JDK distribution and version - do not change unless specifically required for ARM64 compatibility
+- All major JDK distributions (OpenJDK, Eclipse Temurin, Amazon Corretto, Azul Zulu, etc.) support ARM64 for Java 8+
+- Amazon Corretto may be mentioned as an option for consideration in new deployments, but existing distributions should be preserved
+- Dependency updates are limited to ARM64 compatibility requirements only — this includes transitive dependencies with native code
+- The tiered .so file validation policy prevents automatic failures while ensuring compatibility
+- Both statically bundled and runtime-extracted native libraries must be validated for ARM64 compatibility
+- Multi-module projects require analysis of all submodules and the full transitive dependency tree
+- Testing on actual ARM64 hardware/containers is critical for validation
+- Graviton instances perform best at higher CPU utilization (70%+ recommended for testing)

--- a/aws-managed-definitions/java/x86-to-graviton.md
+++ b/aws-managed-definitions/java/x86-to-graviton.md
@@ -1,0 +1,15 @@
+# Java x86 → AWS Graviton (ARM64) Migration
+
+**Canonical location:** [`graviton-migration/java/`](../graviton-migration/java/transformation-definition_x86-to-graviton.md)
+
+Validate and migrate Java applications to run on AWS Graviton (ARM64) processors. The transformation runs a 3-phase workflow:
+
+1. **Static analysis** — scan source, dependencies, and native libraries for ARM64 compatibility
+2. **Targeted fixes** — address only ARM64-blocking issues (no general modernization)
+3. **ARM64 validation** — produce 7 structured reports under `graviton-validation/`
+
+## Why this is in two places
+
+The full transformation definition lives under [`graviton-migration/`](../graviton-migration/) — a cross-language category for AWS Graviton migrations. This stub exists in `java/` for discoverability when browsing Java-specific transformations.
+
+See the [canonical TD](../graviton-migration/java/transformation-definition_x86-to-graviton.md) for the complete workflow, scope boundaries, and documentation standards.


### PR DESCRIPTION
## What

Adds a new AWS-managed transformation definition for migrating Java applications from x86 to AWS Graviton (ARM64).

## Files added

- `aws-managed-definitions/graviton-migration/README.md` — category README for cross-language Graviton migrations
- `aws-managed-definitions/graviton-migration/java/transformation-definition_x86-to-graviton.md` — the canonical TD (1018 lines)
- `aws-managed-definitions/graviton-migration/java/document_references/agent-scope-boundaries.md` — strict scope guardrails
- `aws-managed-definitions/graviton-migration/java/document_references/documentation-standards.md` — output format spec
- `aws-managed-definitions/java/x86-to-graviton.md` — discoverability stub linking to canonical TD

## TD design

**3-phase workflow:**

1. **Static analysis** — scan source, dependencies, and native libraries for ARM64 compatibility
2. **Targeted fixes** — address only ARM64-blocking issues (no general modernization)
3. **ARM64 validation** — produce 7 structured reports under `graviton-validation/`

**Strict scope:** only ARM64-blocking issues are addressed. The TD explicitly does not modernize Java versions, update dependencies beyond compatibility fixes, or refactor code style. This keeps the migration narrow and reversible.

## Discoverability

The TD lives under a new top-level `graviton-migration/` category (forward-compatible with future Python-on-ARM64, Node-native-modules-on-ARM64, etc.). A small stub at `java/x86-to-graviton.md` makes it discoverable when browsing Java-specific transformations without duplicating the 1018-line definition.

## Testing

The TD is markdown — no code changes, no tests required.
