### PR TITLE
Fix/setup and teardown improvements

### DIFF
--- a/AWSTransformExecutionBatchAccess.json
+++ b/AWSTransformExecutionBatchAccess.json
@@ -1,0 +1,210 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "LambdaInvokeATXFunctions",
+            "Effect": "Allow",
+            "Action": "lambda:InvokeFunction",
+            "Resource": "arn:aws:lambda:*:*:function:atx-*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "S3UploadSourceCode",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:AbortMultipartUpload"
+            ],
+            "Resource": [
+                "arn:aws:s3:::atx-source-code-*",
+                "arn:aws:s3:::atx-source-code-*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "S3DownloadResults",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::atx-custom-output-*",
+                "arn:aws:s3:::atx-custom-output-*/*",
+                "arn:aws:s3:::atx-ct-output-*",
+                "arn:aws:s3:::atx-ct-output-*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "KMSEncryptDecrypt",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+            ],
+            "Resource": "arn:aws:kms:*:*:key/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                },
+                "ForAnyValue:StringEquals": {
+                    "kms:ResourceAliases": "alias/atx-encryption-key"
+                }
+            }
+        },
+        {
+            "Sid": "CloudWatchReadLogs",
+            "Effect": "Allow",
+            "Action": [
+                "logs:GetLogEvents",
+                "logs:FilterLogEvents"
+            ],
+            "Resource": [
+                "arn:aws:logs:*:*:log-group:/aws/batch/atx-transform*",
+                "arn:aws:logs:*:*:log-group:/aws/batch/job*",
+                "arn:aws:logs:*:*:log-group:AtxVpc*",
+                "arn:aws:logs:*:*:log-group:/aws/lambda/atx-*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "CloudWatchDashboard",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:GetDashboard",
+                "cloudwatch:ListDashboards"
+            ],
+            "Resource": "arn:aws:cloudwatch::*:dashboard/ATX-Transform-CLI-Dashboard",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "BatchDescribe",
+            "Effect": "Allow",
+            "Action": [
+                "batch:DescribeComputeEnvironments",
+                "batch:DescribeJobQueues",
+                "batch:DescribeJobDefinitions",
+                "batch:DescribeJobs",
+                "batch:ListJobs"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "CheckInfrastructureStatus",
+            "Effect": "Allow",
+            "Action": "cloudformation:DescribeStacks",
+            "Resource": "arn:aws:cloudformation:*:*:stack/AtxInfrastructureStack/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "SecretsManagerATXSecrets",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:CreateSecret",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:DescribeSecret"
+            ],
+            "Resource": "arn:aws:secretsmanager:*:*:secret:atx/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "SchedulerManage",
+            "Effect": "Allow",
+            "Action": "scheduler:*",
+            "Resource": [
+                "arn:aws:scheduler:*:*:schedule-group/atx-control-tower",
+                "arn:aws:scheduler:*:*:schedule/atx-control-tower/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "PassSchedulerRole",
+            "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": "arn:aws:iam::*:role/AtxSchedulerInvocationRole",
+            "Condition": {
+                "StringEquals": {
+                    "iam:PassedToService": "scheduler.amazonaws.com",
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "EC2NetworkDiscovery",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeVpcs",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeRouteTables",
+                "ec2:DescribeNatGateways"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        },
+        {
+            "Sid": "IAMReadRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetRole",
+                "iam:ListAttachedRolePolicies",
+                "iam:GetRolePolicy"
+            ],
+            "Resource": [
+                "arn:aws:iam::*:role/ATX*",
+                "arn:aws:iam::*:role/Atx*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "aws:ResourceAccount": "${aws:PrincipalAccount}"
+                }
+            }
+        }
+    ]
+}
+

--- a/AWSTransformInfrastructureExecutorAccessBatch.json
+++ b/AWSTransformInfrastructureExecutorAccessBatch.json
@@ -133,8 +133,6 @@
             "Sid": "SecretsManagerATXSecrets",
             "Effect": "Allow",
             "Action": [
-                "secretsmanager:CreateSecret",
-                "secretsmanager:PutSecretValue",
                 "secretsmanager:DescribeSecret"
             ],
             "Resource": "arn:aws:secretsmanager:*:*:secret:atx/*",
@@ -207,4 +205,3 @@
         }
     ]
 }
-

--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -16,6 +16,7 @@ const maxVcpus = app.node.tryGetContext('maxVcpus') || 256;
 
 const existingOutputBucket = app.node.tryGetContext('existingOutputBucket') || '';
 const existingSourceBucket = app.node.tryGetContext('existingSourceBucket') || '';
+const existingCtOutputBucket = app.node.tryGetContext('existingCtOutputBucket') || '';
 const existingVpcId = app.node.tryGetContext('existingVpcId') || '';
 const existingSubnetIds = app.node.tryGetContext('existingSubnetIds') || [];
 const existingSecurityGroupId = app.node.tryGetContext('existingSecurityGroupId') || '';
