### PR TITLE
Fix agentic-atx-platform deployment + stale transform IDs; default to Claude Sonnet 4.5

### DIFF
--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -55,7 +55,7 @@ Key settings:
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `AWS_REGION` | `us-east-1` | AWS region for all services |
-| `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-20250514-v1:0` | AI model for orchestrator |
+| `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | AI model for orchestrator |
 | `FARGATE_VCPU` | `2` | vCPU for Batch jobs |
 | `FARGATE_MEMORY` | `4096` | Memory (MB) for Batch jobs |
 | `JOB_TIMEOUT` | `43200` | Max job duration (seconds) |

--- a/agentic-atx-platform/cdk/bin/cdk.ts
+++ b/agentic-atx-platform/cdk/bin/cdk.ts
@@ -45,7 +45,10 @@ const env = {
 // Hybrid mode: deploy on top of base scaled-execution-containers infra
 // Usage: cdk deploy --all -c useBaseInfra=true
 // ========================================
-const useBaseInfra = app.node.tryGetContext('useBaseInfra') === 'true' || true; // Hybrid mode: deploy on top of base infra
+// Hybrid mode (-c useBaseInfra=true): deploy on top of base infra.
+const useBaseInfraContext = app.node.tryGetContext('useBaseInfra');
+// Normalize: CLI -c passes strings, but cdk.json could hold a JSON boolean.
+const useBaseInfra = useBaseInfraContext === true || useBaseInfraContext === 'true';
 
 if (useBaseInfra) {
   // Hybrid: base infra already deployed via scaled-execution-containers/cdk.
@@ -74,17 +77,28 @@ if (useBaseInfra) {
 } else {
   // Full mode: deploy everything including container + infrastructure
 
-  // Stack 1: Container (ECR + Docker Image)
-  const containerStack = new ContainerStack(app, 'AtxContainerStack', {
-    env,
-    ecrRepoName,
-    description: 'AWS Transform CLI - Container and ECR Repository',
-  });
+  // Optionally skip the (slow) local Docker build and use a prebuilt public image
+  // Usage: cdk deploy ... -c publicEcrImage=public.ecr.aws/b7y6j9m3/aws-transform-custom:latest
+  const publicEcrImage = app.node.tryGetContext('publicEcrImage') || '';
+
+  let imageUri: string;
+  let containerStack: ContainerStack | undefined;
+  if (publicEcrImage) {
+    imageUri = publicEcrImage;
+  } else {
+    // Stack 1: Container (ECR + Docker Image)
+    containerStack = new ContainerStack(app, 'AtxContainerStack', {
+      env,
+      ecrRepoName,
+      description: 'AWS Transform CLI - Container and ECR Repository',
+    });
+    imageUri = containerStack.imageUri;
+  }
 
   // Stack 2: Infrastructure (Batch, S3, IAM, CloudWatch)
   const infrastructureStack = new InfrastructureStack(app, 'AtxInfrastructureStack', {
     env,
-    imageUri: containerStack.imageUri,
+    imageUri,
     fargateVcpu,
     fargateMemory,
     jobTimeout,
@@ -96,7 +110,7 @@ if (useBaseInfra) {
     existingSecurityGroupId,
     description: 'AWS Transform CLI - Batch Infrastructure',
   });
-  infrastructureStack.addDependency(containerStack);
+  if (containerStack) infrastructureStack.addDependency(containerStack);
 
   // Stack 3: AgentCore + API (Orchestrator, Lambda, HTTP API)
   // ⚠️ EXPERIMENTAL: Uses @aws-cdk/aws-bedrock-agentcore-alpha

--- a/agentic-atx-platform/deployment/config.env.template
+++ b/agentic-atx-platform/deployment/config.env.template
@@ -11,9 +11,9 @@ AWS_REGION=us-east-1
 
 # Bedrock model for orchestrator + sub-agents
 # Options:
-#   us.anthropic.claude-sonnet-4-20250514-v1:0   (default, recommended)
-#   us.anthropic.claude-sonnet-4-5-20250929-v1:0 (newer, more capable)
-BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514-v1:0
+#   us.anthropic.claude-sonnet-4-5-20250929-v1:0 (recommended)
+#   us.anthropic.claude-sonnet-4-20250514-v1:0   (legacy)
+BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 
 # Fargate task resources for Batch jobs (optional overrides; CDK defaults match these)
 # FARGATE_VCPU=2

--- a/agentic-atx-platform/docs/TROUBLESHOOTING.md
+++ b/agentic-atx-platform/docs/TROUBLESHOOTING.md
@@ -243,7 +243,7 @@ VITE_API_ENDPOINT=$API_URL npx vite build
    aws bedrock list-foundation-models --query "modelSummaries[?contains(modelId,'claude')].{id:modelId,status:modelLifecycle.status}" --output table
    
    # Recommended: Claude Sonnet 4
-   BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514-v1:0
+   BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
    ```
 2. Redeploy the AgentCore stack (Option B) or update the AgentCore runtime (Option A)
 

