### PR TITLE
Fix sub-agent /home/user path resolution bug

### DIFF
--- a/scaled-execution-containers/cdk/lib/api-stack.ts
+++ b/scaled-execution-containers/cdk/lib/api-stack.ts
@@ -94,6 +94,7 @@ export class ApiStack extends cdk.Stack {
           'Action::s3:List*',
           'Resource::<OutputBucket7114EB27.Arn>/*',
           'Resource::<SourceBucketDDD2130A.Arn>/*',
+          `Resource::arn:aws:logs:${this.region}:${this.account}:log-group:/aws/batch/atx-transform:*`,
         ],
       },
     ], true);

--- a/scaled-execution-containers/container/Dockerfile
+++ b/scaled-execution-containers/container/Dockerfile
@@ -139,6 +139,10 @@ COPY --chown=atxuser:atxuser upload-results.sh /app/
 
 RUN chmod +x /app/*.sh
 
+# Workaround: ATX sub-agents resolve ~ to /home/user instead of /home/atxuser
+# Create symlink so writes to /home/user land in /home/atxuser
+RUN ln -s /home/atxuser /home/user
+
 # ============================================================================
 # AWS TRANSFORM CLI
 # ============================================================================


### PR DESCRIPTION
- Add symlink /home/user -> /home/atxuser in Dockerfile (RUN as root)
- Add cdk-nag IAM5 suppression for Batch log group wildcard

Sub-agents use /home/user for file_write but container home is /home/atxuser. The symlink resolves the path mismatch at the filesystem level.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