@@ -67,6 +68,7 @@ const infrastructureStack = new InfrastructureStack(app, 'AtxInfrastructureStack
   maxVcpus,
   existingOutputBucket,
   existingSourceBucket,
+  existingCtOutputBucket,
   existingVpcId,
   existingSubnetIds,
   existingSecurityGroupId,

--- a/cdk.json
+++ b/cdk.json
@@ -91,6 +91,7 @@
     "maxVcpus": 256,
     "existingOutputBucket": "",
     "existingSourceBucket": "",
+    "existingCtOutputBucket": "",
     "existingVpcId": "",
     "existingSubnetIds": [],
     "existingSecurityGroupId": "",

--- a/create-vpc.sh
+++ b/create-vpc.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Creates a Fargate-ready VPC for ATX testing:
+#   - VPC with DNS support
+#   - Internet Gateway
+#   - 1 public subnet (hosts NAT gateway)
+#   - 2 private subnets (for Fargate tasks)
+#   - NAT gateway for outbound internet from private subnets
+#   - Security group (egress-only)
+#
+# Usage: AWS_PROFILE=atx-test ./create-vpc.sh
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+export AWS_DEFAULT_REGION="$REGION"
+
+echo "Creating ATX test VPC in $REGION..."
+
+# 1. Create VPC
+VPC_ID=$(aws ec2 create-vpc --cidr-block 10.1.0.0/16 \
+  --tag-specifications 'ResourceType=vpc,Tags=[{Key=Name,Value=atx-test-vpc}]' \
+  --query 'Vpc.VpcId' --output text)
+aws ec2 modify-vpc-attribute --vpc-id "$VPC_ID" --enable-dns-support
+aws ec2 modify-vpc-attribute --vpc-id "$VPC_ID" --enable-dns-hostnames
+echo "✓ VPC: $VPC_ID"
+
+# 2. Create Internet Gateway
+IGW_ID=$(aws ec2 create-internet-gateway \
+  --tag-specifications 'ResourceType=internet-gateway,Tags=[{Key=Name,Value=atx-test-igw}]' \
+  --query 'InternetGateway.InternetGatewayId' --output text)
+aws ec2 attach-internet-gateway --vpc-id "$VPC_ID" --internet-gateway-id "$IGW_ID"
+echo "✓ Internet Gateway: $IGW_ID"
+
+# 3. Create public subnet (for NAT gateway)
+PUBLIC_SUBNET=$(aws ec2 create-subnet --vpc-id "$VPC_ID" \
+  --cidr-block 10.1.0.0/24 --availability-zone "${REGION}a" \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=atx-test-public-1a}]' \
+  --query 'Subnet.SubnetId' --output text)
+echo "✓ Public subnet: $PUBLIC_SUBNET"
+
+# 4. Create public route table and associate
+PUBLIC_RT=$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+  --tag-specifications 'ResourceType=route-table,Tags=[{Key=Name,Value=atx-test-public-rt}]' \
+  --query 'RouteTable.RouteTableId' --output text)
+aws ec2 create-route --route-table-id "$PUBLIC_RT" --destination-cidr-block 0.0.0.0/0 --gateway-id "$IGW_ID" >/dev/null
+aws ec2 associate-route-table --route-table-id "$PUBLIC_RT" --subnet-id "$PUBLIC_SUBNET" >/dev/null
+echo "✓ Public route table: $PUBLIC_RT"
+
+# 5. Create NAT Gateway
+EIP_ALLOC=$(aws ec2 allocate-address --domain vpc \
+  --tag-specifications 'ResourceType=elastic-ip,Tags=[{Key=Name,Value=atx-test-eip}]' \
+  --query 'AllocationId' --output text)
+NAT_ID=$(aws ec2 create-nat-gateway --subnet-id "$PUBLIC_SUBNET" --allocation-id "$EIP_ALLOC" \
+  --tag-specifications 'ResourceType=natgateway,Tags=[{Key=Name,Value=atx-test-nat}]' \
+  --query 'NatGateway.NatGatewayId' --output text)
+echo "  Waiting for NAT gateway $NAT_ID to become available (~1-2 min)..."
+aws ec2 wait nat-gateway-available --nat-gateway-ids "$NAT_ID"
+echo "✓ NAT Gateway: $NAT_ID"
+
+# 6. Create private subnets (for Fargate tasks)
+PRIVATE_SUBNET_1=$(aws ec2 create-subnet --vpc-id "$VPC_ID" \
+  --cidr-block 10.1.1.0/24 --availability-zone "${REGION}a" \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=atx-test-private-1a}]' \
+  --query 'Subnet.SubnetId' --output text)
+PRIVATE_SUBNET_2=$(aws ec2 create-subnet --vpc-id "$VPC_ID" \
+  --cidr-block 10.1.2.0/24 --availability-zone "${REGION}b" \
+  --tag-specifications 'ResourceType=subnet,Tags=[{Key=Name,Value=atx-test-private-1b}]' \
+  --query 'Subnet.SubnetId' --output text)
+echo "✓ Private subnets: $PRIVATE_SUBNET_1, $PRIVATE_SUBNET_2"
+
+# 7. Create private route table (routes through NAT)
+PRIVATE_RT=$(aws ec2 create-route-table --vpc-id "$VPC_ID" \
+  --tag-specifications 'ResourceType=route-table,Tags=[{Key=Name,Value=atx-test-private-rt}]' \
+  --query 'RouteTable.RouteTableId' --output text)
+aws ec2 create-route --route-table-id "$PRIVATE_RT" --destination-cidr-block 0.0.0.0/0 --nat-gateway-id "$NAT_ID" >/dev/null
+aws ec2 associate-route-table --route-table-id "$PRIVATE_RT" --subnet-id "$PRIVATE_SUBNET_1" >/dev/null
+aws ec2 associate-route-table --route-table-id "$PRIVATE_RT" --subnet-id "$PRIVATE_SUBNET_2" >/dev/null
+echo "✓ Private route table: $PRIVATE_RT"
+
+# 8. Create security group (egress-only for Fargate)
+SG_ID=$(aws ec2 create-security-group --vpc-id "$VPC_ID" \
+  --group-name atx-test-fargate-sg \
+  --description "ATX Fargate tasks - egress only" \
+  --query 'GroupId' --output text)
+aws ec2 create-tags --resources "$SG_ID" --tags Key=Name,Value=atx-test-fargate-sg
+echo "✓ Security Group: $SG_ID"
+
+# 9. Print results
+echo ""
+echo "═══════════════════════════════════════════════"
+echo " Add to cdk.json context:"
+echo "═══════════════════════════════════════════════"
+echo ""
+echo "  \"existingVpcId\": \"$VPC_ID\","
+echo "  \"existingSubnetIds\": [\"$PRIVATE_SUBNET_1\", \"$PRIVATE_SUBNET_2\"],"
+echo "  \"existingSecurityGroupId\": \"$SG_ID\""
+echo ""

--- a/lib/infrastructure-stack.ts
+++ b/lib/infrastructure-stack.ts
@@ -163,8 +163,15 @@ export class InfrastructureStack extends cdk.Stack {
       }, this)],
     }));
 
-    // Security Agent permissions — always present, scoped by account condition.
+    // Security Agent permissions — matches AWSTransformSecurityAgentExecutorAccess policy.
+    // Always present, scoped by account condition.
     // No-op if security analysis isn't configured; avoids manual post-deploy IAM changes.
+    jobRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'STSIdentity',
+      actions: ['sts:GetCallerIdentity'],
+      resources: ['*'],
+    }));
+
     jobRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SecurityAgentApi',
       actions: [
@@ -197,8 +204,8 @@ export class InfrastructureStack extends cdk.Stack {
     jobRole.addToPolicy(new iam.PolicyStatement({
       sid: 'IAMPassSecurityAgentRole',
       actions: ['iam:PassRole'],
-      resources: [`arn:aws:iam::${accountId}:role/security-agent-*`],
-      conditions: { StringEquals: { 'iam:PassedToService': 'securityagent.amazonaws.com' } },
+      resources: ['arn:aws:iam::*:role/security-agent-*'],
+      conditions: { StringEquals: { 'iam:PassedToService': 'securityagent.amazonaws.com', 'aws:ResourceAccount': accountId } },
     }));
 
     // Suppress cdk-nag findings for job role

--- a/lib/infrastructure-stack.ts
+++ b/lib/infrastructure-stack.ts
@@ -167,12 +167,6 @@ export class InfrastructureStack extends cdk.Stack {
     // Always present, scoped by account condition.
     // No-op if security analysis isn't configured; avoids manual post-deploy IAM changes.
     jobRole.addToPolicy(new iam.PolicyStatement({
-      sid: 'STSIdentity',
-      actions: ['sts:GetCallerIdentity'],
-      resources: ['*'],
-    }));
-
-    jobRole.addToPolicy(new iam.PolicyStatement({
       sid: 'SecurityAgentApi',
       actions: [
         'securityagent:ListAgentSpaces',
@@ -217,7 +211,7 @@ export class InfrastructureStack extends cdk.Stack {
       },
       {
         id: 'AwsSolutions-IAM5',
-        reason: 'S3 wildcard permissions are required for dynamic file operations. KMS GenerateDataKey*/ReEncrypt* are standard CDK grant patterns scoped to a single key. Secrets Manager wildcard is scoped to atx/* prefix for credential management. Security agent resources are scoped to account-owned agent spaces and kct-security-agent buckets.',
+        reason: 'S3 wildcard permissions are required for dynamic file operations. KMS GenerateDataKey*/ReEncrypt* are standard CDK grant patterns scoped to a single key. Secrets Manager wildcard is scoped to atx/* prefix for credential management. Security agent resources are scoped to account-owned agent spaces and kct-security-agent buckets. IAM PassRole uses account wildcard in ARN but is constrained by aws:ResourceAccount condition to the deploying account.',
         appliesTo: [
           'Action::s3:Abort*',
           'Action::s3:DeleteObject*',
@@ -240,7 +234,7 @@ export class InfrastructureStack extends cdk.Stack {
           'Resource::arn:aws:s3:::kct-security-agent-*',
           'Resource::arn:aws:s3:::kct-security-agent-*/*',
           'Resource::arn:aws:s3:::kct-security-agent-*/security-scans/*',
-          `Resource::arn:aws:iam::${accountId}:role/security-agent-*`,
+          'Resource::arn:aws:iam::*:role/security-agent-*',
         ],
       },
     ], true);

--- a/lib/infrastructure-stack.ts
+++ b/lib/infrastructure-stack.ts
@@ -163,11 +163,12 @@ export class InfrastructureStack extends cdk.Stack {
       }, this)],
     }));
 
-    // Security Agent permissions for security analysis
+    // Security Agent permissions — always present, scoped by account condition.
+    // No-op if security analysis isn't configured; avoids manual post-deploy IAM changes.
     jobRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'SecurityAgentApi',
       actions: [
         'securityagent:ListAgentSpaces',
-        'securityagent:CreateAgentSpace',
         'securityagent:CreateCodeReview',
         'securityagent:StartCodeReviewJob',
         'securityagent:ListCodeReviewJobsForCodeReview',
@@ -175,20 +176,29 @@ export class InfrastructureStack extends cdk.Stack {
         'securityagent:BatchGetFindings',
         'securityagent:StartCodeRemediation',
       ],
-      resources: [`arn:aws:securityagent:*:${accountId}:agent-space*`],
+      resources: ['arn:aws:securityagent:*:*:agent-space*'],
+      conditions: { StringEquals: { 'aws:ResourceAccount': accountId } },
     }));
 
     jobRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'S3SecurityAgentBucketRead',