--- a/agentic-atx-platform/orchestrator/Dockerfile
+++ b/agentic-atx-platform/orchestrator/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd -m -u 1000 bedrock_agentcore
 USER bedrock_agentcore
 
 ENV AWS_REGION=us-east-1
-ENV BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-20250514-v1:0
+ENV BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
 EXPOSE 8080
 
 CMD ["opentelemetry-instrument", "python", "agent.py"]

--- a/agentic-atx-platform/orchestrator/agent.py
+++ b/agentic-atx-platform/orchestrator/agent.py
@@ -127,7 +127,7 @@ def create_orchestrator(session_id: str = None, actor_id: str = None) -> Agent:
     _load_tools()
 
     region = os.getenv("AWS_REGION", "us-east-1")
-    model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0")
+    model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
 
     bedrock_model = BedrockModel(
         model_id=model_id,

--- a/agentic-atx-platform/orchestrator/tools/createtransform.py
+++ b/agentic-atx-platform/orchestrator/tools/createtransform.py
@@ -199,7 +199,7 @@ Output ONLY the markdown content, no code fences."""
 
     try:
         response = bedrock_runtime.invoke_model(
-            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 8192,
@@ -335,7 +335,7 @@ Return JSON with these fields:
 Example: {{"action": "create", "name": "add-logging", "description": "Add logging", "requirements": "Add structured logging to all functions", "source_url": "https://github.com/user/repo"}}"""
 
         response = bedrock_runtime.invoke_model(
-            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 2048, "temperature": 0.1,
@@ -416,7 +416,7 @@ Files:
 {json.dumps(file_paths, indent=2)}"""
 
                         select_response = bedrock_runtime.invoke_model(
-                            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+                            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
                             body=json.dumps({
                                 "anthropic_version": "bedrock-2023-05-31",
                                 "max_tokens": 4096, "temperature": 0.1,

--- a/agentic-atx-platform/orchestrator/tools/executetransform.py
+++ b/agentic-atx-platform/orchestrator/tools/executetransform.py
@@ -249,7 +249,7 @@ Return JSON with these fields:
 Example: {{"action": "execute", "transformation": "AWS/python-version-upgrade", "source": "https://github.com/user/repo", "configuration": "validationCommands=pytest", "job_id": ""}}"""
 
         response = bedrock_rt.invoke_model(
-            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 2048, "temperature": 0.1,

--- a/agentic-atx-platform/orchestrator/tools/findtransform.py
+++ b/agentic-atx-platform/orchestrator/tools/findtransform.py
@@ -131,7 +131,7 @@ Available transformations:
 {chr(10).join(all_transforms)}"""
 
         response = bedrock_rt.invoke_model(
-            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0"),
+            modelId=os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-sonnet-4-5-20250929-v1:0"),
             body=json.dumps({
                 "anthropic_version": "bedrock-2023-05-31",
                 "max_tokens": 2048, "temperature": 0.1,

--- a/agentic-atx-platform/sam/deploy.sh
+++ b/agentic-atx-platform/sam/deploy.sh
@@ -24,6 +24,12 @@ REGION=${AWS_REGION:-us-east-1}
 OUTPUT_BUCKET="atx-custom-output-${ACCOUNT_ID}"
 SOURCE_BUCKET="atx-source-code-${ACCOUNT_ID}"
 
+# Load model id (and region) from shared config if present
+[ -f ../deployment/config.env ] && source ../deployment/config.env
+# Override the model only if explicitly configured; otherwise the SAM template default applies
+MODEL_OVERRIDE=""
+[ -n "$BEDROCK_MODEL_ID" ] && MODEL_OVERRIDE="BedrockModelId=$BEDROCK_MODEL_ID"
+
 echo "Account: ${ACCOUNT_ID}"
 echo "Region: ${REGION}"
 echo "Output Bucket: ${OUTPUT_BUCKET}"
@@ -75,6 +81,7 @@ sam deploy \
         OutputBucketName="${OUTPUT_BUCKET}" \
         SourceBucketName="${SOURCE_BUCKET}" \
         AwsRegion="${REGION}" \
+        ${MODEL_OVERRIDE} \
         OrchestratorContainerUri="${ORCH_ECR_URI}:latest" \
     --no-confirm-changeset \
     --no-fail-on-empty-changeset \

--- a/agentic-atx-platform/sam/deploy_agentcore.py
+++ b/agentic-atx-platform/sam/deploy_agentcore.py
@@ -131,7 +131,7 @@ def _deploy():
 
     env_vars = {
         'AWS_REGION': REGION,
-        'BEDROCK_MODEL_ID': os.environ.get('BEDROCK_MODEL_ID', 'us.anthropic.claude-sonnet-4-20250514-v1:0'),
+        'BEDROCK_MODEL_ID': os.environ.get('BEDROCK_MODEL_ID', 'us.anthropic.claude-sonnet-4-5-20250929-v1:0'),
     }
 
     if existing_runtime_id:

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -14,7 +14,7 @@ Parameters:
     Description: S3 bucket for source code and custom definitions (from CDK InfrastructureStack)
   BedrockModelId:
     Type: String
-    Default: us.anthropic.claude-sonnet-4-20250514-v1:0
+    Default: us.anthropic.claude-sonnet-4-5-20250929-v1:0
     Description: Bedrock model ID for the orchestrator
   AwsRegion:
     Type: String

--- a/agentic-atx-platform/ui/sample-batch.csv
+++ b/agentic-atx-platform/ui/sample-batch.csv
@@ -2,5 +2,5 @@ source,transformation,validationCommands,additionalPlanContext
 https://github.com/venuvasu/todoapilambda,AWS/python-version-upgrade,pytest,Target Python 3.13
 https://github.com/aws-samples/aws-appconfig-java-sample,AWS/java-version-upgrade,./gradlew clean build test,Target Java 21
 https://github.com/venuvasu/toapilambdanode16,AWS/nodejs-version-upgrade,,Target Node.js 22
-https://github.com/spring-projects/spring-petclinic,AWS/early-access-comprehensive-codebase-analysis,,
-https://github.com/venuvasu/todoapilambda,AWS/early-access-comprehensive-codebase-analysis,,
+https://github.com/spring-projects/spring-petclinic,AWS/comprehensive-codebase-analysis,,
+https://github.com/venuvasu/todoapilambda,AWS/comprehensive-codebase-analysis,,

--- a/agentic-atx-platform/ui/src/components/TransformationForm.jsx
+++ b/agentic-atx-platform/ui/src/components/TransformationForm.jsx
@@ -21,10 +21,13 @@ export default function TransformationForm({ orchestrate, onJobCreated }) {
       'AWS/python-boto2-to-boto3',
       'AWS/java-aws-sdk-v1-to-v2',
       'AWS/nodejs-aws-sdk-v2-to-v3',
-      'AWS/early-access-comprehensive-codebase-analysis',
+      'AWS/comprehensive-codebase-analysis',
+      'AWS/java-performance-optimization',
       'AWS/early-access-java-x86-to-graviton',
       'AWS/early-access-angular-to-react-migration',
-      'AWS/early-access-jfr-performance-optimization',
+      'AWS/vue.js-version-upgrade',
+      'AWS/angular-version-upgrade',
+      'AWS/early-access-log4j-to-slf4j-migration',
     ]
     setTransformations(managed)
     // Load published custom transforms

--- a/agentic-atx-platform/ui/test-mixed-batch.csv
+++ b/agentic-atx-platform/ui/test-mixed-batch.csv
@@ -1,4 +1,4 @@
 source,transformation,validationCommands,additionalPlanContext
 https://github.com/venuvasu/todoapilambda,AWS/python-version-upgrade,pytest,Target Python 3.13
-https://github.com/venuvasu/todoapilambda,AWS/early-access-comprehensive-codebase-analysis,,
+https://github.com/venuvasu/todoapilambda,AWS/comprehensive-codebase-analysis,,
 https://github.com/aws-samples/aws-appconfig-java-sample,AWS/java-version-upgrade,./gradlew clean build test,Target Java 21


### PR DESCRIPTION
## Description

Fixes that unblock deploying the `agentic-atx-platform` sample and align it with the current AWS Transform registry.

### 1. CDK: honor `useBaseInfra` context + optional prebuilt image (`cdk/bin/cdk.ts`)
- `useBaseInfra` was hardcoded as `=== 'true' || true`, which always evaluates to `true`. This forced hybrid mode and meant the full-mode stacks (`AtxContainerStack`, `AtxInfrastructureStack`) documented in README Option A/B were never instantiated. Normalized to accept either a string `'true'` or a JSON boolean `true`.
- Added an optional `-c publicEcrImage=<uri>` context flag. When set, the local Docker build is skipped and the Batch job uses the prebuilt image (e.g. `public.ecr.aws/b7y6j9m3/aws-transform-custom:latest`). Default behavior is unchanged.

### 2. Fix stale AWS-managed transformation identifiers (`ui/...`)
- The Execute form and sample CSVs referenced `AWS/early-access-comprehensive-codebase-analysis` and `AWS/early-access-jfr-performance-optimization`, which are not in the ATX registry and fail at `atx custom def exec` ("Transformation not found").
- Updated to the current names (`AWS/comprehensive-codebase-analysis`, `AWS/java-performance-optimization`) and added the missing `vue.js-version-upgrade`, `angular-version-upgrade`, and `early-access-log4j-to-slf4j-migration`, matching `findtransform.py`/`TransformationList.jsx`.

### 3. Default orchestrator model to Claude Sonnet 4.5
- Bumped the default to `us.anthropic.claude-sonnet-4-5-20250929-v1:0` across the SAM template default, `config.env.template`, code fallbacks, and docs.
- `sam/deploy.sh` now passes `BedrockModelId` only when explicitly configured, so the SAM template default applies otherwise (no empty override).

## Testing
- Deployed end-to-end via Option A (CDK + SAM) in `us-east-1`: infrastructure, AgentCore runtime (READY), HTTP API, and CloudFront UI.
- Verified the UI loads, `/orchestrate` responds, and a transformation submits to AWS Batch with a valid registry identifier.
- `tsc` compiles cleanly; `bash -n` passes on `deploy.sh`.

## Notes / follow-ups
- The UI transformation list is still hardcoded (now consistent across the repo). Consolidating it behind a single backend endpoint is a reasonable follow-up but out of scope here.
- `package-lock.json` files are intentionally not included.

## Licensing
By submitting this PR, I confirm my contribution is made under the terms of the project's MIT-0 license.