### PR TITLE
ATX CT container fixes: install which + scoped upload-ct-artifacts.sh

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,6 +9,7 @@ ENV TZ=UTC
 # Install base dependencies from dnf
 RUN dnf install -y \
     git \
+    which \
     tar \
     gzip \
     unzip \

--- a/container/upload-ct-artifacts.sh
+++ b/container/upload-ct-artifacts.sh
@@ -2,21 +2,31 @@
 # upload-ct-artifacts.sh — uploads ATX Control Tower analysis/remediation
 # artifacts to S3. Runs inside the Batch container before exit.
 #
-# Iterates ALL conversation directories under ~/.aws/atx/custom/, reads each
-# conversation's metadata.json to discover its repo path, and uploads:
+# For each selected conversation directory under ~/.aws/atx/custom/, reads
+# its metadata.json to discover its repo path, and uploads:
 #   - code.zip — the working directory (TD-agnostic; mirrors upload-results.sh)
 #   - logs.zip — cherry-picked debug logs (mirrors upload-results.sh)
 # to s3://${CT_OUTPUT_BUCKET}/${ANALYSIS_ID}/<repo-slug>/.
 #
 # Differs from upload-results.sh in that:
 #   - upload-results.sh picks ONE conversation (ls -t | head -n 1).
-#     This script iterates ALL conversations; ATX CT can produce multiple per container.
+#     This script processes one or more conversations; ATX CT can produce
+#     multiple per container, and the caller can scope which ones to upload.
 #   - upload-results.sh zips /source/. This script zips each conversation's
 #     codeRepositoryPath (from metadata.json), since CT manages source dirs
 #     under ~/.atxct/sources/... not /source/.
 #
 # Usage:
-#   upload-ct-artifacts.sh <analysis-id> <ct-output-bucket>
+#   upload-ct-artifacts.sh <analysis-id> <ct-output-bucket> [conv-id ...]
+#
+# When conv-ids are provided, only those conversations are uploaded. When no
+# conv-ids are provided, ALL conversations on disk are uploaded (legacy
+# behavior). The latter is safe for single-run containers but produces
+# cross-contamination when a long-running container has accumulated
+# conversations from prior analyses or remediations under the new run's
+# S3 prefix. Pass conv-ids when the caller knows which conversations belong
+# to the current run (e.g., from Analysis.summary's convId.* entries
+# populated by CR-278804433).
 #
 # Exit code: always 0. Upload failures are logged but do not fail the job —
 # findings are already in FES (the primary deliverable for ATX CT analyses).