+      actions: ['s3:GetObject', 's3:ListBucket'],
+      resources: ['arn:aws:s3:::kct-security-agent-*', 'arn:aws:s3:::kct-security-agent-*/*'],
+      conditions: { StringEquals: { 's3:ResourceAccount': accountId } },
+    }));
+
+    jobRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'S3SecurityAgentUpload',
       actions: ['s3:PutObject'],
-      resources: ['arn:aws:s3:::kct-security-agent-*/*'],
+      resources: ['arn:aws:s3:::kct-security-agent-*/security-scans/*'],
+      conditions: { StringEquals: { 's3:ResourceAccount': accountId } },
     }));
 
     jobRole.addToPolicy(new iam.PolicyStatement({
+      sid: 'IAMPassSecurityAgentRole',
       actions: ['iam:PassRole'],
-      resources: [`arn:aws:iam::${accountId}:role/security-agent-kct-agent-space-*`],
-      conditions: {
-        StringEquals: { 'iam:PassedToService': 'securityagent.amazonaws.com' },
-      },
+      resources: [`arn:aws:iam::${accountId}:role/security-agent-*`],
+      conditions: { StringEquals: { 'iam:PassedToService': 'securityagent.amazonaws.com' } },
     }));
 
     // Suppress cdk-nag findings for job role
@@ -209,13 +219,21 @@ export class InfrastructureStack extends cdk.Stack {
           'Action::s3:List*',
           'Action::kms:GenerateDataKey*',
           'Action::kms:ReEncrypt*',
+          // CDK-created buckets (token ARNs)
           'Resource::<OutputBucket7114EB27.Arn>/*',
           'Resource::<SourceBucketDDD2130A.Arn>/*',
           'Resource::<CtOutputBucket97C9D9C3.Arn>/*',
+          // Imported buckets (literal ARNs)
+          `Resource::arn:aws:s3:::atx-custom-output-${accountId}/*`,
+          `Resource::arn:aws:s3:::atx-source-code-${accountId}/*`,
+          `Resource::arn:aws:s3:::atx-ct-output-${accountId}/*`,
           `Resource::arn:aws:secretsmanager:${cdk.Stack.of(this).region}:${accountId}:secret:atx/*`,
-          `Resource::arn:aws:securityagent:*:${accountId}:agent-space*`,
+          // Security agent
+          'Resource::arn:aws:securityagent:*:*:agent-space*',
+          'Resource::arn:aws:s3:::kct-security-agent-*',
           'Resource::arn:aws:s3:::kct-security-agent-*/*',
-          `Resource::arn:aws:iam::${accountId}:role/security-agent-kct-agent-space-*`,
+          'Resource::arn:aws:s3:::kct-security-agent-*/security-scans/*',
+          `Resource::arn:aws:iam::${accountId}:role/security-agent-*`,
         ],
       },
     ], true);
@@ -466,8 +484,14 @@ export class InfrastructureStack extends cdk.Stack {
             'Action::s3:List*',
             'Action::kms:GenerateDataKey*',
             'Action::kms:ReEncrypt*',
+            // CDK-created buckets (token ARNs)
             'Resource::<OutputBucket7114EB27.Arn>/*',
             'Resource::<SourceBucketDDD2130A.Arn>/*',
+            'Resource::<CtOutputBucket97C9D9C3.Arn>/*',
+            // Imported buckets (literal ARNs)
+            `Resource::arn:aws:s3:::atx-custom-output-${accountId}/*`,
+            `Resource::arn:aws:s3:::atx-source-code-${accountId}/*`,
+            `Resource::arn:aws:s3:::atx-ct-output-${accountId}/*`,
             `Resource::arn:aws:batch:${this.region}:${this.account}:job-definition/${this.jobDefinition.jobDefinitionName}*`,
           ],
         },
