### PR TITLE
Tag all resources with atx-remote-infra=true

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -75,3 +75,5 @@ const infrastructureStack = new InfrastructureStack(app, 'AtxInfrastructureStack
 if (containerStack) {
   infrastructureStack.addDependency(containerStack);
 }
+
+cdk.Tags.of(app).add('atx-remote-infra', 'true');


### PR DESCRIPTION
## Summary
- Adds a global CDK tag `atx-remote-infra=true` to all resources synthesized by the app, making it easy to identify and group resources deployed from this branch.