@@ -27,9 +37,11 @@ log() { echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $1"; }
 
 ANALYSIS_ID="${1:-}"
 S3_BUCKET="${2:-}"
+shift 2 2>/dev/null || true
+SELECTED_CONV_IDS=("$@")
 
 if [[ -z "$ANALYSIS_ID" || -z "$S3_BUCKET" ]]; then
-  log "Error: usage: upload-ct-artifacts.sh <analysis-id> <ct-output-bucket>"
+  log "Error: usage: upload-ct-artifacts.sh <analysis-id> <ct-output-bucket> [conv-id ...]"
   exit 1
 fi
 
@@ -43,26 +55,37 @@ UPLOADED=0
 SKIPPED=0
 FAILED=0
 
-for conv_dir in "$CONV_BASE"/*/; do
-  [[ -d "$conv_dir" ]] || continue
+# upload_conv: process a single conversation directory.
+# Caller increments UPLOADED/SKIPPED/FAILED counters via stdout-parse.
+upload_conv() {
+  local conv_dir="$1"
+  local CONV_ID
   CONV_ID=$(basename "$conv_dir")
-  META="$conv_dir/metadata.json"
+  local META="$conv_dir/metadata.json"
+
+  if [[ ! -d "$conv_dir" ]]; then
+    log "Skipping $CONV_ID (directory not found)"
+    SKIPPED=$((SKIPPED + 1))
+    return
+  fi
 
   if [[ ! -f "$META" ]]; then
     log "Skipping $CONV_ID (no metadata.json)"
     SKIPPED=$((SKIPPED + 1))
-    continue
+    return
   fi
 
+  local REPO_PATH
   REPO_PATH=$(jq -r '.codeRepositoryPath // empty' "$META" 2>/dev/null)
   if [[ -z "$REPO_PATH" ]]; then
     log "Skipping $CONV_ID (no codeRepositoryPath in metadata.json)"
     SKIPPED=$((SKIPPED + 1))
-    continue
+    return
   fi
 
+  local REPO_SLUG
   REPO_SLUG=$(basename "$REPO_PATH")
-  S3_PREFIX="s3://${S3_BUCKET}/${ANALYSIS_ID}/${REPO_SLUG}"
+  local S3_PREFIX="s3://${S3_BUCKET}/${ANALYSIS_ID}/${REPO_SLUG}"
 
   # code.zip — the entire working directory (whatever the TD wrote there)
   if [[ -d "$REPO_PATH" ]]; then
@@ -89,6 +112,7 @@ for conv_dir in "$CONV_BASE"/*/; do
   fi
 
   # logs.zip — cherry-pick the same files Custom's upload-results.sh picks
+  local LOGS_STAGING
   LOGS_STAGING=$(mktemp -d /tmp/ct-logs-XXXX)
   cp "$HOME/.aws/atx/logs/debug"*.log "$LOGS_STAGING/" 2>/dev/null || true
   cp "$HOME/.aws/atx/logs/error.log" "$LOGS_STAGING/" 2>/dev/null || true
@@ -114,7 +138,20 @@ for conv_dir in "$CONV_BASE"/*/; do
     log "No logs found for $CONV_ID — skipping logs.zip"
   fi
   rm -rf "$LOGS_STAGING"
-done
+}
+
+if [[ "${#SELECTED_CONV_IDS[@]}" -gt 0 ]]; then
+  log "Processing ${#SELECTED_CONV_IDS[@]} explicitly-named conversation(s)"
+  for conv_id in "${SELECTED_CONV_IDS[@]}"; do
+    upload_conv "${CONV_BASE}/${conv_id}"
+  done
+else
+  log "No conversation IDs specified — processing ALL conversations under $CONV_BASE"
+  for conv_dir in "$CONV_BASE"/*/; do
+    [[ -d "$conv_dir" ]] || continue
+    upload_conv "$conv_dir"
+  done
+fi
 
 log "ATX CT artifact upload complete: uploaded=$UPLOADED skipped=$SKIPPED failed=$FAILED analysis_id=$ANALYSIS_ID"
 exit 0


### PR DESCRIPTION
Two related container fixes for ATX Control Tower (CT) flows on EC2 / Batch.

## 1. Dockerfile: install `which`

CT's `GitHubRemediationAccessOps.validatePrerequisites` (introduced in [CR-279032927](https://code.amazon.com/reviews/CR-279032927/revisions/1#/diff)) uses `execFileSync('which', [tool])` to verify `git` and `atx` are on PATH:

```typescript
async validatePrerequisites(_fullName: string, _source?: string): Promise<string> {
  for (const tool of ['git', 'atx']) {
    try {
      execFileSync('which', [tool], { stdio: 'pipe', timeout: CLI_TIMEOUT_MS });
    } catch {
      throw new Error(`${tool} CLI not found on PATH`);
    }
  }
  return 'local-execution';
}
```

The `which` binary itself isn't installed in the container image. The inner `execFileSync` fails with ENOENT, the catch triggers, and the error message claims `git CLI not found on PATH` — even though git IS at `/usr/bin/git`. GitHub remediations fail before any actual transform runs.

Add `which` to the base `dnf install` list.

Note: CT's `validatePrerequisites` should ideally use a shell builtin (e.g., `command -v`) instead of depending on the external `which` binary. That's a CT-side fix tracked separately.

## 2. upload-ct-artifacts.sh: optional conv-id scoping

Today the script iterates ALL conversation directories under `~/.aws/atx/custom/` and uploads each under the analysis ID prefix passed on the command line. In a long-running container that has accumulated conversations from prior analyses or remediations, this means unrelated conversations get re-uploaded under the new run's S3 prefix — confusing attribution and inflating storage.

Add optional positional args naming specific conversation IDs to upload:

```
# Backward compat (uploads all conversations on disk):
upload-ct-artifacts.sh <analysis-id> <ct-output-bucket>

# Scoped (uploads only the listed conversations):
upload-ct-artifacts.sh <analysis-id> <ct-output-bucket> conv-id-1 conv-id-2 ...
```

The intended caller is the EC2/Batch execution skill, which can determine which conversations belong to the current run (e.g., via a before/after diff of `~/.aws/atx/custom/` or any other mechanism) and pass them explicitly. Backward compatible — single-run containers and existing callers that don't pass conv-ids continue to upload all conversations.

Refactored the per-conversation logic into an `upload_conv()` function so both branches share the same code path. No behavior change when no conv-ids are passed.

## Tests

- `npm test`: 69/69 pass (no test changes required since these only affect runtime container behavior)
- `bash -n container/upload-ct-artifacts.sh`: passes
- Smoke-tested all three argv paths (no args = error, two args = legacy mode, two-plus-N args = scoped)