@@ -509,6 +533,7 @@ export class InfrastructureStack extends cdk.Stack {
     makeFn('GetBatchStatusFunction', 'atx-get-batch-status', 'get-batch-status', statusRole);
     makeFn('TerminateBatchJobsFunction', 'atx-terminate-batch-jobs', 'terminate-batch-jobs', terminateRole);
     makeFn('ListBatchesFunction', 'atx-list-batches', 'list-batches', statusRole);
+
 
     // CloudWatch Dashboard
     const dashboard = new cloudwatch.Dashboard(this, 'Dashboard', {
@@ -625,5 +650,6 @@ export class InfrastructureStack extends cdk.Stack {
       description: 'KMS key ARN for S3 encryption',
       exportName: 'AtxKmsKeyArn',
     });
+
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,36 +27,36 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.263",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.263.tgz",
-      "integrity": "sha512-X9JvcJhYcb7PHs8R7m4zMablO5C9PGb/hYfLnxds9h/rKJu6l7MiXE/SabCibuehxPnuO/vk+sVVJiUWrccarQ==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "52.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-52.2.0.tgz",
-      "integrity": "sha512-ourZjixQ/UfsZc7gdk3vt1eHBODMUjQTYYYCY3ZX8fiXyHtWNDAYZPrXUK96jpCC2fLP+tfHTJrBjZ563pmcEw==",
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.1"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -64,7 +64,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.3",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -75,13 +75,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -100,21 +100,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -131,14 +131,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -148,14 +148,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -165,9 +165,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -175,29 +175,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -217,9 +217,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -247,27 +247,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -332,13 +332,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -374,13 +374,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -500,13 +500,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -516,33 +516,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -550,14 +550,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1670,9 +1670,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1111.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1111.0.tgz",
-      "integrity": "sha512-69AVF04cxbAhYzmeJYtUF5bs6ruNnH05EQZJfjadk5Lpg+HVaJY2NjG/2qgsMmKrfRgvLet73Ir8ehVlAaaGng==",
+      "version": "2.1126.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1126.0.tgz",
+      "integrity": "sha512-uNoocb3vCPiAT3j9+SwL6pn/VVggHWBsgC2XpxyhNvYQYt6cE9BM/149GWwtdcwnLrPjnwW1+CV/5nSSh5dV+w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.243.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.243.0.tgz",
-      "integrity": "sha512-qIhg/3gSNeZ9LoVmDATO45HPk+POkoCfPZRezeOPhd2kAJ/wzYswyUcMqpDWXrlRrEVYntxsykQs+2eMA04Isg==",
+      "version": "2.258.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.1.tgz",
+      "integrity": "sha512-isYgP0GASgTY99J3753iN6SLP05wEuinToE+p+Yat0d5Xi55iOtd5HFzBBklOb77FO5R3pikY6r9qaRSZUAwWA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1702,21 +1702,21 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.263",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.1.1",
-        "@aws-cdk/cloud-assembly-schema": "^52.1.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -1726,41 +1726,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.1.1",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.3"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=52.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1769,7 +1746,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1822,7 +1799,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.3",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1867,7 +1844,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -1882,7 +1859,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1921,7 +1898,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1964,11 +1941,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1994,7 +1971,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -2068,7 +2045,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -2195,13 +2172,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2212,10 +2188,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -2236,9 +2211,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2256,11 +2231,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2320,9 +2295,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "dev": true,
       "funding": [
         {
@@ -2341,14 +2316,17 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/cdk-nag": {
-      "version": "2.37.55",
-      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
-      "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
+      "version": "2.38.2",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.38.2.tgz",
+      "integrity": "sha512-Ddim1r8IwAPQn95KB2owbHoU4YHveHg4PfM+k7TdcANqfVmoHem6cTFMpcIuoDM16BkQQ+xshxYxZgcAoeVKGw==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 18.12.0"
+      },
       "peerDependencies": {
         "aws-cdk-lib": "^2.176.0",
-        "constructs": "^10.0.5"
+        "constructs": "^10.5.1"
       }
     },
     "node_modules/chalk": {
@@ -2458,13 +2436,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.5.1.tgz",
-      "integrity": "sha512-f/TfFXiS3G/yVIXDjOQn9oTlyu9Wo7Fxyjj7lb8r92iO81jR2uST+9MstxZTmDGx/CgIbxCXkFXgupnLTNxQZg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
@@ -2592,9 +2569,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
     },
@@ -2626,6 +2603,16 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2902,9 +2889,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2934,9 +2921,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3020,13 +3007,13 @@
       "license": "MIT"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3113,9 +3100,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3652,9 +3639,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3893,9 +3880,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3957,7 +3944,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -4005,11 +3991,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4179,9 +4168,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4291,12 +4280,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -4348,7 +4338,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4579,19 +4568,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.11",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+      "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.0",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -4608,7 +4597,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -4632,9 +4621,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "cdk",
   "version": "0.1.0",
-  "bin": {
-    "cdk": "bin/cdk.js"
-  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/setup.sh
+++ b/setup.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # infrastructure to your AWS account:
 #   1. Checks prerequisites (Node.js, npm, Docker*, AWS CLI, credentials)
 #      *Docker is only required when building a custom container image
-#       (i.e., when prebuiltImageUri is empty in cdk.json)
+#       (i.e., when prebuiltImageUri is empty in npx cdk.json)
 #   2. Installs npm dependencies
 #   3. Compiles TypeScript
 #   4. Bootstraps CDK (if needed)
@@ -61,7 +61,7 @@ info "AWS CLI $(aws --version 2>&1 | head -1)"
 aws sts get-caller-identity >/dev/null 2>&1 || fail "AWS credentials not configured. Run: aws configure sso"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 
-# Region resolution: match bin/cdk.ts precedence
+# Region resolution: match bin/npx cdk.ts precedence
 SUPPORTED_REGIONS=("us-east-1" "eu-central-1")
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo "")}}"
 REGION="${REGION:-us-east-1}"
@@ -81,6 +81,62 @@ export CDK_DEFAULT_ACCOUNT="$ACCOUNT_ID"
 
 echo ""
 
+# --- Validate network configuration (mandatory) ---
+
+echo "Checking network configuration..."
+EXISTING_VPC_ID=$(node -e "console.log(require('./cdk.json').context.existingVpcId || '')" 2>/dev/null || echo "")
+EXISTING_SUBNET_IDS=$(node -e "const s=require('./cdk.json').context.existingSubnetIds||[];console.log(s.length?'ok':'')" 2>/dev/null || echo "")
+EXISTING_SG_ID=$(node -e "console.log(require('./cdk.json').context.existingSecurityGroupId || '')" 2>/dev/null || echo "")
+
+[ -z "$EXISTING_VPC_ID" ] && fail "existingVpcId is not set in cdk.json. You must provide a VPC ID before deploying. AWS Transform does NOT create VPCs — you provide one."
+[ -z "$EXISTING_SUBNET_IDS" ] && fail "existingSubnetIds is empty in cdk.json. You must provide at least two subnet IDs before deploying."
+[ -z "$EXISTING_SG_ID" ] && fail "existingSecurityGroupId is not set in cdk.json. You must provide a security group ID before deploying."
+info "Network: VPC=$EXISTING_VPC_ID, SG=$EXISTING_SG_ID"
+
+echo ""
+
+# --- Detect existing S3 buckets (auto-populate context to avoid CREATE conflict) ---
+
+echo "Checking for existing S3 buckets..."
+SOURCE_BUCKET="atx-source-code-${ACCOUNT_ID}"
+OUTPUT_BUCKET="atx-custom-output-${ACCOUNT_ID}"
+CT_OUTPUT_BUCKET="atx-ct-output-${ACCOUNT_ID}"
+
+UPDATED_CDK_JSON=false
+
+if aws s3api head-bucket --bucket "$SOURCE_BUCKET" --region "$REGION" 2>/dev/null; then
+  CURRENT_SOURCE=$(node -e "console.log(require('./cdk.json').context.existingSourceBucket || '')" 2>/dev/null || echo "")
+  if [ -z "$CURRENT_SOURCE" ]; then
+    node -e "const f='./cdk.json';const c=JSON.parse(require('fs').readFileSync(f));c.context.existingSourceBucket='${SOURCE_BUCKET}';require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n')"
+    UPDATED_CDK_JSON=true
+  fi
+  info "Source bucket exists: $SOURCE_BUCKET (will import)"
+fi
+
+if aws s3api head-bucket --bucket "$OUTPUT_BUCKET" --region "$REGION" 2>/dev/null; then
+  CURRENT_OUTPUT=$(node -e "console.log(require('./cdk.json').context.existingOutputBucket || '')" 2>/dev/null || echo "")
+  if [ -z "$CURRENT_OUTPUT" ]; then
+    node -e "const f='./cdk.json';const c=JSON.parse(require('fs').readFileSync(f));c.context.existingOutputBucket='${OUTPUT_BUCKET}';require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n')"
+    UPDATED_CDK_JSON=true
+  fi
+  info "Output bucket exists: $OUTPUT_BUCKET (will import)"
+fi
+
+if aws s3api head-bucket --bucket "$CT_OUTPUT_BUCKET" --region "$REGION" 2>/dev/null; then
+  CURRENT_CT_OUTPUT=$(node -e "console.log(require('./cdk.json').context.existingCtOutputBucket || '')" 2>/dev/null || echo "")
+  if [ -z "$CURRENT_CT_OUTPUT" ]; then
+    node -e "const f='./cdk.json';const c=JSON.parse(require('fs').readFileSync(f));c.context.existingCtOutputBucket='${CT_OUTPUT_BUCKET}';require('fs').writeFileSync(f,JSON.stringify(c,null,2)+'\n')"
+    UPDATED_CDK_JSON=true
+  fi
+  info "CT output bucket exists: $CT_OUTPUT_BUCKET (will import)"
+fi
+
+if $UPDATED_CDK_JSON; then
+  warn "Updated cdk.json to import pre-existing S3 buckets (avoids CREATE conflict)"
+fi
+
+echo ""
+
 # --- Install dependencies ---
 
 echo "Installing dependencies..."
@@ -97,7 +153,7 @@ echo "Compiling TypeScript..."
 npx tsc
 info "TypeScript compiled"
 
-CDK="cdk"
+CDK="npx cdk"
 info "CDK CLI $($CDK --version 2>&1 | head -1)"
 
 # --- Bootstrap CDK (idempotent) ---
@@ -133,14 +189,50 @@ for STACK_NAME in $STACKS_TO_VERIFY; do
   STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
     --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
   case "$STACK_STATUS" in
-    CREATE_COMPLETE|UPDATE_COMPLETE)
+    CREATE_COMPLETE|UPDATE_COMPLETE|UPDATE_ROLLBACK_COMPLETE)
       info "$STACK_NAME: $STACK_STATUS"
       ;;
     *)
-      fail "$STACK_NAME deployment failed (status: $STACK_STATUS). Run 'cdk deploy --all' to retry."
+      fail "$STACK_NAME deployment failed (status: $STACK_STATUS). Run 'npx cdk deploy --all' to retry."
       ;;
   esac
 done
+
+# --- Scheduler role (idempotent) ---
+
+echo ""
+echo "Configuring scheduler role..."
+SCHEDULER_ROLE_NAME="AtxSchedulerInvocationRole"
+LAMBDA_POLICY_NAME="lambda-invoke-batch-trigger"
+LAMBDA_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:atx-trigger-batch-jobs"
+
+if aws iam get-role --role-name "$SCHEDULER_ROLE_NAME" >/dev/null 2>&1; then
+  info "$SCHEDULER_ROLE_NAME exists"
+else
+  aws iam create-role --role-name "$SCHEDULER_ROLE_NAME" \
+    --assume-role-policy-document '{
+      "Version": "2012-10-17",
+      "Statement": [{
+        "Effect": "Allow",
+        "Principal": {"Service": "scheduler.amazonaws.com"},
+        "Action": "sts:AssumeRole"
+      }]
+    }' >/dev/null
+  info "$SCHEDULER_ROLE_NAME created"
+fi
+
+EXPECTED_POLICY="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"lambda:InvokeFunction\",\"Resource\":\"${LAMBDA_ARN}\"}]}"
+CURRENT_POLICY=$(aws iam get-role-policy --role-name "$SCHEDULER_ROLE_NAME" --policy-name "$LAMBDA_POLICY_NAME" \
+  --query 'PolicyDocument' --output json 2>/dev/null | jq -c '.' 2>/dev/null || echo "")
+
+if [ "$CURRENT_POLICY" != "$EXPECTED_POLICY" ]; then
+  aws iam put-role-policy --role-name "$SCHEDULER_ROLE_NAME" \
+    --policy-name "$LAMBDA_POLICY_NAME" \
+    --policy-document "$EXPECTED_POLICY"
+  info "$LAMBDA_POLICY_NAME policy attached"
+else
+  info "$LAMBDA_POLICY_NAME policy already correct"
+fi
 
 echo ""
 echo "═══════════════════════════════════════════════"

--- a/teardown.sh
+++ b/teardown.sh
@@ -3,18 +3,32 @@
 set -uo pipefail
 
 # ATX Remote Infrastructure — Complete removal
-# Usage: ./teardown.sh
+# Usage: ./teardown.sh [--dry-run]
 #
-# Permanently destroys ALL ATX resources from your AWS account.
-# This is a total reset — nothing ATX-related is left behind.
-# Resilient: continues past individual failures and reports at the end.
+# Scans for ATX resources, shows what will be deleted, then asks for
+# confirmation before proceeding. Pass --dry-run to preview only.
+#
+# ════════════════════════════════════════════════════════════════════
+# SAFETY CONTRACT:
+# This script NEVER deletes:
+#   - VPCs, subnets, NAT gateways, internet gateways, route tables
+#   - S3 buckets (atx-source-code-*, atx-custom-output-*, atx-ct-output-*)
+#   - KMS key (alias/atx-encryption-key) — encrypts the preserved S3 buckets;
+#     deleting it makes bucket contents permanently unreadable
+# Those are customer-managed resources that persist independently of
+# the ATX stack lifecycle. S3 lifecycle policies auto-expire content.
+# ════════════════════════════════════════════════════════════════════
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
 NC='\033[0m'
 
 ERRORS=0
@@ -24,7 +38,7 @@ warn() { echo -e "  ${YELLOW}⚠${NC} $1"; ERRORS=$((ERRORS + 1)); }
 skip() { echo -e "  $1 — skipped (not found)"; }
 
 echo "═══════════════════════════════════════════════"
-echo " ATX Remote Infrastructure — Complete Teardown"
+echo " ATX Remote Infrastructure — Teardown"
 echo "═══════════════════════════════════════════════"
 echo ""
 
@@ -48,6 +62,183 @@ info "AWS Account: $ACCOUNT_ID | Region: $REGION"
 echo ""
 
 # ============================================================
+# Discovery: scan all resources before any destructive action
+# ============================================================
+echo "Scanning resources..."
+echo ""
+
+FOUND_STACKS=()
+FOUND_LOG_GROUPS=()
+FOUND_POLICIES=()
+FOUND_SECRETS=()
+FOUND_ECR_REPOS=()
+FOUND_CDK_BUCKET=""
+FOUND_CDK_STACK=""
+FOUND_LOCAL_FILES=()
+
+# -- CloudFormation stacks --
+for STACK_NAME in AtxInfrastructureStack AtxContainerStack; do
+  STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+    --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
+  if [ "$STACK_STATUS" != "NOT_FOUND" ]; then
+    FOUND_STACKS+=("$STACK_NAME ($STACK_STATUS)")
+  fi
+done
+
+
+# -- CloudWatch log groups --
+ALL_LOG_GROUPS=("/aws/batch/atx-transform" "/aws/batch/job")
+for FN in atx-trigger-job atx-get-job-status atx-terminate-job atx-list-jobs \
+           atx-trigger-batch-jobs atx-get-batch-status atx-terminate-batch-jobs \
+           atx-list-batches; do
+  ALL_LOG_GROUPS+=("/aws/lambda/${FN}")
+done
+for LG in "${ALL_LOG_GROUPS[@]}"; do
+  if aws logs describe-log-groups --log-group-name-prefix "$LG" --region "$REGION" \
+    --query "logGroups[?logGroupName=='$LG'].logGroupName" --output text 2>/dev/null | grep -q "$LG"; then
+    FOUND_LOG_GROUPS+=("$LG")
+  fi
+done
+
+# -- IAM policies --
+for POLICY_NAME in ATXRuntimePolicy ATXDeploymentPolicy ATXLocalPolicy; do
+  POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${POLICY_NAME}"
+  if aws iam get-policy --policy-arn "$POLICY_ARN" 2>/dev/null >/dev/null; then
+    FOUND_POLICIES+=("$POLICY_NAME")
+  fi
+done
+
+# -- Secrets Manager --
+for SECRET_ID in "atx/github-token" "atx/ssh-key" "atx/credentials"; do
+  if aws secretsmanager describe-secret --secret-id "$SECRET_ID" --region "$REGION" 2>/dev/null >/dev/null; then
+    FOUND_SECRETS+=("$SECRET_ID")
+  fi
+done
+
+# -- ECR repositories --
+for REPO in $(aws ecr describe-repositories --region "$REGION" \
+  --query 'repositories[?starts_with(repositoryName, `cdk-atxinfra-container-assets-`)].repositoryName' \
+  --output text 2>/dev/null || echo ""); do
+  [ "$REPO" = "None" ] && continue
+  [ -z "$REPO" ] && continue
+  FOUND_ECR_REPOS+=("$REPO")
+done
+
+# -- CDK bootstrap --
+CDK_BUCKET="cdk-atxinfra-assets-${ACCOUNT_ID}-${REGION}"
+if aws s3api head-bucket --bucket "$CDK_BUCKET" --region "$REGION" 2>/dev/null; then
+  FOUND_CDK_BUCKET="s3://$CDK_BUCKET"
+fi
+CDK_STACK_STATUS=$(aws cloudformation describe-stacks --stack-name CDKToolkit-atxinfra \
+  --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
+if [ "$CDK_STACK_STATUS" != "NOT_FOUND" ]; then
+  FOUND_CDK_STACK="CDKToolkit-atxinfra ($CDK_STACK_STATUS)"
+else
+  CDK_DEFAULT_STATUS=$(aws cloudformation describe-stacks --stack-name CDKToolkit \
+    --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
+  if [ "$CDK_DEFAULT_STATUS" != "NOT_FOUND" ]; then
+    HAS_OUR_QUALIFIER=$(aws cloudformation describe-stacks --stack-name CDKToolkit \
+      --region "$REGION" --query "Stacks[0].Parameters[?ParameterKey=='Qualifier'].ParameterValue" \
+      --output text 2>/dev/null || echo "")
+    if [ "$HAS_OUR_QUALIFIER" = "atxinfra" ]; then
+      FOUND_CDK_STACK="CDKToolkit ($CDK_DEFAULT_STATUS)"
+    fi
+  fi
+fi
+
+# -- Local generated files --
+for F in atx-runtime-policy.json atx-deployment-policy.json cdk.context.json; do
+  if [ -f "$SCRIPT_DIR/$F" ]; then
+    FOUND_LOCAL_FILES+=("$F")
+  fi
+done
+
+# ============================================================
+# Display preview
+# ============================================================
+echo "┌─────────────────────────────────────────────────────────┐"
+echo "│  Resources that WILL be deleted:                         │"
+echo "├─────────────────────────────────────────────────────────┤"
+
+if [ ${#FOUND_STACKS[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}CloudFormation stacks:${NC}"
+  for s in "${FOUND_STACKS[@]}"; do echo "│    • $s"; done
+fi
+
+
+if [ ${#FOUND_LOG_GROUPS[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}CloudWatch log groups:${NC}"
+  for lg in "${FOUND_LOG_GROUPS[@]}"; do echo "│    • $lg"; done
+fi
+
+if [ ${#FOUND_POLICIES[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}IAM policies:${NC}"
+  for p in "${FOUND_POLICIES[@]}"; do echo "│    • $p"; done
+fi
+
+if [ ${#FOUND_SECRETS[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}Secrets Manager secrets:${NC}"
+  for s in "${FOUND_SECRETS[@]}"; do echo "│    • $s"; done
+fi
+
+if [ ${#FOUND_ECR_REPOS[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}ECR repositories:${NC}"
+  for r in "${FOUND_ECR_REPOS[@]}"; do echo "│    • $r"; done
+fi
+
+if [ -n "$FOUND_CDK_BUCKET" ] || [ -n "$FOUND_CDK_STACK" ]; then
+  echo -e "│  ${CYAN}CDK bootstrap:${NC}"
+  [ -n "$FOUND_CDK_BUCKET" ] && echo "│    • $FOUND_CDK_BUCKET"
+  [ -n "$FOUND_CDK_STACK" ] && echo "│    • $FOUND_CDK_STACK"
+fi
+
+if [ ${#FOUND_LOCAL_FILES[@]} -gt 0 ]; then
+  echo -e "│  ${CYAN}Local generated files:${NC}"
+  for f in "${FOUND_LOCAL_FILES[@]}"; do echo "│    • $f"; done
+fi
+
+# Check if nothing was found
+TOTAL_FOUND=$(( ${#FOUND_STACKS[@]} + ${#FOUND_LOG_GROUPS[@]} + ${#FOUND_POLICIES[@]} + ${#FOUND_SECRETS[@]} + ${#FOUND_ECR_REPOS[@]} + ${#FOUND_LOCAL_FILES[@]} ))
+[ -n "$FOUND_CDK_BUCKET" ] && TOTAL_FOUND=$((TOTAL_FOUND + 1))
+[ -n "$FOUND_CDK_STACK" ] && TOTAL_FOUND=$((TOTAL_FOUND + 1))
+
+if [ "$TOTAL_FOUND" -eq 0 ]; then
+  echo "│  (none found — nothing to delete)"
+fi
+
+echo "├─────────────────────────────────────────────────────────┤"
+echo -e "│  ${GREEN}PRESERVED (never deleted):${NC}"
+echo "│    • VPCs, subnets, NAT gateways, route tables"
+echo "│    • S3: atx-source-code-*, atx-custom-output-*,"
+echo "│          atx-ct-output-*"
+echo "│    • KMS key (alias/atx-encryption-key) — encrypts S3 data"
+echo "└─────────────────────────────────────────────────────────┘"
+echo ""
+
+if [ "$TOTAL_FOUND" -eq 0 ]; then
+  echo "Nothing to tear down."
+  exit 0
+fi
+
+if $DRY_RUN; then
+  echo "(dry-run mode — no resources were deleted)"
+  exit 0
+fi
+
+# ============================================================
+# Confirmation gate
+# ============================================================
+read -p "Proceed with teardown? (yes/no): " CONFIRM
+if [ "$CONFIRM" != "yes" ]; then
+  echo "Aborted."
+  exit 0
+fi
+
+echo ""
+echo "Proceeding with teardown..."
+echo ""
+
+# ============================================================
 # Phase 1: Delete CloudFormation stacks
 # ============================================================
 echo "Phase 1: CloudFormation stacks..."
@@ -63,8 +254,6 @@ for STACK_NAME in AtxInfrastructureStack AtxContainerStack; do
 
   echo "  Deleting $STACK_NAME (status: $STACK_STATUS)..."
 
-  # ROLLBACK_COMPLETE can be deleted directly.
-  # DELETE_FAILED needs --retain-resources to force past stuck resources.
   if [[ "$STACK_STATUS" == "DELETE_FAILED" ]]; then
     RETAIN_IDS=$(aws cloudformation list-stack-resources --stack-name "$STACK_NAME" --region "$REGION" \
       --query 'StackResourceSummaries[?ResourceStatus!=`DELETE_COMPLETE`].LogicalResourceId' --output text 2>/dev/null || echo "")
@@ -88,126 +277,34 @@ for STACK_NAME in AtxInfrastructureStack AtxContainerStack; do
   fi
 done
 
+# NOTE: The stack uses imported VPC resources (existingVpcId). CFN stack
+# deletion does NOT cascade to VPC, subnet, NAT, or IGW resources.
+# NOTE: KMS key (alias/atx-encryption-key) is preserved — it encrypts the
+# S3 buckets that persist across teardown. Deleting it makes data unreadable.
+
 # ============================================================
-# Helper: Empty a versioned S3 bucket (deletes all objects,
-# versions, and delete markers)
+# Phase 2: CloudWatch log groups
 # ============================================================
-empty_versioned_bucket() {
-  local bucket="$1"
-  local region="$2"
+echo ""
+echo "Phase 2: CloudWatch log groups..."
 
-  # Delete current objects
-  aws s3 rm "s3://${bucket}" --recursive --region "$region" --quiet 2>/dev/null || true
-
-  # Delete all versions and delete markers in a loop
-  local key_marker="" version_marker=""
-  while true; do
-    local list_args=(--bucket "$bucket" --region "$region" --output json --max-keys 500)
-    [[ -n "$key_marker" ]] && list_args+=(--key-marker "$key_marker" --version-id-marker "$version_marker")
-
-    local response
-    response=$(aws s3api list-object-versions "${list_args[@]}" 2>/dev/null || echo '{}')
-
-    local payload
-    payload=$(echo "$response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-objects = []
-for v in data.get('Versions', []):
-    objects.append({'Key': v['Key'], 'VersionId': v['VersionId']})
-for d in data.get('DeleteMarkers', []):
-    objects.append({'Key': d['Key'], 'VersionId': d['VersionId']})
-if objects:
-    print(json.dumps({'Objects': objects[:1000], 'Quiet': True}))
-" 2>/dev/null || echo "")
-
-    if [[ -z "$payload" ]]; then
-      break
+if [ ${#FOUND_LOG_GROUPS[@]} -gt 0 ]; then
+  for LG in "${FOUND_LOG_GROUPS[@]}"; do
+    if aws logs delete-log-group --log-group-name "$LG" --region "$REGION" 2>/dev/null; then
+      info "Log group $LG deleted"
+    else
+      warn "Could not delete $LG"
     fi
-
-    aws s3api delete-objects --bucket "$bucket" --region "$region" \
-      --delete "$payload" 2>/dev/null || true
-
-    # Check if there are more versions to process
-    local is_truncated
-    is_truncated=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('IsTruncated', False))" 2>/dev/null || echo "False")
-    if [[ "$is_truncated" != "True" ]]; then
-      break
-    fi
-
-    key_marker=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('NextKeyMarker',''))" 2>/dev/null || echo "")
-    version_marker=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('NextVersionIdMarker',''))" 2>/dev/null || echo "")
   done
-}
-
-# ============================================================
-# Phase 2: S3 buckets (RETAIN policy — not deleted by CFN)
-# ============================================================
-echo ""
-echo "Phase 2: S3 buckets..."
-
-for BUCKET in "atx-source-code-${ACCOUNT_ID}" "atx-custom-output-${ACCOUNT_ID}" "atx-ct-output-${ACCOUNT_ID}" "atx-logs-${ACCOUNT_ID}"; do
-  if ! aws s3api head-bucket --bucket "$BUCKET" --region "$REGION" 2>/dev/null; then
-    skip "s3://${BUCKET}"
-    continue
-  fi
-
-  echo "  Emptying s3://${BUCKET}..."
-  empty_versioned_bucket "$BUCKET" "$REGION"
-
-  if aws s3api delete-bucket --bucket "$BUCKET" --region "$REGION" 2>&1; then
-    info "s3://${BUCKET} deleted"
-  else
-    warn "Could not delete s3://${BUCKET} (see error above)"
-  fi
-done
-
-# ============================================================
-# Phase 3: KMS key (RETAIN policy — not deleted by CFN)
-# ============================================================
-echo ""
-echo "Phase 3: KMS key..."
-
-KMS_KEY_ID=$(aws kms describe-key --key-id "alias/atx-encryption-key" --region "$REGION" \
-  --query 'KeyMetadata.KeyId' --output text 2>/dev/null || echo "")
-if [ -n "$KMS_KEY_ID" ] && [ "$KMS_KEY_ID" != "None" ]; then
-  aws kms delete-alias --alias-name "alias/atx-encryption-key" --region "$REGION" 2>/dev/null || true
-  if aws kms schedule-key-deletion --key-id "$KMS_KEY_ID" --pending-window-in-days 7 --region "$REGION" 2>/dev/null; then
-    info "KMS key scheduled for deletion in 7 days (ID: $KMS_KEY_ID)"
-  else
-    warn "Could not schedule KMS key deletion — may already be pending"
-  fi
 else
-  skip "KMS key alias/atx-encryption-key"
+  skip "No ATX log groups found"
 fi
 
 # ============================================================
-# Phase 4: CloudWatch log groups
+# Phase 3: IAM policies
 # ============================================================
 echo ""
-echo "Phase 4: CloudWatch log groups..."
-
-ALL_LOG_GROUPS=("/aws/batch/atx-transform" "/aws/batch/job")
-for FN in atx-trigger-job atx-get-job-status atx-terminate-job atx-list-jobs \
-           atx-trigger-batch-jobs atx-get-batch-status atx-terminate-batch-jobs \
-           atx-list-batches; do
-  ALL_LOG_GROUPS+=("/aws/lambda/${FN}")
-done
-
-LOGS_FOUND=false
-for LG in "${ALL_LOG_GROUPS[@]}"; do
-  if aws logs delete-log-group --log-group-name "$LG" --region "$REGION" 2>/dev/null; then
-    info "Log group $LG deleted"
-    LOGS_FOUND=true
-  fi
-done
-$LOGS_FOUND || skip "No ATX log groups found"
-
-# ============================================================
-# Phase 5: IAM policies
-# ============================================================
-echo ""
-echo "Phase 5: IAM policies..."
+echo "Phase 3: IAM policies..."
 
 for POLICY_NAME in ATXRuntimePolicy ATXDeploymentPolicy ATXLocalPolicy; do
   POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/${POLICY_NAME}"
@@ -258,10 +355,10 @@ elif echo "$CALLER_ARN" | grep -Eq ":assumed-role/|:role/"; then
 fi
 
 # ============================================================
-# Phase 6: Secrets Manager secrets
+# Phase 4: Secrets Manager secrets
 # ============================================================
 echo ""
-echo "Phase 6: Secrets Manager secrets..."
+echo "Phase 4: Secrets Manager secrets..."
 
 for SECRET_ID in "atx/github-token" "atx/ssh-key" "atx/credentials"; do
   if aws secretsmanager describe-secret --secret-id "$SECRET_ID" --region "$REGION" 2>/dev/null >/dev/null; then
@@ -275,34 +372,64 @@ for SECRET_ID in "atx/github-token" "atx/ssh-key" "atx/credentials"; do
 done
 
 # ============================================================
-# Phase 7: ECR repositories
+# Phase 5: ECR repositories
 # ============================================================
 echo ""
-echo "Phase 7: ECR repositories..."
+echo "Phase 5: ECR repositories..."
 
-# CDK asset repos follow the pattern: cdk-{qualifier}-container-assets-{account}-{region}
-ECR_FOUND=false
-for REPO in $(aws ecr describe-repositories --region "$REGION" \
-  --query 'repositories[?starts_with(repositoryName, `cdk-atxinfra-container-assets-`)].repositoryName' \
-  --output text 2>/dev/null || echo ""); do
-  [ "$REPO" = "None" ] && continue
-  [ -z "$REPO" ] && continue
-  ECR_FOUND=true
-  aws ecr delete-repository --repository-name "$REPO" --region "$REGION" --force 2>/dev/null \
-    && info "ECR repo $REPO deleted" \
-    || warn "Could not delete ECR repo $REPO"
-done
-$ECR_FOUND || skip "No ATX ECR repositories found"
+if [ ${#FOUND_ECR_REPOS[@]} -gt 0 ]; then
+  for REPO in "${FOUND_ECR_REPOS[@]}"; do
+    aws ecr delete-repository --repository-name "$REPO" --region "$REGION" --force 2>/dev/null \
+      && info "ECR repo $REPO deleted" \
+      || warn "Could not delete ECR repo $REPO"
+  done
+else
+  skip "No ATX ECR repositories found"
+fi
 
 # ============================================================
-# Phase 8: CDK bootstrap (our custom qualifier)
+# Helper: Empty a versioned S3 bucket (used by CDK bootstrap cleanup only)
+# ============================================================
+empty_versioned_bucket() {
+  local bucket="$1"
+  local region="$2"
+  aws s3 rm "s3://${bucket}" --recursive --region "$region" --quiet 2>/dev/null || true
+  local key_marker="" version_marker=""
+  while true; do
+    local list_args=(--bucket "$bucket" --region "$region" --output json --max-keys 500)
+    [[ -n "$key_marker" ]] && list_args+=(--key-marker "$key_marker" --version-id-marker "$version_marker")
+    local response
+    response=$(aws s3api list-object-versions "${list_args[@]}" 2>/dev/null || echo '{}')
+    local payload
+    payload=$(echo "$response" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+objects = []
+for v in data.get('Versions', []):
+    objects.append({'Key': v['Key'], 'VersionId': v['VersionId']})
+for d in data.get('DeleteMarkers', []):
+    objects.append({'Key': d['Key'], 'VersionId': d['VersionId']})
+if objects:
+    print(json.dumps({'Objects': objects[:1000], 'Quiet': True}))
+" 2>/dev/null || echo "")
+    if [[ -z "$payload" ]]; then break; fi
+    aws s3api delete-objects --bucket "$bucket" --region "$region" --delete "$payload" 2>/dev/null || true
+    local is_truncated
+    is_truncated=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('IsTruncated', False))" 2>/dev/null || echo "False")
+    if [[ "$is_truncated" != "True" ]]; then break; fi
+    key_marker=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('NextKeyMarker',''))" 2>/dev/null || echo "")
+    version_marker=$(echo "$response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('NextVersionIdMarker',''))" 2>/dev/null || echo "")
+  done
+}
+
+# ============================================================
+# Phase 6: CDK bootstrap (our custom qualifier)
 # ============================================================
 echo ""
-echo "Phase 8: CDK bootstrap resources..."
+echo "Phase 6: CDK bootstrap resources..."
 
-CDK_BUCKET="cdk-atxinfra-assets-${ACCOUNT_ID}-${REGION}"
-if aws s3api head-bucket --bucket "$CDK_BUCKET" --region "$REGION" 2>/dev/null; then
-  echo "  Emptying and deleting s3://${CDK_BUCKET}..."
+if [ -n "$FOUND_CDK_BUCKET" ]; then
+  echo "  Emptying and deleting $FOUND_CDK_BUCKET..."
   empty_versioned_bucket "$CDK_BUCKET" "$REGION"
   if aws s3api delete-bucket --bucket "$CDK_BUCKET" --region "$REGION" 2>&1; then
     info "CDK bootstrap bucket deleted"
@@ -313,53 +440,31 @@ else
   skip "CDK bootstrap bucket ($CDK_BUCKET)"
 fi
 
-# Delete the CDK bootstrap stack (uses our custom qualifier)
-CDK_STACK_STATUS=$(aws cloudformation describe-stacks --stack-name CDKToolkit-atxinfra \
-  --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
-if [ "$CDK_STACK_STATUS" != "NOT_FOUND" ]; then
-  echo "  Deleting CDKToolkit-atxinfra stack..."
-  aws cloudformation delete-stack --stack-name CDKToolkit-atxinfra --region "$REGION" 2>/dev/null || true
-  aws cloudformation wait stack-delete-complete --stack-name CDKToolkit-atxinfra --region "$REGION" 2>/dev/null \
+if [ -n "$FOUND_CDK_STACK" ]; then
+  CDK_STACK_TO_DELETE=$(echo "$FOUND_CDK_STACK" | cut -d' ' -f1)
+  echo "  Deleting $CDK_STACK_TO_DELETE stack..."
+  aws cloudformation delete-stack --stack-name "$CDK_STACK_TO_DELETE" --region "$REGION" 2>/dev/null || true
+  aws cloudformation wait stack-delete-complete --stack-name "$CDK_STACK_TO_DELETE" --region "$REGION" 2>/dev/null \
     && info "CDK bootstrap stack deleted" \
     || warn "Could not delete CDK bootstrap stack"
 else
-  # Try default name too (CDKToolkit) — but only if it has our qualifier
-  CDK_DEFAULT_STATUS=$(aws cloudformation describe-stacks --stack-name CDKToolkit \
-    --region "$REGION" --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
-  if [ "$CDK_DEFAULT_STATUS" != "NOT_FOUND" ]; then
-    # Check if this bootstrap uses our qualifier
-    HAS_OUR_QUALIFIER=$(aws cloudformation describe-stacks --stack-name CDKToolkit \
-      --region "$REGION" --query "Stacks[0].Parameters[?ParameterKey=='Qualifier'].ParameterValue" \
-      --output text 2>/dev/null || echo "")
-    if [ "$HAS_OUR_QUALIFIER" = "atxinfra" ]; then
-      echo "  Deleting CDKToolkit stack (qualifier: atxinfra)..."
-      aws cloudformation delete-stack --stack-name CDKToolkit --region "$REGION" 2>/dev/null || true
-      aws cloudformation wait stack-delete-complete --stack-name CDKToolkit --region "$REGION" 2>/dev/null \
-        && info "CDK bootstrap stack deleted" \
-        || warn "Could not delete CDK bootstrap stack"
-    else
-      skip "CDKToolkit stack (different qualifier: ${HAS_OUR_QUALIFIER:-default})"
-    fi
-  else
-    skip "CDK bootstrap stack"
-  fi
+  skip "CDK bootstrap stack"
 fi
 
 # ============================================================
-# Phase 9: Local generated files
+# Phase 7: Local generated files
 # ============================================================
 echo ""
-echo "Phase 9: Local generated files..."
+echo "Phase 7: Local generated files..."
 
-LOCAL_FOUND=false
-for F in atx-runtime-policy.json atx-deployment-policy.json cdk.context.json; do
-  if [ -f "$SCRIPT_DIR/$F" ]; then
+if [ ${#FOUND_LOCAL_FILES[@]} -gt 0 ]; then
+  for F in "${FOUND_LOCAL_FILES[@]}"; do
     rm -f "$SCRIPT_DIR/$F"
     info "Removed $F"
-    LOCAL_FOUND=true
-  fi
-done
-$LOCAL_FOUND || skip "No generated files found"
+  done
+else
+  skip "No generated files found"
+fi
 
 # ============================================================
 # Done
@@ -373,11 +478,13 @@ if [ "$ERRORS" -gt 0 ]; then
   echo "Some resources may not have been fully cleaned up."
   echo "Check the warnings above and retry if needed."
 else
-  echo -e " ${GREEN}Complete teardown finished!${NC}"
+  echo -e " ${GREEN}Teardown finished!${NC}"
   echo "═══════════════════════════════════════════════"
   echo ""
-  echo "All ATX resources have been removed from your account."
+  echo "ATX compute and IAM resources have been removed from your account."
 fi
 echo ""
-echo "Note: KMS key deletion is scheduled (7-day AWS minimum)."
-echo "To cancel: aws kms cancel-key-deletion --key-id <key-id> --region $REGION"
+echo "Preserved (not deleted by teardown):"
+echo "  - S3 buckets (lifecycle policies auto-expire: 7-day source, 30-day output)"
+echo "  - KMS key (alias/atx-encryption-key) — encrypts the preserved S3 data"
+echo "  - VPC/subnet/NAT/IGW (customer-managed network resources)"


### PR DESCRIPTION
    Fix setup/teardown reliability and add scheduling support

    Setup fixes:
    - Fix cdk.json path reference (was './npx cdk.json', now './cdk.json')
    - Remove package.json bin field that shadowed npx cdk with the app entry point
    - Accept UPDATE_ROLLBACK_COMPLETE as valid stack status in verification
    - Add idempotent AtxSchedulerInvocationRole provisioning with
      lambda:InvokeFunction on atx-trigger-batch-jobs (handles pre-existing
      roles created by the scheduling skill)

    CDK changes:
    - Add existingCtOutputBucket context parameter for importing existing
      CT output buckets
    - Remove scheduler role/schedule group from CDK (moved to setup.sh to
      avoid conflicts with pre-existing resources)

    Teardown rewrite:
    - Preview all resources before deletion with confirmation prompt
    - Add --dry-run flag for safe inspection
    - Preserve S3 buckets, KMS key, and VPC/network resources across teardown
      (lifecycle policies handle expiration; KMS deletion makes data unreadable)
    - Reorganize phases and use discovery-first approach

    New:
    - create-vpc.sh: utility to create a Fargate-ready VPC with private
      subnets, NAT gateway, and security group for testing
    - Remove cdk.context.json (CDK-generated cache, not needed in repo)