### PR TITLE
feat: add kubernetes-readiness-migration community transformation

### DIFF
--- a/community-sourced-transformations/kubernetes-readiness-migration/README.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/README.md
@@ -1,0 +1,396 @@
+# Kubernetes Readiness Analysis and Migration Skill
+
+Automated two-phase transformation that assesses any codebase for Kubernetes readiness and then transforms it for full containerised deployment — generating Kubernetes manifests, resolving 12-factor blockers, and producing microservice decomposition plans.
+
+**Supports Go · Java/Maven/Gradle · Node.js · PHP · Python · Ruby/Rails · C#/.NET · and more**
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Problem](#the-problem)
+- [What This Skill Does](#what-this-skill-does)
+- [Skill Architecture](#skill-architecture)
+- [Supported Languages & Frameworks](#supported-languages--frameworks)
+- [Patterns Handled](#patterns-handled)
+- [Edge Cases](#edge-cases)
+- [Getting Started](#getting-started)
+- [Getting Started with AWS Transform Custom](#getting-started-with-aws-transform-custom)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+
+## Overview
+
+Assess and transform applications for containerised Kubernetes deployment in two phases. Phase 1 produces a comprehensive readiness report scored across 21 areas — covering all 12-factor app principles, Kubernetes compatibility, singleton risks, monolith decomposition, and security — including both Minimal and Full decomposition recommendations. Phase 2 consumes that report and systematically resolves every finding: externalising config and secrets, migrating persistent storage, redirecting logging, generating Kubernetes manifests, and validating via a three-tier pipeline (docker build → kubeconform → optional cluster validation).
+
+## The Problem
+
+Organisations migrating applications to Kubernetes face:
+
+- **Hidden blockers**: Hardcoded config, local filesystem writes, and in-memory state are just some of the challenges faced when migrating to Kubernetes 
+- **Monolith complexity**: No clear decomposition plan for which services to extract first and in what order
+- **Secret sprawl**: Credentials embedded in config files, docker-compose overrides, and connection strings
+- **Scaling failures**: Session state, singleton schedulers, rate limiters, and file-coordination code break under horizontal scaling
+- **Slow feedback cycles**: Issues discovered at deploy time rather than before a line of manifest is written
+- **Manual effort**: Kubernetes manifest generation, security hardening, and infrastructure documentation typically take days per application
+
+## What This Skill Does
+
+Given any application codebase, this skill:
+
+**Phase 1 — Readiness Analysis**
+1. Evaluates the codebase against all 12 factors of the 12-factor app methodology
+2. Identifies containerisation blockers, warnings, and informational findings across 21 analysis areas
+3. Detects singleton patterns that break horizontal scaling (schedulers, rate limiters, caches, WebSocket state)
+4. Audits all credentials, API keys, secrets, and connection strings
+5. Maps local filesystem usage and recommends object store or shared volume replacements
+6. Produces a Named Service Inventory with Decomposition Complexity ratings and both Minimal and Full Decomposition Recommendations for monolith decomposition
+7. Identifies startup order dependencies and in-memory state sharing between microservice candidates
+8. Outputs a single consolidated report (HTML or Markdown) with visual scorecard, severity badges, and structured finding tables
+
+**Phase 2 — Containerisation Transformation**
+1. Resolves every Phase 1 blocker and warning with code changes
+2. Externalises all hardcoded config to environment variables; generates ENV_VARIABLES.md
+3. Migrates persistent storage to object store (S3/GCS/Azure Blob) or Kubernetes shared volumes
+4. Redirects all file-based logging to stdout/stderr
+5. Externalises sessions for horizontal scaling (only where not already DB-backed)
+6. Extracts scheduled tasks to Kubernetes CronJob manifests
+7. Generates Kubernetes manifests for the Minimal Execution Set (Namespace, Deployment, Service, ConfigMap, Secret, NetworkPolicy)
+8. Hardens containers: non-root user, read-only root filesystem, dropped capabilities, resource limits, probes
+9. Configures IRSA for AWS credential access; removes all hardcoded credentials
+10. Validates via docker build, kubeconform strict mode, and optional Minikube deployment
+11. Produces TRANSFORMATION_SUMMARY.md and INFRASTRUCTURE_REQUIREMENTS.md
+
+## Skill Architecture
+
+The skill runs as a two-phase sequential pipeline with on-demand reference dispatch. Before any analysis begins, the skill conducts an **Initial Entry Interview** (§0) to gather user preferences in two blocks:
+
+- **Block A** (always asked): phase selection (Phase 1 only, or Phase 1 + 2), report output path, report format (Markdown or HTML), and detail level (full 21-area scorecard or executive summary).
+- **Block B** (Phase 2 only): decomposition scope (`minimal` or `full`) and validation tooling (auto-detected, then confirmed).
+
+In non-interactive / CI mode, defaults are applied automatically: Phase 1+2, Markdown, full detail, minimal scope, KWOK attempted if available.
+
+```
+Phase 1: Readiness Analysis
+  ├── §0 Initial Entry Interview (Block A)
+  ├── 12-factor evaluation (all 12 factors)
+  ├── Kubernetes compatibility checks
+  ├── Singleton & scaling risk analysis
+  ├── Credential & secrets audit
+  ├── Monolith decomposition assessment
+  │     └── Named Service Inventory + Complexity ratings
+  │         ├── Minimal Decomposition Recommendation
+  │         └── Full Decomposition Recommendation
+  └── Output: consolidated readiness report (HTML or Markdown)
+        Visual scorecard (21 areas) · Severity badges · Finding tables
+
+Phase 2: Containerisation Transformation
+  ├── §0 Initial Entry Interview (Block B, if not already completed)
+  ├── §1  Initial Setup — parse report, gather user preferences
+  ├── §2  Decomposition Assessment — ingest Named Service Inventory,
+  │         apply execution scope (minimal or full)
+  ├── §3  Configuration Externalisation
+  ├── §4  Session & Cache Externalisation
+  ├── §5  Logging Transformation → stdout/stderr
+  ├── §6  Filesystem → Object Store Migration
+  ├── §7  Credentials & Secrets (IRSA, Kubernetes Secrets)
+  ├── §8  Backing Services (replace hardcoded addresses)
+  ├── §9  Scheduled Tasks → CronJob manifests
+  ├── §10 Concurrency & Scaling
+  ├── §11 Build/Release/Run separation
+  ├── §12 Disposability & Startup Resilience (probes, terminationGracePeriodSeconds)
+  ├── §13 Security Hardening (non-root, readOnlyRootFilesystem, capabilities)
+  ├── §14 Database Connection Optimisation
+  ├── §15 Kubernetes Manifest Generation (execution scope)
+  ├── §16 Infrastructure Requirements Document
+  ├── §17 Dockerfile Update (multi-stage, non-root)
+  ├── §17b Docker Build Verification (Tier 1)
+  ├── §18 kubeconform Validation (Tier 2) + optional cluster Tier 3
+  └── §19 Final Review — TRANSFORMATION_SUMMARY.md + Decomposition Roadmap
+```
+
+### Minimal Execution Set
+
+Phase 2 generates manifests only for the **primary Deployment + required supporting resources** — not every decomposition candidate. The full roadmap is documented but not generated, keeping the output focused and deployable from day one.
+
+| Resource | Always Generated |
+|---|---|
+| Namespace | ✅ |
+| Primary Deployment + Service | ✅ |
+| ConfigMap + Secret | ✅ |
+| NetworkPolicy | ✅ |
+| Required Job / CronJob | Conditional |
+| Secondary microservice Deployments | Roadmap only |
+
+### Key Design Decisions
+
+1. **Phase 1 before Phase 2.** The readiness report drives transformation scope. If Phase 1 output is unavailable (automated pipelines), Phase 2 derives blocker context directly from source files using the same analysis patterns.
+
+2. **Minimal Execution Set.** Only the primary workload and its required dependencies are generated as manifests. Additional decomposition candidates go into the roadmap — preventing manifest sprawl and keeping Tier 1/2/3 validation tractable.
+
+3. **Three-tier validation.** Docker build (Tier 1) → kubeconform strict mode (Tier 2) → optional Minikube (Tier 3). Tier 2 never runs until Tier 1 passes. Tier 3 is opt-in.
+
+4. **No-defer rule for blockers.** Runtime startup blockers (e.g., root-privileged entrypoint ops after `USER nonroot`, `.bak` files, stale manifest references) are fixed in the same task scope they are discovered — never deferred.
+
+5. **Source-authoritative env vars.** Before finalising ConfigMap/Secret keys, actual source files are grepped for env var read patterns (`os.environ`, `process.env`, `@Value`, `viper.Get`, etc.). Task-spec variable names are indicative only — source code is authoritative.
+
+6. **Session verification gate.** Before adding Redis for session externalisation, the skill checks for DB-backed session patterns (Django `backends.db`, Rails `ActiveRecord::SessionStore`). DB-backed sessions do NOT get Redis.
+
+## Supported Languages & Frameworks
+
+| Language | Frameworks / Tooling |
+|---|---|
+| Go | Standard library, Fiber, Viper, gRPC |
+| Java | Spring Boot, Maven, Gradle, Quartz, Spring Batch, Hibernate, Liquibase |
+| Node.js | Express, NestJS, Next.js, Apollo Federation, Bull/BullMQ, node-cron, Socket.io |
+| PHP | Laravel, PHP-FPM, Composer, supervisord |
+| Python | Django, Flask, FastAPI, Celery, APScheduler, gunicorn, uvicorn, pydantic-settings |
+| Ruby | Rails, Puma, Sidekiq, Sidekiq-Cron, ActionCable, ActionMailer, ActiveStorage |
+| C#/.NET | ASP.NET Core, Entity Framework Core, SignalR, Kestrel |
+
+## Patterns Handled
+
+| Pattern | Transformation |
+|---|---|
+| Hardcoded IP/hostname/port | Replaced with env var reads; documented in ENV_VARIABLES.md |
+| Hardcoded credentials in source | Removed; sourced from Kubernetes Secret + IRSA |
+| docker-compose secret literals | Audited via Forms A–F; replaced with Secret refs |
+| Connection URL with embedded creds | Externalised; URL reconstructed from env vars |
+| Local filesystem writes (logs, uploads) | Redirected to stdout/stderr or migrated to object store (S3/GCS/Azure Blob) |
+| File-based sessions | Externalised to Redis or left as-is if already DB-backed |
+| In-process Quartz / APScheduler / cron / Laravel Kernel / node-cron | Extracted to Kubernetes CronJob manifests |
+| Singleton rate limiters, sequence generators | Replaced with distributed alternatives |
+| WebSocket state (in-memory) | Documented as scaling prerequisite; Redis backplane for Socket.io/ActionCable |
+| WAR/EAR packaging (Java) | Converted to executable JAR / multi-stage Docker build |
+| root-privileged entrypoint ops | Moved to build-time RUN or init-container; UID explicitly set |
+| Dynamic UID (`useradd -r`) | Replaced with explicit `--uid 1000` to match `runAsUser` |
+| readOnlyRootFilesystem violations | Writable paths audited; emptyDir mounts added for required runtime write paths |
+| PVC with ReadWriteMany | `storageClassName: "replace-with-rwm-class"` placeholder added |
+| HPA with local PVCs | `minReplicas: 1` with MIGRATION comment listing prerequisites |
+| @PostConstruct + @Transactional (Spring) | Replaced with `@EventListener(ApplicationReadyEvent.class)` |
+| Multi-module monolith | Named Service Inventory produced; extraction order and complexity rated |
+| Startup order coupling | Documented; readiness/liveness probes + retry logic added |
+
+## Edge Cases
+
+| Scenario | How It's Handled |
+|---|---|
+| Phase 1 report unavailable (automated pipeline) | Phase 2 derives blocker context directly from source files |
+| DB-backed sessions (Django, Rails ActiveRecord) | Redis NOT added; sessions already scalable |
+| Quartz scheduler with `auto-startup=false` | CronJob NOT generated; treated as empty scheduler |
+| Distroless base images | All probes omitted; `activeDeadlineSeconds` used instead |
+| Official DB images (Postgres, MySQL) | `runAsUser: 0`, capabilities preserved, `readOnlyRootFilesystem: false` |
+| nginx:alpine base image | `runAsUser: 101`, `runAsGroup: 101` |
+| PHP-FPM / PHP-Apache (Debian) | `runAsUser: 33`, `runAsGroup: 33` |
+| Spring XML + `@PropertySource` hybrid | `PropertiesFactoryBean` action protocol applied |
+| Gunicorn `--graceful-timeout` | `terminationGracePeriodSeconds = graceful-timeout + 5` |
+| Spring `timeout-per-shutdown-phase=25s` | `terminationGracePeriodSeconds = 30` |
+| `$(VAR)` in command/args | Uses shell form for envFrom-sourced vars; direct env: list for same-container vars |
+| NEXT_PUBLIC_* vars | Excluded from ConfigMap (build-time baked values, not runtime-injectable) |
+| Multi-module Maven build | `Dockerfile` COPY uses correct build context; two-COPY Gradle wrapper pattern |
+| Windows-only runtimes (.NET Framework, IIS, COM+) | Phase 1 Blocker flagged; Linux-compatible migration required before containerisation |
+
+## Benchmark Results
+
+### Full Manual Testing and Kubernetes Deployment
+
+The following real-world open source applications have been fully transformed and validated through all three tiers — docker build, kubeconform, and local Kubernetes deployment:
+
+| Application | Language / Stack | Description | Execution Time |
+|---|---|---|---|
+| [Bookstack](https://github.com/BookStackApp/BookStack) | PHP / Laravel | Documentation and wiki platform | 17m 31s |
+| [OpenMRS Core](https://github.com/openmrs/openmrs-core) | Java / Spring | Open source electronic medical records system | 13m 24s |
+| [Trac](https://trac.edgewall.org/) | Python | Project management and bug tracking tool | 11m 35s |
+| [Shopizer](https://github.com/shopizer-ecommerce/shopizer) | Java / Spring Boot | E-commerce platform | 14m 40s |
+| [OpenCart](https://github.com/opencart/opencart) | PHP | Open source online store management system | 15m 46s |
+
+Each of these projects was taken from a non-containerised state through Phase 1 readiness analysis, full Phase 2 transformation, and confirmed running on a local Kubernetes cluster with all health probes passing.
+
+### Automated Testing
+
+In addition to the full end-to-end benchmarks above, the skill has been tested against a broad range of open source projects across the supported language ecosystem to validate readiness analysis accuracy, 12-factor coverage, credential detection, manifest generation, and kubeconform compliance:
+
+| Language | Status |
+|---|---|
+| Java | ✅ Tested |
+| Ruby | ✅ Tested |
+| PHP | ✅ Tested |
+| Python | ✅ Tested |
+| Go | ✅ Tested |
+| Node.js | ✅ Tested |
+
+## Getting Started
+
+### Prerequisites
+
+| Tool | Version | Purpose |
+|---|---|---|
+| AWS Transform CLI (atx) | Latest | Execute the skill |
+| Docker | 20.10+ | Tier 1 build validation |
+| kubeconform | 0.6+ | Tier 2 manifest validation |
+| Minikube (optional) | 1.30+ | Tier 3 local deployment validation |
+| kubectl | 1.26+ | Apply and verify manifests |
+
+> **Note:** Docker, kubeconform, and any local Kubernetes tool (Minikube, Docker Desktop with Kubernetes enabled, or k3s/k3d) must be installed on the machine where the skill runs for the corresponding validation tiers to execute. If these tools are not present, the skill will skip those tiers and report them as unavailable. Installing them beforehand is recommended — Tier 3 in particular provides the most complete validation and is worth the setup cost.
+
+### Getting Started with AWS Transform Custom
+
+To set up the AWS Transform CLI, configure authentication, and run your first transformation, see the [AWS Transform Custom Getting Started Guide](https://docs.aws.amazon.com/transform/latest/userguide/custom-get-started.html).
+
+### Cloning the Repo and Publishing the Transformation
+
+```bash
+git clone https://github.com/aws-samples/aws-transform-custom-samples
+cd community-sourced-transformations
+
+atx custom def publish -n kubernetes-readiness-migration \
+    --sd kubernetes-readiness-migration \
+    --description "Two-phase Kubernetes containerisation skill: assesses any codebase against 12-factor and Kubernetes requirements, then transforms it"
+```
+
+### Running the Transformation
+
+```bash
+atx custom def exec \
+  -n kubernetes-readiness-migration \
+  -p ./my-application \
+    -t
+```
+
+### Validating the Output
+
+The skill runs a three-tier validation pipeline internally. You can also run each tier manually:
+
+```bash
+# Tier 1: Docker build — one Dockerfile per workload in the Minimal Execution Set.
+# Workload list is in TRANSFORMATION_SUMMARY.md under "Manifest Inventory".
+docker build -f Dockerfile -t <primary-service>:<tag> .
+docker build -f <worker-service>/Dockerfile -t <worker-service>:<tag> <worker-service>/
+
+# Tier 2: Manifest validation (all manifests in one pass)
+kubeconform -strict -summary kubernetes/
+
+# Tier 3: Minikube (optional — requires Tier 1 and Tier 2 to pass first)
+minikube start
+kubectl apply -f kubernetes/
+kubectl get pods -w
+kubectl logs deployment/<primary-service>
+```
+
+#### Local Kubernetes validation
+
+Running local Kubernetes validation at the end of the transformation is strongly recommended. Tier 1 (docker build) and Tier 2 (kubeconform) are static checks — they cannot catch probe misconfiguration, missing env vars at runtime, image pull failures, or networking issues between pods. A local cluster exercises the full deployment end-to-end and is the only tier that confirms the application actually starts and responds correctly.
+
+The skill uses Minikube by default for Tier 3, but any of the following work equally well:
+
+| Tool | Notes |
+|---|---|
+| **Minikube** | Default. Good general-purpose local cluster with broad platform support. |
+| **Docker Desktop** | Enable Kubernetes in Docker Desktop settings — zero extra install if you're already using it. Single-node cluster, simplest setup on Mac and Windows. |
+| **k3s / k3d** | Lightweight Kubernetes; k3d wraps k3s in Docker for fast startup. The skill includes a k3s fallback procedure in `references/docker-build-validation.md` for resource-constrained environments. |
+
+When Tier 3 is selected during the transformation, the skill deploys to the local cluster, monitors pod startup, tails logs for errors, and iterates on any failures before declaring success. You can also trigger it after the fact by re-running the skill and confirming local validation when prompted, or by applying the manifests manually with `kubectl apply -f kubernetes/`.
+
+### Requesting Further Decomposition
+
+By default the skill generates manifests for the **Minimal Execution Set** — the primary Deployment plus any required supporting workloads — and documents the remaining microservice candidates in a decomposition roadmap in `TRANSFORMATION_SUMMARY.md`.
+
+If you want to go further and extract additional services from the roadmap, tell the skill which candidates to promote:
+
+> "Extract the `OrderService` and `NotificationWorker` from the roadmap and generate full Kubernetes manifests for each."
+
+The skill will re-run Phase 2 §2 (Decomposition Assessment) for those candidates, apply the Minimal Execution Set rules to each, generate Deployments, Services, ConfigMaps, Secrets, and NetworkPolicies, and update `INFRASTRUCTURE_REQUIREMENTS.md` and `TRANSFORMATION_SUMMARY.md` accordingly. Each extracted service goes through the same three-tier validation as the primary workload.
+
+### Expected Output
+
+```
+kubernetes/
+  namespace.yaml
+  deployment.yaml
+  service.yaml
+  configmap.yaml
+  secret.yaml
+  networkpolicy.yaml
+  cronjob-<name>.yaml      # if scheduled tasks present
+  ingress.yaml             # if browser-facing
+
+ENV_VARIABLES.md           # all env vars with K8s scope, source, and classification
+INFRASTRUCTURE_REQUIREMENTS.md   # databases, Redis, S3, IAM, networking to provision
+TRANSFORMATION_SUMMARY.md        # executive summary, manifest inventory, per-finding changes
+```
+
+## Documentation & References
+
+### Skill Definition
+
+| File | Description |
+|---|---|
+| [SKILL.md](SKILL.md) | Complete skill definition — objective, scope, 20-phase transformation workflow, validation criteria, reference dispatch table, and exit criteria |
+
+### Reference Documents
+
+These are loaded on-demand by the agent when specific patterns are encountered:
+
+| Reference | Trigger | Description |
+|---|---|---|
+| [skill-a-readiness-analysis.md](references/skill-a-readiness-analysis.md) | Phase 1 work | Full 101-step readiness analysis procedure, scoring rules, report formatting |
+| [skill-b-containerisation-transformation.md](references/skill-b-containerisation-transformation.md) | Phase 2 work | Full 20-sub-phase transformation procedure, per-task hygiene gates, 8-point closure gate |
+| [docker-build-validation.md](references/docker-build-validation.md) | §17b Docker build validation | Three-tier validation, smoke-test commands, common failure patterns, KWOK fallback |
+| [minimal-execution-set.md](references/minimal-execution-set.md) | §2 decomposition and §15 manifest generation | Resource classification table defining execution vs reporting scope |
+| [microservice-decomposition-patterns.md](references/microservice-decomposition-patterns.md) | Phase 1 decomposition; ≥2 service candidates | Named Service Inventory, Complexity Rubric, Data Ownership Matrix, extraction heuristics |
+| [validation-patterns.md](references/validation-patterns.md) | Post-batch and post-migration sweeps | YAML structural checks, banned-phrase sweeps, ENV_VARIABLES.md audit, Secret validation |
+| [credential-audit-patterns.md](references/credential-audit-patterns.md) | §7 credentials; docker-compose\*.yml present | Forms A–F credential audit, IRSA config, Secret classification, URL-embedded creds |
+| [go-patterns.md](references/go-patterns.md) | go.mod present | Viper env helpers, gRPC probes, S3 mock testing, GOMEMLIMIT ConfigMap rules |
+| [nodejs-patterns.md](references/nodejs-patterns.md) | package.json present | process.env timing, ioredis pub/sub, NestJS WebSocket, Bull/BullMQ graceful shutdown |
+| [php-patterns.md](references/php-patterns.md) | composer.json present | Laravel queue routing, supervisord, PHP-FPM non-root, S3 ACL patterns |
+| [java-maven-patterns.md](references/java-maven-patterns.md) | pom.xml or build.gradle present | Spring @Value bridging, Quartz JDBC clustering, Liquibase Job, EF efbundle |
+| [python-patterns.md](references/python-patterns.md) | requirements.txt / setup.py / pyproject.toml | pydantic-settings, APScheduler, gunicorn preload_app, Celery Beat writable paths |
+| [ruby-rails-patterns.md](references/ruby-rails-patterns.md) | Gemfile present | ActionCable Redis, ActiveStorage, whenever→Sidekiq-Cron, Puma graceful shutdown |
+| [dotnet-patterns.md](references/dotnet-patterns.md) | .csproj / .sln present | IConfiguration bridge, EF Core efbundle Job, SignalR Redis backplane, Kestrel port config |
+
+## Known Limitations
+
+| Limitation | Severity | Notes |
+|---|---|---|
+| Windows-only runtimes (.NET Framework, IIS, COM+) | HIGH | Phase 1 Blocker — Linux-compatible migration required first |
+| True 2PC / XA distributed transactions | MEDIUM | Replaced with separate TransactionManagers or Saga pattern recommendation |
+| Complex stateful EJBs (JBoss-specific) | MEDIUM | Handled if combined with JBoss-to-Spring-Boot migration upstream |
+| JSF / PrimeFaces frontends | MEDIUM | Decomposed to REST APIs or Thymeleaf; separate frontend rewrite may be needed |
+| Applications >50K LOC | LOW | May hit context limits; consider running Phase 1 and Phase 2 separately |
+| Minikube on resource-constrained machines | LOW | Tier 3 is optional; Tier 1 + Tier 2 are sufficient for CI validation |
+
+## Troubleshooting
+
+| Issue | Resolution |
+|---|---|
+| `docker build` fails with permission denied on entrypoint | Entrypoint script has root-only operations after `USER nonroot`. Move `chown`/`mkdir` to build-time `RUN` or add an init container. |
+| kubeconform rejects integer ConfigMap values | Quote all numeric values: `PORT: "8080"`, `WORKERS: "4"`. Unquoted integers fail strict mode. |
+| Pods crash with `read-only file system` | Runtime writes to non-emptyDir paths. Add `emptyDir` mount for the offending path (check `/tmp`, log dirs, PID dirs). |
+| All requests blocked after deployment | Spring Security or similar auto-configured. Add `SecurityFilterChain` with `permitAll()` for public routes; or verify `NetworkPolicy` egress allows required backing services. |
+| Session lost on pod restart | Session backend not externalised. Check `SESSION_ENGINE` (Django), `config/initializers/session_store.rb` (Rails), or PHP `session.save_handler`. |
+| `CrashLoopBackOff` on CronJob | CronJob missing required env vars from ConfigMap/Secret. Verify `envFrom` or `env` refs match generated ConfigMap keys exactly. |
+| kubeconform `unknown field` error | API version mismatch. Use `autoscaling/v2` for HPA (v2beta2 removed in K8s 1.26). |
+| `runAsUser` mismatch at runtime | `useradd -r` allocated dynamic UID. Rebuild Dockerfile with `useradd --uid 1000 appuser` explicitly. |
+| Probe returning 401 | Health endpoint protected by auth middleware. Move probe path to a public `/healthz` route. |
+| `terminationGracePeriodSeconds` too short | Formula: `max(graceful_shutdown_timeout + 5, 30)`. For gunicorn `--graceful-timeout 120`, set to `125`. |
+
+## Repository Structure
+
+```
+├── SKILL.md                                    # Skill definition (two-phase pipeline)
+├── README.md                                   # This file
+├── references/
+│   ├── skill-a-readiness-analysis.md           # Phase 1: full 101-step analysis procedure
+│   ├── skill-b-containerisation-transformation.md  # Phase 2: full transformation procedure
+│   ├── docker-build-validation.md              # Three-tier validation: docker, kubeconform, Minikube
+│   ├── minimal-execution-set.md               # Execution scope vs reporting scope classification
+│   ├── microservice-decomposition-patterns.md # Named Service Inventory, Complexity Rubric
+│   ├── validation-patterns.md                 # YAML checks, banned-phrase sweeps, ENV audit
+│   ├── credential-audit-patterns.md           # Forms A–F, IRSA, Secret classification
+│   ├── go-patterns.md                         # Go-specific patterns
+│   ├── nodejs-patterns.md                     # Node.js-specific patterns
+│   ├── php-patterns.md                        # PHP-specific patterns
+│   ├── java-maven-patterns.md                 # Java/Maven/Gradle-specific patterns
+│   ├── python-patterns.md                     # Python-specific patterns
+│   ├── ruby-rails-patterns.md                 # Ruby/Rails-specific patterns
+│   └── dotnet-patterns.md                     # C#/.NET-specific patterns
+```

--- a/community-sourced-transformations/kubernetes-readiness-migration/SKILL.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: kubernetes-readiness-migration
+description: >-
+  Two-phase Kubernetes containerisation workflow: analyses a codebase against all
+  12-factor app principles and Kubernetes compatibility requirements to produce a
+  readiness report with detailed microservice decomposition plan (minimal and full
+  recommendations), then systematically resolves all findings by externalising
+  configuration, migrating persistent storage to object store (S3/GCS/Azure Blob),
+  externalising sessions for horizontal scaling, redirecting logging to stdout/stderr,
+  executing decomposition assessments, and generating complete Kubernetes YAML manifests.
+  Validates via three-tier pipeline: docker build, kubeconform, optional cluster.
+  Supports decomposition_scope parameter: minimal (default) or full.
+  Triggers: containerisation, Kubernetes, 12-factor, cloud-native, readiness, migration.
+---
+
+# Kubernetes Readiness Analysis and Migration
+
+A comprehensive two-phase transformation that first assesses any codebase for containerisation and Kubernetes readiness (including detailed microservice decomposition planning with both minimal and full recommendations), then transforms it for full Kubernetes deployment — executing decomposition where feasible.
+
+## Entry Criteria
+
+1. The codebase is available for static analysis and contains application source code in one or more programming languages.
+2. The application is currently running in a non-containerised environment (bare metal, VMs, or traditional deployment) or is being assessed before an initial containerisation effort.
+3. Build and dependency configuration files are present (e.g., build manifests, package lock files, or equivalent for any language/framework).
+4. Windows-only runtimes (.NET Framework, IIS, COM+) → Phase 1 Blocker requiring Linux-compatible migration as a prerequisite before containerisation.
+5. **Decomposition scope**: `minimal` (default) or `full`. Controls whether Phase 2 generates manifests only for the primary Deployment and required support resources (minimal) or for all viable Low/Medium complexity candidates from the Named Service Inventory (full). When absent or unset, apply `minimal`.
+6. **Primary Deployment** = the service handling the majority of inbound HTTP traffic, or the service named in the project root package manifest (package.json/pom.xml/go.mod main module).
+
+## Examples
+
+**Example 1 — PHP/Laravel monolith (interpreted, minimal scope):**
+- Input: Single-repo Laravel app with Blade templates, Redis sessions, MySQL DB, file uploads to local disk.
+- Key signals: `composer.json`, `env()` calls in `config/`, `FILESYSTEM_DISK=local`.
+- Output: Readiness report (21-area scorecard) + 7 manifests (Namespace, Deployment, Service, ConfigMap, Secret, NetworkPolicy, ServiceAccount) + ENV_VARIABLES.md + INFRASTRUCTURE_REQUIREMENTS.md + TRANSFORMATION_SUMMARY.md.
+
+**Example 2 — Java/Spring Boot with Maven (compiled language, pre-build gate):**
+- Input: Multi-module Maven project, Spring Boot 3.x, Liquibase migrations, Quartz scheduler.
+- Key signals: `pom.xml`, `@Value("${...}")`, `System.getenv()`, `spring-boot-starter-quartz`.
+- Output: Same as above + migration Job manifest + `mvn package -DskipTests` passes before `docker build`.
+
+**Example 3 — Python/Django (interpreted, standard 12-factor):**
+- Input: Django REST API with Celery workers, S3 file storage, PostgreSQL.
+- Key signals: `requirements.txt`, `os.environ.get()`, `CELERY_BROKER_URL`, `DEFAULT_FILE_STORAGE`.
+- Output: Same as above + worker Deployment manifest + CronJob for Celery Beat.
+
+## Limitations
+
+- **Compiled languages require matching host toolchain**: Java, Go, C#, Rust projects require the correct SDK version installed on the host for the pre-Docker compilation gate. Version mismatches produce CONDITIONAL PASS, not PASS.
+- **Interpreted languages with version constraints**: Ruby (Bundler), Python (pyproject.toml `python_requires`) — host interpreter version mismatch causes dependency install failures → CONDITIONAL PASS.
+- **Tier 3 KWOK validates API acceptance only**: KWOK cluster validation confirms Kubernetes API schema and resource relationships — it does NOT execute containers or verify runtime behaviour.
+- **Docker-absent environments produce static-checklist results only**: Without Docker, Tier 1 falls back to a 5-point static verification checklist. Image correctness is unverifiable.
+- **Windows-only runtimes require Linux migration prerequisite**: .NET Framework, IIS, COM+ are Phase 1 Blockers — containerisation cannot proceed without a Linux-compatible rewrite.
+- **Integration tests requiring live infrastructure are excluded**: Criterion 13 covers unit tests only. Tests needing running databases, message brokers, or external APIs are out of scope.
+- **DB-stored configuration cannot be externalised to ConfigMap**: Settings managed via admin UI (e.g., OpenMRS GlobalProperty, WordPress wp_options) remain database-stored. Document as post-install admin configuration.
+- **Plugin-registry architectures may require single-replica Recreate strategy**: OSGi, JNLP plugin registries with local plugin state may not support RollingUpdate without shared storage.
+- **Version mismatches that cannot be resolved by toolchain installation produce CONDITIONAL PASS**: Before recording CONDITIONAL PASS for a version mismatch, attempt `mise install` for the required toolchain (see language reference §Toolchain Bootstrap). Only record CONDITIONAL PASS if mise is absent or installation fails.
+- **Interpreted languages require host-side validation gate**: PHP, Python, Ruby, Node.js projects MUST pass language-native syntax/dependency validation on the host BEFORE `docker build`. See each language reference §Pre-Docker Local Validation and `references/docker-build-validation.md` §Step 0b.
+- **Multi-stage Dockerfiles complement but do NOT replace the host-side validation gate**: Host-side compilation/validation is ALWAYS attempted first for fast feedback. Docker build further validates the Dockerfile itself. The sequence is always: (1) host-side compile/check → (2) docker build. The host-side gate is only recorded as CONDITIONAL PASS (not skipped) when the toolchain is unavailable and mise installation fails.
+
+## §0 Initial Entry Interview
+
+**Before any analysis or file reads**, gather user preferences in two blocks. Record all answers before proceeding.
+
+### Block A — Always Asked
+
+1. **Phase selection**: "Run Phase 1 (analysis report) only, or Phase 1 + Phase 2 (analysis + transformation)?"
+2. **Report output path**: "Where should the readiness report be written?" (default: current directory)
+3. **Report format**: "Markdown or HTML?" (default: Markdown)
+4. **Report detail level**: "Full 21-area scorecard, or executive summary only?" (default: full)
+
+### Block B — Asked Only If Phase 2 Selected
+
+5. **Decomposition scope**: "Minimal (primary Deployment only) or full (all viable services)?" (default: minimal)
+6. **Validation tooling**: Auto-detect availability of Docker, Minikube, kind, k3s, and kwokctl. Check each tool independently (do NOT chain checks — individual tool absences must remain individually visible). Then confirm: "Detected: [tools]. Use these for validation? Any additional preferences?" (default: use whatever is detected; attempt KWOK download if nothing found)
+
+### Non-Interactive / CI Defaults
+
+When no interactive prompt is possible, apply: Phase 1+2, Markdown, full detail, minimal scope, KWOK attempted if available (Docker used if present). Log all defaults applied.
+
+## Implementation Steps
+
+### Phase 1 - Containerisation Readiness Analysis
+
+**§0 Initial Entry Interview MUST complete before Phase 1 steps begin.**
+
+Perform a comprehensive static analysis of the codebase to identify containerisation blockers, risks, and remediation steps. Follow `references/skill-a-readiness-analysis.md`.
+
+This phase covers:
+
+1. Analysis of all 12 factors of the 12-factor app methodology
+2. Kubernetes-specific compatibility checks
+3. Horizontal scaling and singleton pattern challenges
+4. Local filesystem usage assessment and replacement recommendations
+5. Credentials, API keys, and secrets management audit
+6. Monolith decomposition assessment with Named Service Inventory, Data Ownership Matrix, and Decomposition Complexity ratings — see `references/microservice-decomposition-patterns.md`
+7. Database connection and data integrity analysis
+8. Memory growth and leak pattern detection
+9. Startup order dependency mapping
+10. User session externalisation assessment
+11. Local caching strategy recommendations
+12. In-memory state sharing between microservice candidates
+
+Output: A single consolidated readiness report (HTML or markdown) with visual readiness scorecard (21 areas), executive summary table, per-section structured finding tables, colour-coded severity badges, Named Service Inventory table with complexity ratings, **both Minimal and Full Decomposition Recommendations**, and singleton risk summary table.
+
+**Zero decomposition candidates rule**: When the Named Service Inventory contains only the primary service (or is empty), the Microservice Decomposition Roadmap section MUST state "No additional decomposition candidates identified" rather than being omitted.
+
+Refer to `references/skill-a-readiness-analysis.md` for the full implementation steps, validation criteria, and formatting rules.
+
+### Phase 2 - Kubernetes Containerisation Transformation
+
+Consume the Phase 1 readiness report and systematically resolve every finding. Follow `references/skill-b-containerisation-transformation.md`.
+
+**Pre-flight codebase existence check (FIRST action):** Before any file_read or shell command referencing the codebase path, verify the path exists and contains files. If check fails: write ERROR_REPORT.md and exit 1.
+
+**Execution Scope:** Determined by `decomposition_scope` (Entry Criteria §5 / §0 Block B):
+- **`minimal` (default):** Primary Deployment + required supporting resources only. See `references/minimal-execution-set.md`.
+- **`full`:** Generate manifests for all Low and Medium complexity candidates from the Named Service Inventory, in addition to the primary Deployment and required support resources.
+
+If the Phase 1 readiness report is unavailable, Phase 2 workers derive blocker context directly from source files using analysis patterns in `references/skill-a-readiness-analysis.md`.
+
+This phase covers 20 sub-phases:
+
+> **Execution Philosophy**: All procedural steps in this specification describe **OUTCOMES** to achieve. The specific tools, commands, and exact syntax used to achieve each outcome are the worker's choice based on the available environment. No command string in this specification or its reference files is mandatory — only the described outcome is mandatory. **Exception**: Validation commands (kubeconform flags, structural assertion patterns, stale-claim grep patterns) define outcomes themselves — their flags and patterns are normative, not merely illustrative.
+
+1. **Initial Setup** — Parse report, copy codebase, gather user preferences (if not already gathered via §0). **Backup file rule**: After every file modification, immediately remove any backup files (`.bak`, `.orig`, `~`) created by the editing tool. Prefer `file_write` (full-file overwrite) over `str_replace` for documentation files to avoid creating backups. This applies to all editing operations throughout all tasks without exception. **Non-interactive defaults**: if preferences cannot be gathered interactively in CI mode, apply Minimal Execution Set defaults and skip Tier 3 cluster validation. See `references/minimal-execution-set.md`. See §Tier 3 Validation Decision Gate below for tooling resolution.
+2. **Decomposition Assessment** — Ingest Phase 1 Named Service Inventory. When `decomposition_scope=minimal` (default): execution scope = primary Deployment + required Jobs/workers only; full catalog goes to report/roadmap. When `decomposition_scope=full`: generate manifests for all Low/Medium complexity candidates; High candidates still documented only. See `references/microservice-decomposition-patterns.md` Phase 2 Execution Rules. ⚠ Guard: Verify Named Service Inventory is current — if source structure has diverged from Phase 1, re-derive service boundaries from package manifests before proceeding. ⚠ Guard: P0/P1 structural blockers identified during Phase 1 (e.g., pom.xml `scope=provided` on embedded server, missing dependencies) MUST appear as explicit dedicated Phase 2 tasks — do NOT rely on them being handled incidentally by other tasks.
+3. **Configuration Externalisation** — **Mandatory first action: source-authoritative env var discovery (5-pass algorithm).** Before writing ENV_VARIABLES.md, complete ALL five passes from repo root (never scoped to a single module):
+
+   **Pass 1 — Full-tree literal-string discovery** (from repo root, pattern `[A-Za-z][A-Za-z0-9_]+`):
+   Use language-specific env-read patterns from the Reference Dispatch table. Scan the ENTIRE repo tree, not a single module. For multi-module projects, scan from root — never a single module subdirectory.
+
+   **Pass 2 — Data-structure literal scan**: Scan for uppercase identifiers stored in config maps/dictionaries/collections (e.g., Python dicts, JS objects, Java Maps with string keys matching `[A-Z][A-Z0-9_]+`). **Disambiguation rule**: identifiers appearing in subprocess child-env dict assignments (e.g., `subprocess.Popen(env={...})`) or SDK wire-protocol Map.put() constants (e.g., Kafka `ProducerConfig.put("key.serializer", ...)`) are output/injected — NOT application input. Exclude from ENV_VARIABLES.md. **Additional exclusion categories**: (a) Property-file LHS keys: identifiers on the left side of `key=value` in `.properties` files are property bindings, not env var reads — exclude unless the value side contains `${VAR}` placeholder syntax. (b) WSGI CGI meta-variables: for Python WSGI apps, exclude RFC 3875 §4.1 CGI meta-variable names (`PATH_INFO`, `SERVER_NAME`, `SERVER_PORT`, `REQUEST_METHOD`, `CONTENT_TYPE`, `REMOTE_USER`, `REMOTE_ADDR`, `HTTP_*`, `AUTH_TYPE`, `SCRIPT_NAME`) — these are per-request environ dict keys, not OS env vars. See `references/python-patterns.md` §WSGI Environ False-Positive Exclusion.
+
+   **Pass 3 — Direct OS env reads** (MANDATORY): `System.getenv` (Java), `GetEnvironmentVariable` (C#), `os.environ`/`os.getenv`/`os.environ.setdefault` (Python), `process.env` (Node.js), `os.Getenv` (Go), `ENV[]`/`ENV.fetch` (Ruby), `getenv()`/`env()` (PHP). **Per-language conditional triggers**: When `Azure.Identity` is in .NET dependencies, also scan for `GetEnvironmentVariable` calls targeting AZURE_* vars. When Python uses `os.environ.setdefault()`, capture both key and value as env var reads.
+
+   **Pass 4 — Entrypoint bash parameter-expansion**: Identify all environment variable names referenced via shell default-value syntax (`${VAR:-default}`) in entrypoint and startup scripts (entrypoint*.sh, docker-entrypoint*.sh, start.sh, run.sh, and equivalents). Also scan for `VAR=${VAR:-default}` assignment forms — these are operator-overridable even when they have computed defaults, and must be included in ENV_VARIABLES.md. **`:?` safety-guard exclusion**: Inspect each `${VAR:?msg}` result in script context — if the variable was assigned earlier in the same script, it is locally-constructed and must be excluded (applies to `${VAR:?msg}` safety-guard forms on local variables).
+
+   **Pass 5 — Indirect helper call-site patterns** (Node.js/PHP/Go/TS): PRIMARY implementation — Python one-liner (avoids shell quoting fragility). MUST iterate over ALL four target extensions:
+   ```bash
+   python3 -c "import re,pathlib;[print(m) for ext in ('*.js','*.ts','*.php','*.go') for f in pathlib.Path('.').rglob(ext) if 'node_modules' not in str(f) and 'vendor' not in str(f) for m in re.findall(r\"(?:requireEnv|getEnv|mustGetEnv|config)\(['\\\"]([A-Z][A-Z0-9_]+)\", f.read_text(errors='ignore'))]"
+   ```
+   FALLBACK — grep (when Python unavailable): Identify all call sites of env-var wrapper helpers (`requireEnv`, `getEnv`, `mustGetEnv`, `config`, and project-specific equivalents) that accept uppercase string keys. These wrappers are common in Node.js (custom `requireEnv` validators), PHP (Laravel `config()` which chains to `env()`), and Go (custom config helpers). Extract all uppercase string arguments passed to these call sites across the source tree (excluding vendor/dependency directories).
+
+   **Phase 2-entrypoint clause**: When any task creates or modifies a shell entrypoint script, immediately re-run Pass 4 against it and update ENV_VARIABLES.md with any new variables before closing.
+
+   **ConfigMap/Secret moves clause**: Any task that relocates a variable between ConfigMap and Secret (or vice versa) MUST update the K8s Scope column in ENV_VARIABLES.md in the same task.
+
+   **Comment-line exclusion** is mandatory on all passes: exclude lines beginning with language-appropriate comment markers (`//` for Java/C#/JS/Go; `#` for Python/Ruby/shell/properties files).
+
+   **Dependency directory exclusion** is mandatory on all passes. Add `--exclude-dir` flags for third-party code:
+
+   | Language | Excluded Directories |
+   |----------|---------------------|
+   | PHP | `vendor` + non-standard vendor-dir from `composer.json` (run `grep -oP '"vendor-dir"\s*:\s*"\K[^"]+' composer.json` before grep passes) |
+   | Node.js | `node_modules` |
+   | Python | `.venv`, `site-packages`, `tests`, `test` |
+   | Ruby | `vendor/bundle` |
+   | Go | `vendor` |
+   | Java | `target`, `.m2` |
+
+   Any env var whose ONLY source is inside a dependency directory is third-party-internal and MUST be excluded from ENV_VARIABLES.md.
+
+   **Zero-result fallback**: When all five passes return zero results, treat manifest env stanza as authoritative and document accordingly.
+
+   Source code reads are AUTHORITATIVE — deduplicate discovery results as the baseline row count. Replace hardcoded config with env var reads, generate ENV_VARIABLES.md. **Per-document stale-claim gate**: after generating or modifying any `.md` document, verify it contains no future-tense language (`will`, `shall`, `would`) before closing the task.
+
+   ⚠ **Per-task ENV_VARIABLES.md update mandate**: Every task that introduces ANY new env var read (getenv/ENV.fetch/@Value/os.environ/process.env) in source code MUST add the corresponding ENV_VARIABLES.md row before closing. This is mandatory (with one exception noted below) — narrow task scope descriptions do NOT override this requirement. **Documentation-only task exemption**: Tasks that modify only `.md` files and introduce no new source code env var reads are exempt from the ENV_VARIABLES.md update mandate only — all other Closure Gate requirements still apply. Verify by running 5-pass grep confirming zero new keys. **Deferred-row escalation**: When a task's file list omits ENV_VARIABLES.md but introduces new env var reads, document deferred rows in the task report under a "Deferred ENV_VARIABLES.md Rows" heading. **Operational enforcement**: When a task report contains a Deferred ENV_VARIABLES.md Rows heading, the orchestrator MUST (a) add ENV_VARIABLES.md to the file scope of the nearest subsequent task AND (b) explicitly reference the deferred key names in that task description. This converts a passive planning note into an active assignment. **Atomic count-literal update**: When adding rows to ENV_VARIABLES.md, update both the new row AND the header count in the same editing operation — never leave count and row count out of sync. The §19 ENV_VARIABLES.md Final Review Completeness Check serves as the catch-all for all deferred rows — re-running all 5 passes to discover any gaps. **High-risk task types for omission**: backing-services (§8), db-optimisation (§14), security-hardening (§13), filesystem-to-object-store (§6), dockerfile-creation/entrypoint (§17), and logging-transformation (§5) tasks commonly introduce env vars without updating ENV_VARIABLES.md — apply extra vigilance.
+
+   Source grep is necessary but NOT sufficient — operationally-injected keys (e.g., Redis password, database admin credentials) not read by application code will not appear in any pass. After manifest generation (§15), run §15b Operationally-Injected Key Sweep: diff kubernetes/*.yaml env keys against ENV_VARIABLES.md; keys present in manifests but absent from docs are a documentation gap regardless of source grep results.
+
+4. **Session and Cache Externalisation** — Verify session mechanism first; DB-backed sessions do NOT need Redis.
+5. **Logging Transformation** — Replace file-based logging with stdout/stderr. **Pre-action step**: Before modifying any log config, enumerate all modules containing file-based logging configuration (rolling files, file appenders, file sinks) across the full repo tree. Apply the stdout/stderr transformation to every discovered file, not just the primary module. After changing default log output to stderr, immediately run the unit test suite to detect regressions from test harnesses that capture stderr.
+6. **Filesystem to Object Store Migration** — Refactor persistent storage to cloud object store or shared volume via SDK. ⚠ **SDK env var mandate**: S3/GCS/Azure SDK integration typically introduces 3-6 new env var reads (bucket, region, endpoint, key, secret, prefix). Any task introducing SDK integrations (S3, GCS, Azure Blob, Redis, SMTP, Elasticsearch, OpenSearch) MUST include a **New Env Vars Introduced** heading in the task report listing all new environment variable keys, even if the ENV_VARIABLES.md update is deferred to a later task.
+7. **Credentials and Secrets** — Remove hardcoded credentials, configure IRSA. See `references/credential-audit-patterns.md`. Credential-only field scope: apply null/empty defaults ONLY to credential fields (key, secret, token); non-credential config fields (region, endpoint, bucket) retain sensible defaults. **Cloud IAM co-requisite**: For AWS IRSA and GCP Workload Identity ServiceAccounts, always set `automountServiceAccountToken: true` explicitly on the ServiceAccount — cluster policies may disable automounting by default. See `references/credential-audit-patterns.md` §IRSA Configuration for the full automountServiceAccountToken reconciliation rule (true on ServiceAccount, false on pod spec). **Source-authoritative grep reminder**: Before generating Secret/ConfigMap or manifest env blocks, re-run source-authoritative env var grep to confirm every key name matches source code reads. Context summaries are planning-level approximations and NOT authoritative for exact key names. ⚠ Guard: After Forms A–F, run Form G (Final Literal Sweep) on ALL docker-compose files AND Cross-Profile Property Consistency Check — see `references/credential-audit-patterns.md` §Form G, §Cross-Profile. **Form G fix-immediately mandate** — Form G and Cross-Profile sweep fixes MUST be applied immediately in the same task regardless of the original task file list. All source/config profile files (e.g., `src/main/resources/` and framework equivalents) are always in-scope for credential remediation. **Out-of-Scope Findings delegation applies to ALL credential findings regardless of file type.** When a task records Out-of-Scope Findings (docker-compose overlays, source files, config profiles, or any other file containing credential patterns), the orchestrator MUST include those specific file:line violations in the file scope of the next eligible downstream task — either by creating a dedicated follow-up task or appending to the nearest downstream task files list.
+8. **Backing Services** — Replace hardcoded addresses with env var reads.
+9. **Scheduled Tasks and Background Jobs** — Extract to CronJob manifests. See `references/skill-b-containerisation-transformation.md` §Sub-Phase §9 for framework exception rules, §Scheduled-Task Extraction Checklist, and §CronJob Manifest Reference for field placement rules. ⚠ Guard: Mode-toggle env vars that trigger exit/shutdown (e.g., CRON_MODE with System.exit()/process.exit()) MUST be CronJob-inline env only, never in shared ConfigMap — misplacement causes all web pods to CrashLoopBackOff. ⚠ Pre-condition: Before writing CronJob manifest, verify `kubernetes/namespace.yaml` exists on disk — if not, create it first.
+10. **Concurrency and Scaling** — Replace in-memory patterns with distributed alternatives.
+11. **Build/Release/Run** — Move build activities to image build time. **For compiled languages (Java, Go, C#, Rust, TypeScript), the native build tool MUST be invoked and exit 0 on the host BEFORE `docker build` is attempted.** The compiled artifact (JAR, binary, DLL, JS bundle) must exist at the expected Dockerfile COPY path. **For interpreted languages (PHP, Python, Ruby, Node.js), the language-native syntax/validation check MUST be run on the host BEFORE `docker build`** — this catches syntax errors, import failures, and dependency resolution problems early (see `references/docker-build-validation.md` §Step 0b). The sequence is always: (1) host-side compile/validate → (2) docker build. If the required toolchain is unavailable and `mise install` fails, record CONDITIONAL PASS — do NOT silently skip. Compiling at container runtime is prohibited — all compilation must occur at image build time (multi-stage Dockerfile) or on the host before the build.
+12. **Disposability and Startup Resilience** — Add retry logic, circuit breakers, health checks. Set `terminationGracePeriodSeconds` to exceed the application graceful shutdown window (see stack-specific reference for formula). **Health probe ordering rule**: Health/readiness probe endpoints MUST be registered BEFORE any global auth middleware.
+13. **Security Hardening** — Non-root execution, read-only root filesystem. ⚠ Guard: emptyDir Mount Scope — when mounting at a path containing image-baked content, use init container to copy content first — see `references/skill-b-containerisation-transformation.md` §emptyDir Mount Scope Rules. ⚠ Guard: Confirm pod-level `securityContext.fsGroup` equals `runAsUser` for every Deployment with emptyDir volumes. Omission causes silent PermissionError on first runtime write. ⚠ Forward-reference: when writing supervisord.conf, set `user=www-data` (not root) to align with §13 `runAsNonRoot`. ⚠ Guard: When `readOnlyRootFilesystem: true`, scan entrypoint scripts for writes to OS paths beyond the application directory (`grep -nE 'mkdir|touch|cat >|tee|>>' entrypoint*.sh`) — each write target needs an emptyDir mount or init-container copy.
+14. **Database Connection Optimisation** — Connection pooling, locking patterns.
+15. **Kubernetes Manifest Generation** — Generate manifests for the execution scope. **Source-authoritative grep reminder**: Before finalising ConfigMap/Secret keys, re-run source-authoritative env var grep (all 5 passes) to confirm every key name matches source code reads. Source code env var reads AND entrypoint shell script `${VAR}` references are authoritative for ConfigMap/Secret keys. **Resolution hierarchy**: source code env reads → manifest yaml → ENV_VARIABLES.md. Source code is authoritative for key names; manifests are authoritative for key placement (ConfigMap vs Secret). **Job/CronJob inline env coverage**: extract env var keys from ALL kubernetes/*.yaml including Job/CronJob container spec `env:` sections. **Post-manifest ENV_VARIABLES.md reconciliation gate**: each manifest-generation task MUST diff its output keys against ENV_VARIABLES.md and add missing rows before closing. See `references/validation-patterns.md` §Post-Manifest ENV_VARIABLES.md Reconciliation.
+15b. **Operationally-Injected Key Sweep** — After §15 manifest generation (manifests must exist on disk), identify infrastructure-injected env vars not discoverable by source grep (e.g., Redis password injected by Helm chart, database admin credentials from operator). Diff kubernetes/*.yaml env keys against ENV_VARIABLES.md; keys present in manifests but absent from docs require documentation rows.
+16. **Infrastructure Requirements Document** — Database, Redis, S3, IAM, networking, secrets, monitoring. Must include §0 Target Microservice Architecture for projects with ≥2 decomposition candidates. ⚠ Guard: After generating any previously-missing manifest, grep INFRASTRUCTURE_REQUIREMENTS.md for `pending`/`not generated` annotations and update to resolved. **Backtick-scope rule**: Only use inline backticks for identifiers that are actual manifest env var keys. SQL keywords, IAM placeholders → fenced code or plain text. **Disk-state-first mandate**: Before writing Manifest Inventory, run `ls kubernetes/*.yaml` to enumerate disk state. Only list files absent from disk as roadmap items.
+17. **Dockerfile Update** — Multi-stage build, non-root user, immutable image. ⚠ Guard: Audit entrypoint scripts for root-privileged operations (`chown`, `adduser`, `apt-get`, `mkdir /var/run`) — any match is a runtime startup blocker, fix in same pass. ⚠ Guard: Verify HEALTHCHECK binary (curl/wget/nc) is present in the base image before use — install as root before USER switch if absent (see each language reference §Dockerfile Pitfalls for base-image tool tables). Set HEALTHCHECK `--start-period=30s` minimum for apps with backing-service dependencies (60s for apps with DB migrations).
+17b. **Docker Build Verification** — Tier 1 validation. See `references/docker-build-validation.md`.
+18. **Minikube Validation** (conditional) — Only after Tier 1 passes.
+19. **Final Review** — Generate TRANSFORMATION_SUMMARY.md with required sections (see Criterion 9). Must include **§Scope Comparison: Minimal vs Full** in the Microservice Decomposition Roadmap. **Re-validation guard**: Before populating the Three-Tier Validation table, compare mtime of every `kubernetes/*.yaml` file against the timestamp of the last validation task. If any manifest is newer, re-run kubeconform and KWOK against current disk state and record fresh results. Before populating the Three-Tier Validation table, read the cluster-validation task report. Do not re-check binary availability in Final Review; record the most favourable validated result from prior task reports. Use `PASSED` (past tense) for ALL individual assertion cells. Audit trail format: `PASSED (N found and removed during cleanup; 0 remaining)`. **Manifest Inventory in TRANSFORMATION_SUMMARY.md MUST be populated from actual disk state (`ls kubernetes/*.yaml`), not from INFRASTRUCTURE_REQUIREMENTS.md annotations.** **Final Review MUST NOT create new manifests or fix Dockerfile gaps — these are defects that belong to earlier tasks. Only ENV_VARIABLES.md row reconciliation, TRANSFORMATION_SUMMARY.md generation, and deferred gap closures (ENV_VARIABLES.md row additions and manifest field corrections — not new manifest file creation — that were explicitly documented in a prior task report under Deferred ENV_VARIABLES.md Rows or Deferred Manifest Fixes headings) are acceptable §19 edits.** A manifest field correction means adding/changing fields within an existing kubernetes/*.yaml file. Adding a new kubernetes/*.yaml file is new manifest file creation and is not permitted in §19. Deferred gap closures must be re-validated with kubeconform and KWOK before closing. **ENV_VARIABLES.md Final Review Completeness Check**: re-run source-authoritative env var grep (all 5 passes) and diff against ENV_VARIABLES.md — add missing rows before closing. **Resource counting mandate**: Use `yaml.safe_load_all()` for counting manifests and keys — never sum from memory.
+
+   **Post-generation validation guards**: (a) Security Hardening status cells must not contain 'Required'/'Recommended' — only 'Applied'/'Configured'. (b) Scope Comparison Actual Outcome column must match `ls kubernetes/*.yaml` disk state. (c) Three-Tier Validation cells must contain 'PASSED' with tool flags — never blank.
+
+   **SELF-REFERENCE GUARD**: Audit trail row labels and Notes cells MUST NOT quote literal banned tokens or search phrases. Use functional abstractions: "Future-tense gate" (not "will/shall/would"), "Banned-phrase check" (not the specific phrase), "Resolved-issue verification" (not "Known-Issues scan"). Run banned-phrase check after EACH individual edit operation on TRANSFORMATION_SUMMARY.md, not only at task close. See `references/validation-patterns.md` §Stale-Claim Sweep for safe label templates.
+
+   **Safe-label substitution table** (use these to avoid triggering the stale-claim sweep):
+   | ❌ Triggers sweep | ✓ Safe replacement |
+   |---|---|
+   | `All 6 required fields` | `All 6 mandatory fields` |
+   | `recommended approach` | `supported approach` |
+   | `not generated` | `roadmap only` |
+   | `Action Required` | `Operator Setup Step` |
+   | `Known-issue resolution` | `Prior-findings verification` |
+   | `Required` / `Recommended` (in Security status cells) | `Applied` / `Configured` |
+   | `must be` (requirement context) | `is a prerequisite for` |
+   | `would enable` | `enables once configured` |
+   | `should be` | `is expected to be` |
+   | `needs to be` | `requires` |
+   | `must be configured by` | `operator configures` |
+
+   The security-hardening grep targets status cells only — Notes/Details cells with natural adjective use of these words are false positives. Use the safe labels above to avoid triggering the sweep.
+
+   **Self-referential trap — WRONG vs CORRECT:**
+   - ❌ WRONG: Notes cell says `Scanned for 'will' — 0 hits` (re-embeds the banned word)
+   - ✓ CORRECT: Notes cell says `Future-tense gate: clean` (functional abstraction)
+   - ❌ WRONG: Notes cell says `CONDITIONAL PASS` when tool was simply absent (misclassification)
+   - ✓ CORRECT: Notes cell says `PASSED (skipped — tool unavailable)` for absent tools
+   - ❌ WRONG: Notes cell says `no Known-Issues entries` (re-embeds banned phrase)
+   - ✓ CORRECT: Notes cell says `all prior issue annotations verified closed`
+   - ❌ WRONG: Notes cell says `no Required or Recommended found` (re-embeds banned tokens)
+   - ✓ CORRECT: Notes cell says `all cells reflect completed-state language`
+   - ❌ WRONG: Notes cell says `Scanned for will — 0 hits` (quotes the banned word)
+   - ✓ CORRECT: Notes cell says `Future-tense gate: clean`
+
+   **Post-debugger documentation sync**: After applying any code fix via debugger, update affected documentation (ENV_VARIABLES.md, INFRASTRUCTURE_REQUIREMENTS.md, TRANSFORMATION_SUMMARY.md) in the same pass — do not leave stale 'out-of-scope' annotations.
+
+Refer to `references/skill-b-containerisation-transformation.md` for the full implementation steps. The 12-Point Mandatory Closure Gate defined there applies to ALL tasks without exception (including documentation-only tasks).
+
+#### Tier 3 Validation Decision Gate
+
+If validation tooling was not resolved in §0 Block B, determine Tier 3 cluster validation availability during Sub-Phase §1:
+
+1. **Auto-detect**: Check independently for the availability of Minikube, kind, k3s, and kwokctl. Check each separately to avoid masking individual absences.
+2. **If detected**: Tier 3 is available — proceed with cluster validation after Tier 1 passes (or immediately for KWOK).
+3. **If NOT detected — attempt kwokctl download** (30-second timeout). Check whether kwokctl is already cached locally before attempting a download.
+4. **Prompt the user** (30-second timeout; no response = N):
+   ```
+   Tier 3 cluster validation (Minikube/kind/k3s/KWOK) was not auto-detected.
+   Would you like to run Tier 3 cluster validation? [y/N]
+   ```
+5. **In fully automated (CI) mode**: default to skip, emit visible NOTICE, log decision.
+6. **Record the decision** in task report AND TRANSFORMATION_SUMMARY.md.
+
+**Split-task guidance**: When kubeconform/KWOK are absent at manifest-generation time, do NOT retry downloads within that task — close with `PASSED (tool unavailable — skipped)` and create a dedicated validation task. When populating TRANSFORMATION_SUMMARY.md Three-Tier Validation table, always read prior task reports for tool results — tool availability is environment-transient; prior task results are canonical.
+
+## Reference Dispatch
+
+| Signal | Reference |
+|--------|-----------|
+| Phase 1 work | `references/skill-a-readiness-analysis.md` |
+| Phase 2 work | `references/skill-b-containerisation-transformation.md` |
+| Docker build validation (§17b) | `references/docker-build-validation.md` |
+| Minimal Execution Set scope decisions | `references/minimal-execution-set.md` |
+| Decomposition plan with ≥2 service candidates | `references/microservice-decomposition-patterns.md` |
+| Validation patterns (YAML, banned-phrase, .bak) | `references/validation-patterns.md` |
+| Credential audit (docker-compose, AWS SDK, URLs) | `references/credential-audit-patterns.md` |
+| Go project (go.mod) | `references/go-patterns.md` |
+| Node.js project (package.json) | `references/nodejs-patterns.md` |
+| PHP project (composer.json) | `references/php-patterns.md` |
+| Java/Maven/Gradle (pom.xml / build.gradle) | `references/java-jvm-patterns.md` |
+| Python project (requirements.txt/pyproject.toml) | `references/python-patterns.md` |
+| Ruby/Rails project (Gemfile) | `references/ruby-rails-patterns.md` |
+| C#/.NET project (.csproj/.sln) | `references/dotnet-patterns.md` |
+
+**Mixed-language dispatch**: If primary runtime differs from build-time toolchain (e.g., PHP app + Node.js asset build, Java app + Angular frontend), consult BOTH relevant language references.
+
+## Reference Procedures
+
+The procedures below describe mechanical transforms and verification sweeps the worker performs on demand using standard shell commands. There are no executable scripts — the worker reads each procedure and issues the commands directly.
+
+- **Pre-migration procedures** run BEFORE any file-by-file migration work.
+- **Post-batch procedures** run AFTER each batch of related changes.
+- **Post-migration procedures** run AFTER all code changes are complete.
+
+- **`references/docker-build-validation.md`** — Three-tier validation pipeline: docker build, kubeconform, cluster. Includes Step 0 (Pre-Docker Native Compilation Gate for compiled languages), Tier 3 ask-before-skip protocol, kwokctl binary download, KWOK Operational Checklist, 00-namespace.yaml convention. When to run: post-batch (Tier 1). Patterns: `pom.xml`, `build.gradle`, `go.mod`, `.csproj`, `Cargo.toml`, `package.json` (with build script).
+- **`references/minimal-execution-set.md`** — Resource-type classification and scope decisions. When to run: pre-migration planning.
+- **`references/microservice-decomposition-patterns.md`** — Decomposition workflow and templates including Scope Comparison table. When to run: pre-migration and post-batch.
+- **`references/validation-patterns.md`** — Reusable YAML, banned-phrase, reconciliation, stale-claim procedures, grep tempfile pattern, grep robustness rules, and assertion battery template. When to run: post-batch and post-migration.
+- **`references/credential-audit-patterns.md`** — Credential audit Forms A–G, IRSA, Secret classification, credential-only field scope rule, cross-profile consistency check, scan-vs-modify scope boundary, external-service username rule, nounset-safe credential removal. When to run: pre-migration and post-batch.
+- **`references/go-patterns.md`** — Go: Pre-Docker Local Validation (go vet, go build, go test -short), viper, gRPC probes (including distroless native K8s grpc: probe type), S3 mock, GOMEMLIMIT, probe ordering, mise bootstrap (three-step activation), Dockerfile pitfalls. When to run: pre-migration and post-batch.
+- **`references/nodejs-patterns.md`** — Node.js: Pre-Docker Local Validation (node --check, npm ci, tsc --noEmit), connect-redis, ioredis, multer-s3, CronJob patterns, probe ordering, config-module audit, mise bootstrap (three-step activation), JSDoc cron hazard, jest.mock virtual, S3 migration cascade, NestJS probe path verification, lock file desync pre-check, package removal ordering, Dockerfile pitfalls (dead multi-stage detection, HEALTHCHECK start-period). When to run: pre-migration and post-batch.
+- **`references/php-patterns.md`** — PHP: Pre-Docker Local Validation (php -l, composer validate, composer install), Toolchain Bootstrap (Composer NOT available via mise — use direct curl installer), config fallback, FPM non-root, supervisord, S3, Stage 0 extension builder, Apache non-root, vendor directory exclusion, non-standard vendor-dir detection, production-safe ConfigMap defaults, SMTP egress NetworkPolicy, apache CMD inheritance trap, configPath override detection, terminationGracePeriodSeconds formula, 5-pass grep tools/scripts exclusion, Dockerfile pitfalls. When to run: pre-migration and post-batch.
+- **`references/java-jvm-patterns.md`** — Java/Maven/Gradle (covers BOTH build tools): Pre-Docker Local Validation (mvn package/gradlew build, mise toolchain bootstrap), Spring @Value, Quartz, Liquibase, WAR patterns, Tomcat WAR Deployment (CATALINA_OPTS env export, Infinispan JGroups ports), HikariCP API Misuse Detection, System.getenv() scan, PIPESTATUS for Maven pipe verification, Spring cron conversion, host-side compilation mandate, Hibernate dual-load guard, @KafkaListener EL placeholders, SPRING_PROFILES_ACTIVE mandatory ConfigMap, Spring Redis ENV bridge, Kafka Consumer HPA sizing, bootJar archiveVersion, Gradle wrapper JAR regeneration, Spring XML PPC Profile Isolation, Latin-1 Properties Encoding, JWT Lazy Credential Validation, canonical JVM ENTRYPOINT, embedded cache emptyDir, Dockerfile pitfalls. When to run: pre-migration and post-batch.
+- **`references/python-patterns.md`** — Python: Pre-Docker Local Validation (py_compile, pip install, pytest unit-only), venv Docker, SIGTERM, Celery Beat, pydantic-settings, lazy imports, exec probe, pytest, APScheduler CronJob conversion, INI dual-path config, multi-line os.environ.get, tuple-list config mapping, Redis triple-role, WSGI environ false-positive exclusion, Dockerfile pitfalls. When to run: pre-migration and post-batch.
+- **`references/ruby-rails-patterns.md`** — Ruby/Rails: Pre-Docker Local Validation (ruby -c, bundle check, rspec unit-only, mise/rbenv bootstrap), ENV.fetch, ActiveStorage, cable.yml, Puma, post-externalisation test sync, Sidekiq queue config, Rails 7.x Sprockets, Gemfile version pin, SMTP egress NetworkPolicy, CONDITIONAL PASS for Bundler mismatch, post-logging transformation test sync, Dockerfile pitfalls. When to run: pre-migration and post-batch.
+- **`references/dotnet-patterns.md`** — C#/.NET: Pre-Docker Local Validation (dotnet build, dotnet test unit-only), IConfiguration, EF Core, SignalR, Kestrel, InboundClaimTypeMap, Xabaril health checks, DefaultAzureCredential, Dockerfile pitfalls (base image tool availability). When to run: pre-migration and post-batch.
+
+## Validation / Exit Criteria
+
+### Phase 1 Validation
+1. User was prompted for output location and format preference before analysis began (§0 Block A).
+2. All findings produced in a single consolidated report at the user-specified location.
+3. Report begins with a visual readiness scorecard (21 areas) with correct status icons.
+4. Executive summary table follows with severity counts and narrative paragraph.
+5. Every source file scanned against all 12 factors and additional analysis areas.
+6. All findings categorised as Blocker, Warning, or Informational with consistent emoji icons.
+7. Per-section findings in structured tables with file:line references verified via grep.
+8. Named Service Inventory table with all 11 mandatory columns included. **Must include both Minimal Decomposition Recommendation and Full Decomposition Recommendation subsections.**
+9. Singleton risk summary table included.
+
+### Phase 2 Validation (Criteria 1-13)
+
+1. Every blocker finding addressed by code change, manifest, or infrastructure requirement. **CronJob extraction sub-check**: after extracting a scheduled task to a CronJob manifest, grep the primary Deployment source for the original scheduler trigger (e.g., `cron.AddFunc`, `@Scheduled`, `APScheduler.add_job`, `cron.schedule`) and assert it is absent or disabled.
+2. All hardcoded config replaced with env var reads.
+3. Session state is non-local and safe for horizontal scaling. **Session verification gate**: before adding Redis for sessions, grep for DB-backed session patterns.
+4. All logging redirected to stdout/stderr.
+5. Persistent filesystem usage replaced with appropriate object store or shared volume.
+6. All hardcoded credentials removed; sourced from Kubernetes Secrets. Verify credential-only field scope: null/empty defaults applied ONLY to credential fields, not to region/endpoint/bucket.
+7. Complete Kubernetes manifests generated in kubernetes/ (or k8s/) directory for the execution scope (per `decomposition_scope`). ⚠ Guard: ConfigMap data values must be strings; CronJob podSelector label must match `spec.jobTemplate.spec.template.metadata.labels`, not top-level metadata.labels.
+8. Every main container in Deployment, Job, and CronJob manifests includes: resource requests/limits, probes, and complete security context. ⚠ Guard: For UID/capability exceptions by base image, see `references/skill-b-containerisation-transformation.md` §Security Context Edge Cases. **Container-level securityContext MUST include ALL six fields: `runAsNonRoot: true`, `runAsUser: <UID>`, `runAsGroup: <UID>`, `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities: {drop: [ALL]}`. Pod-level securityContext alone is insufficient — container-level fields MUST be repeated.** **Probe rules by workload type**: (a) Init containers: no probes. (b) Job/CronJob WITH HTTP endpoint: startupProbe + livenessProbe (omit readiness). (c) Job/CronJob WITHOUT HTTP endpoint: exec livenessProbe only — use shell form `["/bin/sh", "-c", "kill -0 1"]` (not standalone binary path). Distroless exception: omit ALL probes — use `activeDeadlineSeconds` (≤80% schedule interval). (d) Deployment main containers: all three probes. Headless workers: exec probes only. **startupProbe first-boot sizing**: failureThreshold: 30, periodSeconds: 10 (300s budget). **DB-migration sizing**: For applications with database migration tooling (Liquibase, Flyway, Alembic, Django migrations, ActiveRecord migrations), use failureThreshold: 60, periodSeconds: 10 (600s budget) — migration at startup requires a larger window. Always review timing observations from the readiness report before setting final values. **Fallback when no readiness report timing data is available**: use DB-migration budget (failureThreshold: 60) as conservative default for any app with database migration tooling detected in source. **Probe path authentication rule**: Verify probe path returns HTTP 2xx WITHOUT auth. For WAR/servlet apps, include deployment context path from Dockerfile HEALTHCHECK in the probe path. For NestJS, use `expressApp.get()` registration paths in `main.ts`, NOT `@Controller()` route paths.
+9. **Stale-claim sweep, .bak enforcement, and TRANSFORMATION_SUMMARY.md integrity.**
+
+   **Outcome checks** (procedure details in `references/validation-patterns.md` §Stale-Claim Sweep):
+   - (a) Zero `.bak` files in working tree.
+   - (b) No future-tense language (`will`, `shall`, `would`) in transformation documents. The Two-Category Triage exemption applies ONLY to Phase 1 readiness reports. **Audit trail row labels must use functional abstractions — never literal banned tokens or verbatim grep strings.** Audit trail format: `PASSED (N found and removed during cleanup; 0 remaining)`.
+   - (c) No banned phrases (`should be`, `TODO`, `TBD`, action-required markers) in TRANSFORMATION_SUMMARY.md.
+   - (d) Known-Issues entries verified as resolved.
+   - (e) Post-debugger documentation re-sweep passes.
+   - (f) File-path verification: every file path cited in TRANSFORMATION_SUMMARY.md must exist on disk. ⚠ Guard: Pre-filters — (i) exclude absolute paths starting with `/` (container-internal), (ii) match only known repo-relative prefixes (`kubernetes/`, `k8s/`, `src/`, `config/`, `lib/`), (iii) exclude abbreviated class paths. Use regex `[A-Za-z0-9/_.-]` for path matching. Deferred Resources tables MUST NOT use backtick-quoted `kubernetes/` paths for files that do not exist — describe by resource type only.
+   - (g) Tool-skipped enforcement: when Docker was skipped due to unavailability, verify TRANSFORMATION_SUMMARY.md records the tier as `PASSED (skipped — tool unavailable)`, not `CONDITIONAL PASS`. `CONDITIONAL PASS` is reserved for cases where a tool was present but validation produced a recoverable failure.
+   - (h) Heading-format check: Verify that no heading in TRANSFORMATION_SUMMARY.md begins with repeated `#` sequences separated by a space (e.g., `### ### Section Title`). Any such doubled-heading pattern is a malformed heading that must be corrected.
+
+   **TRANSFORMATION_SUMMARY.md required section headings**: `## Executive Summary`, `## Manifest Inventory`, `## Configuration Changes`, `## Security Hardening Summary`, `## NetworkPolicy Summary`, `## Microservice Decomposition Roadmap` (mandatory when monolith_risk is high/critical; recommended otherwise). The Roadmap MUST include a **### Scope Comparison: Minimal vs Full** subsection.
+
+   **Env var count definition**: count = sum of unique keys from configmap.yaml data + secret.yaml stringData/data.
+
+10. **Criterion 10 — Assembly and Reconciliation**: All generated Kubernetes manifests pass sub-rules (A)–(G) from `references/validation-patterns.md`. ⚠ Guard: **Service selector parity**: assert AT LEAST ONE Deployment matches each Service selector (ANY-match, `len(matches) > 0`), not ALL-match. Implement via Python `all(k in dep_labels and dep_labels[k] == v for k, v in selector.items())` subset check — selector keys must be a subset of Deployment labels, not an equality check.
+
+11. **Three-Tier Validation Pipeline** (strictly ordered):
+
+    **Tier 1 — Docker Build:** `docker build` exit 0 for every Dockerfile in scope. If Docker unavailable: status = `PASSED (skipped — tool unavailable)`, overall result is unaffected (not degraded). See `references/docker-build-validation.md`.
+
+    **Tier 2 — kubeconform + Structural Assertions:** Always runs. Canonical: `kubeconform -kubernetes-version 1.28.0 -strict -ignore-missing-schemas -summary kubernetes/*.yaml`. ⚠ Guard: Post-kubeconform, run placement assertions for CronJob `activeDeadlineSeconds` and Secret envFrom dotted-key check — see `references/docker-build-validation.md` §Post-kubeconform Placement Assertions. **kubeconform known blind spots**: kubeconform -strict does NOT verify namespace field presence on namespaced resources or CronJob `activeDeadlineSeconds` placement — Criterion 10F Python assertions are the sole catching mechanism for these. **Post-kubeconform, the structural assertion battery (Criterion 10 sub-rules A–G) is MANDATORY regardless of kubeconform exit status — kubeconform -strict does NOT validate field placement within a valid schema, namespace membership, or cross-resource parity.** Include `terminationGracePeriodSeconds` placement assertion: for Deployment, StatefulSet, and DaemonSet assert `doc['spec']['template']['spec'].get('terminationGracePeriodSeconds')` (NOT at Deployment `spec` root). For CronJob, the correct path is `doc['spec']['jobTemplate']['spec']['template']['spec'].get('terminationGracePeriodSeconds')`.
+
+    **Tier 3 — Cluster Validation (ask-before-skip):** Minikube/kind/k3s/KWOK. For KWOK `--runtime=binary`, Tier 3 can proceed regardless of Tier 1 status because KWOK validates only API acceptance. See `references/docker-build-validation.md`.
+
+    **CONDITIONAL PASS scoring**: `CONDITIONAL PASS` is reserved for cases where a tool **was present** but produced a recoverable failure (e.g., Docker build failed but can be fixed, or tests failed due to missing system deps). Tool absence is NOT a failure — unavailable tiers are recorded as `PASSED (skipped — tool unavailable)` and do NOT degrade the overall result. When ALL available tiers pass (or are skipped due to absence) and Tier 2 passes, overall status = `PASSED`.
+
+12. **NetworkPolicy completeness (bidirectional)**: Every workload has ingress+egress NetworkPolicy. Non-web workloads (workers, CronJobs, Jobs with no inbound traffic) MUST declare `ingress: []` (deny-all ingress). Web-facing workloads use explicit port-based ingress rules instead of `ingress: []`. ALL workloads MUST declare `policyTypes: [Ingress, Egress]` — this ensures the ingress policy is enforced regardless of whether rules or empty array is used. DNS egress MUST list BOTH `protocol: UDP, port: 53` AND `protocol: TCP, port: 53`. External service egress uses ports-only (NO `to:` field, NEVER `to: []`). Do NOT use `ipBlock` for external service egress even when existing codebase uses it — use ports-only (omit `to:` field entirely). The ports-only pattern (omitting `to:` entirely) means "allow egress to ANY destination on these ports" — this is intentional for external services where destination IPs are not known at deploy time. **Egress determination rule**: Determine NetworkPolicy egress from actual driver/ORM `require()`/`import` calls, not env var reads alone — a process reading a connection string for validation but never importing the driver does NOT need that service in egress. ⚠ Guard: CronJob podSelector must match `spec.jobTemplate.spec.template.metadata.labels`; egress NetworkPolicy uses pod port not Service port. See `references/skill-b-containerisation-transformation.md` §CronJob Manifest Reference.
+
+13. **Container Build & Basic Tests Gate** — docker build exits 0 (or `PASSED (skipped — tool unavailable)` when Docker is absent; this does NOT degrade the overall result). **Pre-Docker native compilation gate (compiled languages):** For projects with `pom.xml`/`build.gradle` (Java), `go.mod` (Go), `.csproj`/`.sln` (C#), or `package.json` with a `build` script (TypeScript/Node.js), the language-native build tool MUST be invoked and exit 0 before `docker build`. Host-side compilation is ALWAYS attempted first — even for multi-stage Dockerfiles — because it provides faster feedback than a Docker build failure. See `references/docker-build-validation.md` §Step 0. **Pre-Docker validation gate (interpreted languages):** For projects with `composer.json` (PHP), `requirements.txt`/`pyproject.toml` (Python), `Gemfile` (Ruby), or `package.json` without a `build` script (Node.js), the language-native validation commands MUST be run and exit 0 before `docker build`. See `references/docker-build-validation.md` §Step 0b and each language reference §Pre-Docker Local Validation. If the toolchain version does not match the project requirements (e.g., JDK mismatch), attempt resolution via `mise install` first; record `CONDITIONAL PASS` with root cause only if mise is absent or installation fails — do NOT silently skip. **CONDITIONAL PASS for interpreted-language version mismatches**: Ruby: host ruby version != Gemfile `ruby` constraint → `bundle install` exit non-zero → CONDITIONAL PASS. Python: host python incompatible with `python_requires` → `pip install` exit non-zero → CONDITIONAL PASS. A HIGHER host JDK compiling LOWER source level is backward-compatible — attempt build first; exit 0 = PASS. **Repeat-failure escalation**: if the language-native compile/validation step fails in 2+ tasks for the same environmental reason (e.g., JDK version mismatch), the overall Criterion 13 result MUST be `CONDITIONAL PASS` — not `PASS`. Document root cause and affected tasks in the Three-Tier Validation table. Language-native test suite passes (unit tests only, exclude integration tests requiring live infrastructure). **Test attempt mandate**: Before documenting tests as skipped, ATTEMPT to run unit tests with infrastructure-exclusion flags: Python `pytest -m 'not integration and not db' -x`; Ruby `rspec --tag ~@integration`; Java `mvn test -Dtest='!*IntegrationTest,!*Integration'`; Go `go test ./... -short`; Node.js `npx jest --testPathIgnorePatterns='integration'`; PHP `vendor/bin/phpunit --exclude-group=integration`. Infrastructure-dependent failures = CONDITIONAL PASS; syntax/import errors = FAIL. Pre-existing test failures from missing system deps → CONDITIONAL PASS with root cause list. Projects with no test suite: document absence as a note; do not fail on missing tests.

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/credential-audit-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/credential-audit-patterns.md
@@ -1,0 +1,922 @@
+# Credential Audit Patterns Reference
+
+Complete credential audit procedure for Phase 2 Sub-Phase §7 (Credentials and Secrets Remediation). Covers all mandatory scan locations, docker-compose forms, IRSA configuration, Secret classification, and connection URL rules.
+
+## Table of Contents
+
+1. [Credential-Only Field Scope Rule (Global)](#credential-only-field-scope-rule-global)
+2. [Docker-Compose Credential Scan](#docker-compose-credential-scan)
+3. [Source Code Credential Scan](#source-code-credential-scan)
+4. [Cross-Profile Property Consistency Check](#cross-profile-property-consistency-check)
+5. [IRSA Configuration](#irsa-configuration)
+6. [Secret Classification Guards](#secret-classification-guards)
+7. [Connection URL Secret Classification](#connection-url-secret-classification)
+8. [URL-Embedded Credential Detection (Form F)](#url-embedded-credential-detection-form-f)
+9. [Final Literal Sweep (Form G)](#final-literal-sweep-form-g)
+10. [Dotted Secret Key Workaround](#dotted-secret-key-workaround)
+11. [Framework-Internal Mandatory Secrets](#framework-internal-mandatory-secrets)
+12. [Multi-Profile Credential Scan](#multi-profile-credential-scan)
+13. [Nounset-Safe Credential Default Removal](#nounset-safe-credential-default-removal)
+
+---
+
+## Credential-Only Field Scope Rule (Global)
+
+**This rule is GLOBAL — applies to every credential externalisation task regardless of whether IRSA is involved.**
+
+Apply null/empty defaults ONLY to credential fields (key, secret, token). Non-credential config fields (region, endpoint, bucket) retain sensible defaults:
+```yaml
+# CORRECT — credential fields get empty string (for IRSA) or placeholder:
+AWS_ACCESS_KEY_ID: ""
+AWS_SECRET_ACCESS_KEY: ""
+DB_PASSWORD: "replace-with-db-password"
+# CORRECT — config fields retain useful defaults:
+AWS_DEFAULT_REGION: "us-east-1"
+S3_ENDPOINT: "https://s3.amazonaws.com"
+S3_BUCKET: "replace-with-bucket-name"
+DB_HOST: "replace-with-db-host"
+```
+
+**Cross-profile credential default scan** (run after ANY credential externalisation task):
+```bash
+grep -rn '\${[A-Z_]*(KEY|SECRET|TOKEN|PASSWORD):[^}]+}' --include='*.properties' --include='*.yml' --include='*.yaml' .
+```
+Any match with a non-empty default for a credential field = violation. Credential fields must use bare `${VAR}` (no fallback) or `${VAR:-}` (empty fallback).
+
+**Scope of this rule:**
+- Applies in §7 (Credentials and Secrets), §3 (Config Externalisation), and §15 (Manifest Generation)
+- Applies to ALL frameworks and languages — not only AWS/IRSA scenarios
+- Any task that adds `${VAR}` placeholders to credential-like fields must verify the default is empty
+
+---
+
+## Docker-Compose Credential Scan
+
+**Scope mandate**: Credential audit ALWAYS covers ALL files matching `docker-compose*.yml` via `find . -name 'docker-compose*.yml' -not -path '*/.git/*'`. Task descriptions naming individual docker-compose files are indicative only — overlay/variant files (docker-compose.grafana.yml, docker-compose.prod.yml, docker-compose.override.yml) are ALWAYS in scope.
+
+**Scan-vs-Modify scope boundary**: All `docker-compose*.yml` files are "in scope for SCANNING" (inspect for credential patterns, report findings). Only files explicitly listed in the task assignment are "in scope for MODIFICATION". Findings in scan-only files MUST be recorded under "Out-of-Scope Findings" in the task report for future remediation — never silently skipped. **Source-file credential findings**: Out-of-scope delegation applies to ALL credential findings regardless of file type — docker-compose overlays AND source files (e.g., `application-prod.properties` found during scanning but not in task file list). Any task recording Out-of-Scope Findings MUST set status to OPEN in the Security Hardening Summary for unremediated items until a downstream task resolves them.
+
+**Cross-profile blocking gate**: Credential sweep MUST cover base AND all profile-specific override files in the same pass:
+```bash
+grep -r 'SECRET_KEY:.*[0-9]\|JWT_SECRET:.*[a-z]\|PASSWORD:.*[a-z]' --include='*.properties' --include='*.yml' --include='*.yaml' .
+# Must return zero matches before task closure
+```
+
+**Scan ordering**: docker-compose*.yml FIRST (before src/).
+
+**Absence guard**: `ls docker-compose*.yml 2>/dev/null || echo 'No docker-compose files — skip Forms A-E scan'`
+
+### Five Forms
+
+**(A)** Bash-expansion defaults:
+```bash
+grep -nE '\$\{[A-Z_]+:-[a-zA-Z0-9]+\}' docker-compose*.yml
+# Extended: also catch quoted defaults like ${VAR:-"literal"} or ${VAR:-'literal'}
+grep -nE '\$\{[A-Z_]+:-['\''"]?[a-zA-Z0-9]+' docker-compose*.yml
+```
+
+**(B)** YAML mapping with credential keywords:
+```bash
+grep -nE '^\s+[A-Z_]+:\s+[a-zA-Z0-9]' docker-compose*.yml | grep -iE 'pass|secret|key|token|user|host|port'
+```
+
+**(C)** List-form environment entries:
+```bash
+grep -nE '^\s+-\s+[A-Z_]+=\S' docker-compose*.yml | grep -iE 'pass|secret|key|token|user'
+```
+
+**(D)** URL-embedded defaults:
+```bash
+grep -nE ':-[a-zA-Z0-9_.~%@:/+-]+' docker-compose*.yml | grep -iE 'pass|secret|key|token|user'
+```
+
+**(E)** Post-fix canonical check:
+```bash
+grep -E '\$\{[A-Z_]+:-[^}]+\}' docker-compose*.yml
+```
+Any remaining match = lingering default; production credentials use bare `${VAR}` with NO fallback literal.
+
+**(A')** Hibernate/Spring single-colon variant (for .properties files):
+```bash
+grep -rE '\$\{[A-Z_]+:[^-][^}]*\}' . --include='*.properties' --include='*.yml' --include='*.yaml' | grep -iE 'pass|secret|key|token'
+```
+This catches `${VAR:literal}` (Spring/Hibernate default syntax using single colon, NOT bash double-colon `:-`). Each match with a non-placeholder literal is a credential exposure.
+
+**Scope**: Scan ALL service blocks including infrastructure (postgres, redis, mysql). Placeholder URLs (e.g., `https://auth.example.com/...`) → classify as Required env vars in ENV_VARIABLES.md.
+
+**Overlay scoping note**: Dev/monitoring-only docker-compose overlays (e.g., `docker-compose.dev.yml`, `docker-compose.monitoring.yml`) should be scanned for credential patterns but env vars found ONLY in overlays labelled "dev" or "test" may be classified as optional.
+
+## Source Code Credential Scan
+
+The credential audit covers four mandatory locations:
+
+**(a)** Config files — grep application config (`.env`, `config/*.yml`, `application.properties`, etc.) for hardcoded values.
+
+**(b)** Hardcoded string constants and fallback DSN constructions — search for inline connection strings:
+```bash
+grep -rn 'password\|secret\|api_key\|token' src/ --include='*.py' --include='*.js' --include='*.java' --include='*.php' --include='*.rb' --include='*.go' | grep -v 'test\|spec\|mock' | grep -v '^\s*#\|^\s*//'
+```
+
+**(c)** Framework SetDefault/fallback calls:
+- Go: `viper.SetDefault("key", "literal")`
+- Python: `os.Getenv("KEY", "literal")` fallback args
+- Spring: `@Value("${VAR:literal-default}")` defaults
+- PHP: `env('KEY', 'literal-default')` literal defaults
+- Node.js: `process.env.KEY || 'literal-default'`
+
+**(d)** Startup/entrypoint shell scripts AND docker-compose*.yml:
+```bash
+grep -E '\$\{[A-Z_]*(PASSWORD|SECRET|KEY|TOKEN)[A-Z_]*:-[^}]+\}' startup*.sh entrypoint*.sh docker-entrypoint.sh docker-compose*.yml
+```
+
+**Bash nounset compatibility**: Before removing a hardcoded literal from `${VAR:-literal}`, inspect the script shebang/set flags. If `set -u` or `#!/bin/bash -u` is present, use `${VAR:-}` (empty default) rather than bare `${VAR}` — bare references cause nounset failures.
+
+**Post-transformation src/ tree sweep**: After removing config-module fallbacks, grep entire src/ for the same env var name to detect secondary direct reads (e.g., `process.env.X` reads that bypass the config module).
+
+**Boolean-value filter**: Exclude credential-scan matches where the default value is in the boolean set {true, false, 0, 1, yes, no} or is <= 4 characters. Variables with `_LOCKED`, `_ENABLED`, `_ACTIVE`, `_DISABLED` suffixes are typically boolean toggles, not credentials — they are NOT credentials regardless of name pattern. Reclassify as ConfigMap. **Port exclusion**: values matching common infrastructure ports (2181, 3306, 5432, 6379, 8080, 9092, 27017) are not credentials.
+
+## Cross-Profile Property Consistency Check
+
+**Purpose:** For any property externalised as a required secret (no-default, bare `${VAR}`) in ANY named Spring/framework profile, verify the base/default profile also uses the no-default form. A hardcoded fallback in the base profile creates a silent credential bypass when the env var is absent at runtime.
+
+**When to run:** After credential remediation on any Spring/multi-profile project (Sub-Phase §7, post-batch).
+
+**Preconditions:** Application uses Spring profiles (application-{profile}.properties/yml) or equivalent framework-specific profile configuration.
+
+**Procedure:**
+
+1. Identify all property keys that were externalised as secrets (no-default form):
+```bash
+# Find all bare ${VAR} patterns in named profile files
+grep -rn '\${[A-Z_]*}' --include='application-*.properties' --include='application-*.yml' . | \
+  grep -v ':-' | grep -v ':[^}]' | sed 's/.*\${\([A-Z_]*\)}.*/\1/' | sort -u > /tmp/secret_vars.txt
+```
+
+2. For each variable, check that the base/default profile also uses the no-default form:
+```bash
+while read VAR; do
+  # Check base profile for residual fallback
+  grep -rn "${VAR}" application.properties application.yml 2>/dev/null | grep -E ':-|:[^}]' && \
+    echo "RESIDUAL FALLBACK: ${VAR} has default in base profile"
+done < /tmp/secret_vars.txt
+```
+
+3. Any match with a `:-fallback` or `:fallback` in the base profile is a residual credential exposure — replace with bare `${VAR}`.
+
+**Verification:** Re-run step 2. Zero matches expected.
+
+**Example:**
+```properties
+# BEFORE (base profile — WRONG, has fallback):
+encryption.secret.key=${ENCRYPTION_SECRET_KEY:defaultSecret}
+
+# AFTER (base profile — CORRECT, no fallback):
+encryption.secret.key=${ENCRYPTION_SECRET_KEY}
+```
+
+**Rationale:** Spring Boot loads profile-specific properties that override base properties. But when a named profile is NOT active (e.g., production uses only `application.properties`), the base profile fallback value is used — silently bypassing the intended credential externalisation.
+
+**Source:** https://docs.spring.io/spring-boot/reference/features/profiles.html — "Profile-specific variants of both application.properties and files referenced through @ConfigurationProperties are considered as files and loaded."
+
+## IRSA Configuration
+
+### Trigger Condition
+
+Apply when source contains ANY AWS SDK client instantiation — not just pre-existing credential env reads. **Trigger is SDK client constructor presence, regardless of whether source already reads credential vars.** Trigger list: `boto3.client`, `boto3.resource`, `new S3Client`, `new SQSClient`, `new SNSClient`, `new DynamoDBClient`, `aws-sdk` client builders, `spring-cloud-aws`, `AWSSDK.S3`, `AWSSDK.SQS`, `AWSClientBuilder`.
+
+**Test-file exclusion**: SDK usage appearing ONLY in test files (`*_test.go`, `*.test.js`, `*Test.java`, `test_*.py`) does NOT trigger IRSA.
+
+### Empty-String Guard
+
+AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY MUST be active non-commented empty-string entries in Secret for IRSA. Commented-out YAML keys are invisible to envFrom.
+
+### Credential-Only Field Scope
+
+See §Credential-Only Field Scope Rule (Global) above — this rule applies globally, not just in IRSA contexts.
+
+### Idempotency Check Before Applying
+
+Before applying the IRSA empty-string pattern, check if the code already uses `|| ""` or `|| null` on AWS credential vars. If already-compliant, record as compliant and skip to avoid unnecessary edits.
+
+### Healthcheck.test Co-Update (Form B)
+
+After parameterising any identity env var (POSTGRES_USER, DB_USER, MYSQL_USER) in docker-compose, grep `healthcheck.test` CMD-SHELL entries for the same literal. If found, update to `${VAR:-default}` interpolation:
+```yaml
+# BEFORE:
+healthcheck:
+  test: ["CMD-SHELL", "pg_isready -U admin"]
+# AFTER:
+healthcheck:
+  test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-admin}"]
+```
+
+### Cross-Task Dependency
+
+AWS credential env vars MUST use `process.env.X || ""` or `os.environ.get('X', '')` (NOT requireEnv/ENV.fetch without default) — requireEnv treats empty string as falsy and crashes in IRSA mode where values are intentionally empty.
+
+### SDK kwargs Empty-String Guard
+
+`if key and secret: kwargs.update(...)` — passing any non-None value (including empty string) for credential params prevents SDK provider chain activation.
+
+### ServiceAccount Manifest
+
+When IRSA is triggered, generate a ServiceAccount manifest with `eks.amazonaws.com/role-arn: REPLACE-WITH-ROLE-ARN` annotation and reference it in Deployment `spec.serviceAccountName`. If IRSA triggered in §6, ServiceAccount is in-scope regardless of other scoping rules.
+
+**automountServiceAccountToken reconciliation rule**: Set `automountServiceAccountToken: true` on the ServiceAccount resource (ensures IRSA token projected into the pod) and `automountServiceAccountToken: false` on the Deployment pod spec (prevents default token mount, scopes to IRSA only). While `true` is the Kubernetes default on ServiceAccount, some cluster policies or Pod Security Standards disable it — explicit declaration is required:
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: app-service-account
+  annotations:
+    eks.amazonaws.com/role-arn: "REPLACE-WITH-ROLE-ARN"
+automountServiceAccountToken: true
+```
+
+Deployment pod spec:
+```yaml
+spec:
+  template:
+    spec:
+      serviceAccountName: app-service-account
+      automountServiceAccountToken: false
+      containers:
+      - name: app
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+```
+
+### Co-Located SDK Client Rule
+
+When applying the IRSA conditional guard to any AWS SDK client, grep the same module for ALL other AWS SDK client builders (S3, SES, SNS, SQS, DynamoDB) and apply the same guard to each in the same task — regardless of task file list scope. A partially-guarded module causes credential resolution inconsistency where one client uses IRSA and another attempts static credentials.
+
+**Detection (run after applying guard to any one client):**
+```bash
+grep -rn 'AmazonS3\|AmazonSQS\|AmazonSNS\|AmazonDynamoDB\|AmazonSES\|S3Client\|SqsClient\|SnsClient\|SesClient\|DynamoDbClient' $(dirname <file-just-modified>) --include='*.java' --include='*.py' --include='*.js' --include='*.go' --include='*.php' --include='*.rb'
+```
+
+**Rule:** If additional SDK clients are found in the same module/directory, apply the IRSA empty-string guard to ALL of them before closing the task.
+
+### Secret Key Naming
+
+When activating commented-out AWS credential entries, verify keys are UPPERCASE canonical form — envFrom injects key name verbatim; lowercase stubs must be renamed.
+
+### IAM Policy
+
+Must include s3:ListBucket on bucket ARN (not wildcard /*) alongside s3:PutObject/GetObject/DeleteObject; missing s3:ListBucket causes misleading AccessDenied on non-existent keys.
+
+### Non-Standard Credential Names
+
+Applications may use custom AWS credential env var names (e.g., `S3_KEY`, `STORAGE_KEY`). Grep storage/filesystem config files for ALL credential-like values.
+
+## Secret Classification Guards
+
+1. **DB field separation**: DB_USERNAME, DB_HOST, DB_PORT, DB_DATABASE → always ConfigMap; only DB_PASSWORD, DB_CONNECTION_STRING → Secret.
+2. **Routing keys**: vars ending in `_ROUTING_KEY` (e.g., AMQP RABBITMQ_ROUTING_KEY) are non-credential ConfigMap values.
+3. **Placeholder convention**: ALL values in Secret stringData must use `replace-with-*` placeholder convention.
+   - **Exception A**: IRSA credential vars (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY) use `""` (empty string activates IRSA provider chain).
+   - **Exception B**: Optional override fields where empty string triggers fallback (detect via `grep -E 'if \[ -z "\$\{VAR:-\}" \]'` in entrypoint scripts) use empty string with YAML comment explaining purpose.
+4. **Value-content-supersedes-name rule**: Variables whose VALUES embed credentials (JDBC URLs with `?user=X&password=Y`, connection strings with `:password@` syntax) MUST be classified as Secret regardless of variable name.
+
+## Connection URL Secret Classification
+
+Variables whose names match `*_URL` or `*_DSN` and whose values follow a connection URL scheme MUST be placed in Secret regardless of whether the current dev value contains credentials.
+
+**Covered schemes**: `redis://`, `amqp://`, `mongodb://`, `postgres://`, `mysql://`, `sqlserver://`
+
+**Override rule**: Any `*_URL`/`*_DSN` variable whose value matches one of the covered schemes MUST be classified as Secret per this rule, regardless of task-pattern classification or variable name lacking credential keywords. This rule supersedes any ConfigMap classification made by other heuristics.
+
+**Rationale**: Connection URLs can embed credentials in production; classified as Secret proactively.
+
+**YAML comment template**:
+```yaml
+stringData:
+  REDIS_URL: "replace-with-redis-url"  # URL can embed credentials in production; classified as Secret proactively
+  CELERY_BROKER_URL: "replace-with-broker-url"
+```
+
+**Detection**:
+```bash
+grep -rn '_URL\|_DSN' ENV_VARIABLES.md | grep -iE 'redis|amqp|mongo|postgres|mysql|sqlserver' | grep -i 'ConfigMap'
+# Any match = misclassification — must be Secret
+```
+
+## URL-Embedded Credential Detection (Form F)
+
+**Problem:** Forms A–E catch variable-name-based credential patterns, but connection URLs embedding `user:password@host` are missed when the variable NAME lacks credential keywords (e.g., `CELERY_BROKER_URL`, `DATABASE_URL`, `REDIS_URL`).
+
+**Form F — URL-embedded credentials:**
+```bash
+grep -nE '://[^$][^@]*@' docker-compose*.yml
+```
+
+This catches patterns like:
+- `amqp://guest:guest@rabbitmq:5672/`
+- `redis://:mypassword@redis:6379/0`
+- `postgres://user:pass@db:5432/mydb`
+- `mongodb://admin:secret@mongo:27017/`
+
+**Rule:** Any URL containing `user:password@host` or `:password@host` embeds credentials regardless of variable name. These MUST be externalised — the entire URL goes to Secret (per Connection URL Secret Classification above).
+
+**Form F workflow:**
+1. Run the grep above on all docker-compose*.yml files.
+2. For each match, extract the variable name from context (line above or inline assignment).
+3. Classify the variable as Secret.
+4. Replace the hardcoded URL with a placeholder: `replace-with-<service>-url`.
+
+**Detection of missed URL-embedded credentials (post-transformation check):**
+```bash
+# Verify no URL-embedded credentials remain in source after migration
+grep -rnE '://[a-zA-Z0-9_]+:[a-zA-Z0-9_]+@' src/ config/ --include='*.yml' --include='*.yaml' --include='*.env' --include='*.properties' 2>/dev/null | grep -v 'example\|placeholder\|replace-with'
+# Any match = credential not yet externalised
+```
+
+## Final Literal Sweep (Form G)
+
+**Purpose:** After Forms A–F, catch any remaining bare literals in docker-compose environment sections that were missed by credential-name-based patterns.
+
+**When to run:** After Forms A–F remediation, as the final docker-compose pass.
+
+**YAML-format detection (MANDATORY pre-check):** Before running Form G grep, determine the docker-compose environment format:
+```bash
+# Detect YAML mapping format (KEY: VALUE) vs list format (- KEY=VALUE)
+grep -A2 'environment:' docker-compose*.yml | grep -q '^\s\+[A-Z_]\+:' && echo "MAPPING_FORMAT" || echo "LIST_FORMAT"
+```
+- **List format** (`- KEY=VALUE`): Use Form G grep below.
+- **YAML mapping format** (`KEY: VALUE`): Form G grep does NOT match this format — substitute Form B (docker-compose credential scan from §2) which uses YAML-aware key extraction. Any mapping-format environment section with non-placeholder values is a violation.
+
+**Form G — Final Literal Sweep (list format):**
+```bash
+grep -nE '^\s+-\s+[A-Za-z0-9_]+=\S' docker-compose*.yml | grep -v '\${' | grep -v '^\s*#'
+```
+
+**Additional scan location — healthcheck.test**: docker-compose `healthcheck.test` fields often contain embedded credentials (e.g., `mysql -p<password>`). Scan these separately:
+```bash
+grep -A5 'healthcheck:' docker-compose*.yml | grep -E '(test:|test:.*\[)' | grep -iE '(password|pass|secret|token|key)' | grep -v '\${'
+```
+Any match with a bare literal credential = violation.
+
+**Rule:** Any remaining bare literal assignment (not using `${VAR}` substitution) must be evaluated. Parameterise all hits that are NOT:
+- Boolean flags (`true`, `false`, `0`, `1`, `yes`, `no`)
+- Standard ports (`80`, `443`, `3306`, `5432`, `6379`, `8080`, `9092`, `27017`)
+- Docker-internal hostnames matching service names in the same compose file
+- Composite service:port values (e.g., `kafka:9092`, `redis:6379`) — these are docker-internal references, NOT credentials
+
+**Keyword-extension note**: Variables containing `USERNAME` or `USER` in their names (e.g., `MAIL_USERNAME`, `DB_USER`) require cross-reference against the Non-Credential Classification Table. If the variable is an identity field (not a credential), classify as ConfigMap. If it serves as an authentication credential (e.g., SMTP auth username), classify as Secret. **SMTP_USERNAME rule**: `SMTP_USERNAME`, `MAIL_USERNAME`, and `MAILER_USERNAME` are ALWAYS Secret-classified — they serve as authentication identity for external mail providers.
+
+**Fix-immediately mandate**: Form G and Cross-Profile sweep MUST apply fixes immediately regardless of original task file list. All source/config profile files under `src/main/resources` (or framework equivalent) are in-scope for credential remediation whenever the task touches that module. **Out-of-Scope Findings delegation applies to ALL credential findings regardless of file type.** When a task records Out-of-Scope Findings (docker-compose overlays, source files, config profiles, or any other file containing credential patterns), the orchestrator MUST include those specific file:line violations in the file scope of the next eligible downstream task — either by creating a dedicated follow-up task or appending to the nearest downstream task files list.
+
+**Workflow:**
+1. Run the grep above.
+2. For each match, determine if the value is a boolean/port/service-name (exempt) or a configuration value (must parameterise).
+3. Parameterise non-exempt values as `${VAR_NAME}` with corresponding ENV_VARIABLES.md entry.
+
+**Verification:**
+```bash
+# Re-run after remediation — only exempt values should remain
+grep -nE '^\s+-\s+[A-Za-z0-9_]+=\S' docker-compose*.yml | grep -v '\${' | grep -v '^\s*#' | \
+  grep -vE '=(true|false|0|1|yes|no|80|443|3306|5432|6379|8080|9092|27017)$' | \
+  grep -vE '=[a-z][-a-z0-9]*:[0-9]+$'
+# Expected: zero matches (or only docker-internal hostnames)
+```
+
+## Dotted Secret Key Workaround
+
+**Problem**: Keys containing dots (e.g., `spring.datasource.password`) are silently skipped by `envFrom.secretRef` bulk injection. Kubernetes envFrom injects keys as environment variables, but dots are invalid in env var names on most systems — the key is simply ignored.
+
+**Fix**: Inject dotted-key secrets via explicit `env[].valueFrom.secretKeyRef` with SCREAMING_SNAKE_CASE env var names:
+
+```yaml
+# WRONG — silently skipped:
+envFrom:
+- secretRef:
+    name: app-secret
+# Where app-secret has key: spring.datasource.password
+
+# CORRECT — explicit injection with valid env var name:
+env:
+- name: SPRING_DATASOURCE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: app-secret
+      key: spring.datasource.password
+```
+
+**Detection**:
+```bash
+python3 -c "
+import yaml
+with open('kubernetes/secret.yaml') as f:
+    for doc in yaml.safe_load_all(f):
+        if doc and doc.get('kind') == 'Secret':
+            for k in list(doc.get('stringData', {}).keys()) + list(doc.get('data', {}).keys()):
+                if '.' in k:
+                    print(f'DOTTED KEY: {k} — will be skipped by envFrom')
+"
+```
+
+## Framework-Internal Mandatory Secrets
+
+These MUST always appear in Secret manifest regardless of grep output:
+
+| Framework | Variable | Purpose |
+|-----------|----------|---------|
+| Rails | `SECRET_KEY_BASE` | Cookie signing, session encryption |
+| Django | `SECRET_KEY` | CSRF tokens, session signing |
+| Laravel | `APP_KEY` | Encryption, cookie signing |
+| Spring Boot | `JASYPT_ENCRYPTOR_PASSWORD` | Property encryption (if Jasypt present) |
+| Node.js/Express | `SESSION_SECRET` | Session cookie signing (if express-session) |
+
+**Rule**: Even if the application does not currently read these from env vars (hardcoded or generated), they MUST be externalised to Secret during migration.
+
+## Non-Credential Classification Table
+
+Variables that contain "password", "key", or "secret" substrings in their names but are NOT credentials:
+
+| Category | Examples | Classification | Rationale |
+|----------|----------|---------------|-----------|
+| SMTP auth identity | SMTP_USERNAME, MAIL_USERNAME, MAILER_USERNAME | Secret | Authentication credential for mail providers — always Secret |
+| External-service auth identity | KAFKA_SASL_USERNAME, RABBITMQ_USER, LDAP_BIND_DN | Secret | Username authenticating to EXTERNAL services (Kafka, AMQP, LDAP) — always Secret |
+| Usernames | DB_USERNAME, MYSQL_USER, POSTGRES_USER | ConfigMap | Not secret material |
+| Database names | DB_DATABASE, DB_NAME, MYSQL_DATABASE | ConfigMap | Not secret material |
+| Hostnames | DB_HOST, REDIS_HOST, SMTP_HOST | ConfigMap | Network config, not secret |
+| Ports | DB_PORT, REDIS_PORT, SMTP_PORT | ConfigMap | Numeric config |
+| Boolean flags | *_LOCKED, *_ENABLED, *_ACTIVE | ConfigMap | Feature toggles |
+| Routing keys | *_ROUTING_KEY, *_QUEUE_NAME, *_EXCHANGE_NAME | ConfigMap | AMQP routing labels |
+| Public certificates | JWT_PUBLIC_KEY, TLS_PUBLIC_CERT | ConfigMap | Public by definition |
+
+**Rule**: Only passwords, API keys, tokens, secrets, and connection strings (which may embed credentials) require default removal and Secret classification.
+
+## Post-Form-C .env Gap Fill
+
+**Problem**: After converting docker-compose `${VAR:-literal}` to bare `${VAR}`, running `docker-compose config --quiet` fails if the variable is absent from `.env`. Development environments need placeholder values to remain functional.
+
+**Procedure**: After removing credential defaults (Form C remediation):
+1. Run `docker-compose config --quiet 2>&1 | grep 'variable is not set'`
+2. For each missing variable, add a dev-safe placeholder to `.env.example` (NOT `.env`):
+   ```
+   DB_PASSWORD=replace-with-db-password
+   ```
+3. Document in ENV_VARIABLES.md that `.env.example` contains template values.
+
+**IRSA null-default side-effects**: After applying IRSA empty-string pattern, grep test directories for assertions that check non-empty values of AWS credential vars:
+```bash
+grep -rn 'assertNotEmpty.*AWS\|assertNotNull.*AWS\|expect.*AWS.*not.*empty' tests/ __tests__/ spec/ 2>/dev/null
+```
+If found and tests are out of scope, document as residual item in TRANSFORMATION_SUMMARY.md.
+
+## Read-Before-Write Rule for .env Sanitisation
+
+**Trigger:** Credential sanitisation task (Sub-Phase §7) modifying `.env` or shared config files that were already modified by prior tasks (e.g., session driver, logging channel).
+
+**Problem:** If the credential sanitisation task reads a stale cached version of `.env` (or any shared config file) and writes the full file with placeholder replacements, it silently reverts values correctly set by prior tasks (e.g., `SESSION_DRIVER=redis` reverted to `SESSION_DRIVER=file`, `LOG_CHANNEL=stack` reverted to `LOG_CHANNEL=daily`).
+
+**Rule — read-before-write:** Before sanitising `.env` or any shared config file with credential placeholders:
+1. Read the file's CURRENT contents in full (`cat .env` or `file_read`)
+2. Only replace literal credential values — NEVER revert previously-correct env var values set by prior transformation tasks
+3. Preserve all non-credential values as-is
+
+**Detection of cross-task clobber:**
+```bash
+# After credential sanitisation, verify key values weren't reverted:
+grep -E 'SESSION_DRIVER|LOG_CHANNEL|CACHE_DRIVER|QUEUE_CONNECTION' .env
+# Expected: values from prior tasks (redis, stack, redis, redis) — not original defaults (file, daily, file, sync)
+```
+
+**Prevention pattern:**
+```python
+# Read current state
+content = open('.env').read()
+lines = content.splitlines()
+new_lines = []
+# Only replace lines containing actual credentials
+credential_patterns = ['PASSWORD', 'SECRET', 'KEY', 'TOKEN']
+for line in lines:
+    key = line.split('=')[0] if '=' in line else ''
+    if any(p in key.upper() for p in credential_patterns):
+        # Replace value with placeholder
+        new_lines.append(f"{key}=replace-with-{key.lower()}")
+    else:
+        new_lines.append(line)  # Preserve existing value
+open('.env', 'w').write('\n'.join(new_lines) + '\n')
+```
+
+**Rule:** This is a cross-task hygiene rule applicable to ANY task that modifies shared config files. Always read current disk state before writing — never operate on cached or assumed contents.
+
+## Middleware/Handler Fallback Literal Scan
+
+**Purpose:** After clearing credential fields in config modules, detect hardcoded fallback literals in middleware/handler functions that bypass the config module.
+
+**When to run:** After Forms A–F remediation, as part of the source-code credential scan.
+
+**Problem:** Config-module-level remediation (removing defaults from env() or getenv() in config files) is insufficient when middleware or handler functions have their OWN hardcoded fallback literals that bypass the config module entirely.
+
+**Procedure:**
+```bash
+# Scan application code (not config modules) for hardcoded credential fallbacks
+grep -rn "password\|secret\|api_key\|token" src/ app/ lib/ handlers/ middleware/ --include='*.js' --include='*.ts' --include='*.go' --include='*.py' --include='*.php' --include='*.rb' | \
+  grep -v 'test\|spec\|mock\|node_modules' | \
+  grep -v '^\s*#\|^\s*//' | \
+  grep -E "'\S{4,}'|\"[^\"]{4,}\"|`[^`]{4,}`"
+```
+
+**What to look for:**
+- `|| 'hardcoded-secret'` fallback patterns in handlers
+- `default: 'my-api-key'` in middleware config objects
+- String literals matching credential patterns in auth middleware
+
+**Rule:** After config-module credential remediation, run this scan on ALL non-config source directories. Any match containing a non-placeholder literal (not `replace-with-*`, not empty string) is a credential exposure requiring the same treatment as Form C (config fallback removal).
+
+## npm_* Environment Variable Exclusion
+
+**Purpose:** Filter npm-injected environment variables from `process.env` grep output during credential and env var audits.
+
+**Problem:** Running `node -e 'console.log(Object.keys(process.env))'` or `grep -rn 'process.env' .` captures npm-injected lifecycle variables that are NOT Kubernetes-relevant env vars:
+- `npm_package_version`
+- `npm_lifecycle_event`
+- `npm_package_name`
+- `npm_config_*`
+
+These variables are injected by npm during `npm run` commands and do NOT exist in container runtime.
+
+**Rule:** Exclude ALL `npm_*` prefixed variables from:
+1. ENV_VARIABLES.md (do NOT document them)
+2. ConfigMap/Secret manifests (do NOT include them)
+3. Credential audit results (do NOT flag them)
+
+**Exclusion grep filter:**
+```bash
+grep -rhoP 'process\.env\.([A-Za-z][A-Za-z0-9_]+)' . --include='*.js' --include='*.ts' | \
+  grep -v 'node_modules' | grep -v '^npm_' | sort -u
+```
+
+**Also exclude:** `NODE_ENV` (set by container runtime/Dockerfile, not ConfigMap — document but do NOT add to ConfigMap unless explicitly read for feature switching).
+
+## Multi-Profile Credential Scan
+
+**Purpose:** Detect non-empty credential defaults that survive in profile-specific or module-specific configuration files after primary credential externalisation. Workers typically grep only the primary config file (e.g., `application.properties`) and miss credentials in profile variants (`application-dev.properties`), module-specific resources (`module/src/main/resources/application.yml`), and environment-specific files (`config/environments/production.rb`).
+
+**When to run:** After ANY credential externalisation task (Sub-Phase §7, post-batch) on multi-profile or multi-module projects. Also run at Final Review (§19) as a catch-all.
+
+**Preconditions:** At least one credential has been externalised (bare `${VAR}` or `${VAR:-}` form applied).
+
+**Procedure:**
+
+1. **Scan all config files recursively for credential variables with non-empty defaults:**
+```bash
+grep -rn '\${[A-Z_]*\(KEY\|SECRET\|TOKEN\|PASSWORD\)[A-Z_]*:[^}]*[a-zA-Z0-9]}' \
+  --include='*.properties' --include='*.yml' --include='*.yaml' --include='*.xml' \
+  --include='*.env' --include='*.rb' --include='*.php' . | grep -v 'node_modules\|vendor\|target/'
+```
+
+   **Explanation:** This matches `${VAR_NAME_WITH_CREDENTIAL_KEYWORD:non-empty-default}` across all config file types.
+
+2. **For Spring/Java projects — also scan single-colon defaults (Spring syntax):**
+```bash
+grep -rn '\${[A-Z_]*\(KEY\|SECRET\|TOKEN\|PASSWORD\)[A-Z_]*:[^-][^}]*}' \
+  --include='*.properties' --include='*.yml' --include='*.yaml' . | grep -v 'target/'
+```
+
+   This catches `${DB_PASSWORD:mysecret}` (Spring single-colon default syntax).
+
+3. **For Ruby/Rails projects — scan ENV.fetch with fallback:**
+```bash
+grep -rn "ENV.fetch(['\"][A-Z_]*\(KEY\|SECRET\|TOKEN\|PASSWORD\)" \
+  --include='*.rb' . | grep -v 'spec/\|test/'
+```
+
+4. **Evaluate each match:**
+   - If the default value is a real credential (non-placeholder, non-empty, not `replace-with-*`): **violation** — replace with bare `${VAR}` or `${VAR:-}`.
+   - If the default value is already a placeholder (`replace-with-*`): acceptable.
+   - If the default is empty string (`:-}`): acceptable.
+
+5. **Fix violations:** Replace non-empty credential defaults with bare `${VAR}` or `${VAR:-}` (see §13 Nounset-Safe Credential Default Removal for choosing between these forms).
+
+**Verification:** Re-run step 1. Zero matches with real (non-placeholder) credential defaults expected.
+
+**Idempotence:** Running the scan on already-clean files returns zero matches and requires no action.
+
+**Classification update:** Any credential field found with `USERNAME` or `USER` in name that serves as an authentication identity (e.g., `SMTP_USERNAME`, `MAIL_USERNAME`) MUST be classified as Secret, not ConfigMap. Authentication identity fields grant access to external services and are secret material.
+
+---
+
+## MIGRATION Comment Authoring Rule
+
+**Purpose:** Prevent MIGRATION comments from re-triggering credential sweep grep assertions by quoting removed literal values.
+
+**Rule:** MIGRATION comments MUST NOT quote removed literal credential values — use generic functional description instead. Quoting the literal re-embeds a formerly-live key and re-triggers grep assertions that check for credential patterns.
+
+**Before (WRONG — re-triggers grep):**
+```java
+// MIGRATION: Removed hardcoded password "superSecret123" from connection string
+```
+
+**After (CORRECT — functional description):**
+```java
+// MIGRATION: Hardcoded insecure default removed; now sourced from Secret via env var
+```
+
+**Rule applies to:** All languages. When describing pre-migration state in code comments, never reproduce the removed literal. Use descriptions like "Hardcoded default removed", "Inline credential externalised", "Literal connection string replaced with env var".
+
+## Form G Recursive-From-Root Mandate
+
+**Rule:** Form G Final Literal Sweep MUST use recursive-from-root grep (`grep -rn` from the project root or `src/main/resources/` equivalent), NEVER named-directory enumeration. Named enumeration silently misses unlisted profiles, modules, and config variants.
+
+**Correct:**
+```bash
+grep -rn '\${[A-Z_]*(PASSWORD|SECRET|KEY|TOKEN)[A-Z_]*:-[a-zA-Z0-9]' \
+  --include='*.properties' --include='*.yml' --include='*.yaml' --include='*.xml' . | \
+  grep -v 'node_modules\|vendor\|target/'
+```
+
+**Wrong — named directory enumeration misses unlisted profiles:**
+```bash
+# WRONG: Only checks known directories
+grep -n 'PASSWORD' src/main/resources/application.properties src/main/resources/application-dev.properties
+# Misses: application-cloud.properties, application-mysql.properties, module-b/src/main/resources/...
+```
+
+## Nounset-Safe Credential Default Removal
+
+**Purpose:** When removing hardcoded credential defaults from shell scripts, ensure the replacement form is compatible with the script's error handling mode. Bare `${VAR}` (no default) crashes containers that use `set -u` (nounset), causing CrashLoopBackOff on startup when the variable is unset.
+
+**When to run:** During credential remediation (Sub-Phase §7) — specifically when modifying entrypoint or startup shell scripts. Also applies when modifying any shell script referenced by a Dockerfile CMD or ENTRYPOINT.
+
+**Preconditions:** The script being modified is an entrypoint/startup script that runs in the container at boot time.
+
+**Procedure:**
+
+1. **Detect nounset mode in the target script:**
+```bash
+grep -E '(set -[aeioux]*u|set -o nounset)' entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null
+```
+
+   Also check the shebang line:
+```bash
+head -1 entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null | grep -E '(bash|sh) -[a-z]*u'
+```
+
+   If either grep returns a match → nounset is active → use `${VAR:-}` form.
+
+2. **Choose the correct replacement form:**
+
+   | Nounset active? | Correct form | Incorrect form (causes crash) |
+   |-----------------|-------------|-------------------------------|
+   | Yes (`set -u`) | `${VAR:-}` (empty default) | `${VAR}` (bare — crashes) |
+   | No | `${VAR}` (bare) or `${VAR:-}` | Either works |
+
+   **Rule:** When in doubt, always use `${VAR:-}` — it is safe in all contexts.
+
+3. **Apply the transformation:**
+
+   **BEFORE** (hardcoded credential default):
+   ```bash
+   DB_PASSWORD=${DB_PASSWORD:-superSecretPassword123}
+   REDIS_AUTH=${REDIS_AUTH:-myRedisToken}
+   ```
+
+   **WRONG** (bare removal — crashes with `set -u`):
+   ```bash
+   DB_PASSWORD=${DB_PASSWORD}
+   REDIS_AUTH=${REDIS_AUTH}
+   ```
+
+   **CORRECT** (empty-default removal — safe with `set -u`):
+   ```bash
+   DB_PASSWORD=${DB_PASSWORD:-}
+   REDIS_AUTH=${REDIS_AUTH:-}
+   ```
+
+4. **For complex expansion patterns** (`${VAR:+...}` conditional), preserve the expansion operator and only remove the literal:
+   ```bash
+   # BEFORE:
+   EXTRA_OPTS="${DB_PASSWORD:+--password=secretval}"
+   # CORRECT:
+   EXTRA_OPTS="${DB_PASSWORD:+--password=${DB_PASSWORD:-}}"
+   ```
+
+**Verification:**
+
+1. Confirm no hardcoded credential literals remain:
+```bash
+grep -E '\$\{[A-Z_]*(PASSWORD|SECRET|KEY|TOKEN)[A-Z_]*:-[a-zA-Z0-9]' \
+  entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null
+```
+   Expected: zero matches (only `:-}` empty defaults should remain).
+
+2. If nounset is active, confirm no bare credential references:
+```bash
+grep -E '\$\{[A-Z_]*(PASSWORD|SECRET|KEY|TOKEN)[A-Z_]*\}' \
+  entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null | grep -v ':-'
+```
+   Expected: zero matches (all credential vars use `:-` form).
+
+**Idempotence:** Running the verification on already-fixed scripts returns zero matches and requires no action.
+
+**Rationale:** `set -u` (aka `set -o nounset`) causes bash to exit immediately with "unbound variable" when any unset variable is referenced. In Kubernetes, this manifests as CrashLoopBackOff when a Secret is not yet mounted or when an optional credential env var is deliberately empty (e.g., IRSA mode with empty AWS_ACCESS_KEY_ID). The `${VAR:-}` form provides an empty string default, satisfying nounset while still allowing the Kubernetes Secret to inject the real value.
+
+**Critical CrashLoopBackOff pattern**: If a container enters CrashLoopBackOff immediately after credential externalisation and the entrypoint uses `set -u` or `set -euo pipefail`, the root cause is almost always a bare `${VAR}` reference where `${VAR:-}` is needed. Check entrypoint nounset mode FIRST when debugging post-migration startup failures.
+
+---
+
+## IRSA Empty-String Guard (Cross-Language)
+
+**Purpose:** AWS SDKs require specific handling when IRSA (IAM Roles for Service Accounts) is active — credential env vars must be present but empty, and application code must guard against passing empty strings to SDK constructors.
+
+**Rule:** The Secret MUST declare `AWS_ACCESS_KEY_ID: ""` and `AWS_SECRET_ACCESS_KEY: ""` (empty-string values, not absent keys). SDK-specific guard patterns prevent the empty strings from being passed as explicit credentials, allowing the SDK provider chain to fall through to IRSA.
+
+### Per-Language Guard Patterns
+
+**PHP:**
+```php
+$key = env('AWS_ACCESS_KEY_ID');
+$secret = env('AWS_SECRET_ACCESS_KEY');
+if ($key && $secret) {
+    $config['credentials'] = ['key' => $key, 'secret' => $secret];
+}
+```
+
+**Java (AWS SDK v1):**
+```java
+String accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+String secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
+    .withRegion(System.getenv("AWS_DEFAULT_REGION"));
+if (!StringUtils.isBlank(accessKey) && !StringUtils.isBlank(secretKey)) {
+    builder.withCredentials(new AWSStaticCredentialsProvider(
+        new BasicAWSCredentials(accessKey, secretKey)));
+}
+// When both blank, builder uses DefaultAWSCredentialsProviderChain (IRSA)
+return builder.build();
+```
+
+**Java (AWS SDK v2):**
+```java
+S3ClientBuilder builder = S3Client.builder()
+    .region(Region.of(System.getenv("AWS_DEFAULT_REGION")));
+String accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+String secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+if (accessKey != null && !accessKey.isBlank() && secretKey != null && !secretKey.isBlank()) {
+    builder.credentialsProvider(StaticCredentialsProvider.create(
+        AwsBasicCredentials.create(accessKey, secretKey)));
+}
+return builder.build();
+```
+
+**Python:**
+```python
+import os
+access_key = os.getenv("AWS_ACCESS_KEY_ID", "")
+secret_key = os.getenv("AWS_SECRET_ACCESS_KEY", "")
+kwargs = {"region_name": os.getenv("AWS_DEFAULT_REGION", "us-east-1")}
+if access_key and secret_key:
+    kwargs["aws_access_key_id"] = access_key
+    kwargs["aws_secret_access_key"] = secret_key
+# When both empty, boto3 uses default provider chain (IRSA)
+client = boto3.client("s3", **kwargs)
+```
+
+**Node.js:**
+```javascript
+const config = { region: process.env.AWS_REGION || 'us-east-1' };
+const accessKey = process.env.AWS_ACCESS_KEY_ID || undefined;
+const secretKey = process.env.AWS_SECRET_ACCESS_KEY || undefined;
+if (accessKey && secretKey) {
+    config.credentials = { accessKeyId: accessKey, secretAccessKey: secretKey };
+}
+const s3 = new S3Client(config);
+```
+
+**Go:**
+```go
+accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+var opts []func(*config.LoadOptions) error
+if accessKey != "" && secretKey != "" {
+    opts = append(opts, config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")))
+}
+cfg, _ := config.LoadDefaultConfig(ctx, opts...)
+```
+
+### Critical Rules
+
+1. AWS SDK v1 (Java) `EnvironmentVariableCredentialsProvider` throws on empty-string credentials — do NOT call `builder.withCredentials()` when both keys are blank.
+2. The `|| undefined` pattern in Node.js converts empty string to undefined, preventing SDK from treating empty strings as explicit credentials.
+3. Python `os.getenv("X", "")` returns empty string (falsy in Python) — the `if access_key and secret_key:` guard prevents passing empty strings to boto3.
+4. PHP `env()` with no second argument returns null for unset vars — use `if ($key && $secret)` which rejects both null and empty string.
+
+**Source:** AWS SDK for Java 1.x EnvironmentVariableCredentialsProvider loads credentials from AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables — https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.html
+
+---
+
+## SSL Suffix Classification Rule
+
+**Purpose:** Classify variables with SSL-related suffixes correctly as Secret or ConfigMap.
+
+| Suffix | Content Type | Classification | Rationale |
+|--------|-------------|---------------|-----------|
+| `_KEY` (when SSL context) | Private key PEM | Secret | Private key material |
+| `_CERT` | Client certificate | Secret | Authentication material |
+| `_CA` / `_CA_CERT` | CA certificate (public) | ConfigMap | Public trust anchor |
+| `_KEYSTORE_PASSWORD` | Keystore unlock | Secret | Credential |
+| `_TRUSTSTORE_PATH` | File path | ConfigMap | Non-secret path |
+
+**Detection:**
+```bash
+grep -rn '_KEY\|_CERT\|_CA\|_SSL\|_TLS' ENV_VARIABLES.md | grep -i 'ConfigMap' | grep -ivE '_CA[^_]|_CA$'
+# Any _KEY or _CERT match classified as ConfigMap = potential misclassification
+```
+
+**Rule:** When variable names end in `_KEY` and the context is SSL/TLS (determined by adjacent `_CERT` or `_CA` variables, or by the variable description mentioning PEM/certificate), classify as Secret. The generic `_KEY` suffix heuristic (which triggers credential scan) is CORRECT for SSL keys — they are private material.
+
+---
+
+## Colon-Delimited Connection String Classification
+
+**Purpose:** Variables whose values use colon-delimited or URL-format connection strings that can embed credentials must be classified as Secret.
+
+**Covered patterns:**
+- `HOST:PORT:DB:USER:PASSWORD` (PostgreSQL `.pgpass` format)
+- `redis://[:password@]host:port/db`
+- `amqp://user:pass@host:port/vhost`
+- Semicolon-delimited: `Server=host;Database=db;User=u;Password=p`
+
+**Variables that ALWAYS require Secret classification (regardless of current value):**
+
+| Variable Pattern | Reason |
+|-----------------|--------|
+| `REDIS_SERVERS`, `REDIS_URL` | Can embed `:password@` |
+| `DATABASE_URL`, `DB_URL` | Can embed `user:password@` |
+| `MONGO_URI`, `MONGODB_URL` | Can embed credentials |
+| `RABBITMQ_URL`, `AMQP_URL` | Can embed `user:pass@` |
+| `CELERY_BROKER_URL` | Wraps AMQP/Redis URL |
+| `*_CONNECTION_STRING` | Semicolon format embeds Password= |
+
+**Detection:**
+```bash
+grep -iE '(REDIS_SERVERS|DATABASE_URL|DB_URL|MONGO_URI|MONGODB_URL|RABBITMQ_URL|AMQP_URL|CELERY_BROKER_URL|_CONNECTION_STRING)' ENV_VARIABLES.md | grep -i 'ConfigMap'
+# Any match = misclassification — must be Secret
+```
+
+**Rule:** Any variable whose value CAN embed credentials in production (even if the current dev value does not) MUST be classified as Secret. This supersedes name-based heuristics that might place these in ConfigMap.
+
+---
+
+## DB Root/Admin Credential Scope Exclusion
+
+**Purpose:** Database root/admin credentials (used for database initialisation, backup, schema creation) MUST NOT appear in the application pod's `envFrom` Secret. They belong in a separate Secret consumed only by the database service or migration Job.
+
+**Rule:** When `DB_ROOT_PASSWORD`, `MYSQL_ROOT_PASSWORD`, `POSTGRES_SUPERUSER_PASSWORD`, or similar admin-level credentials are discovered:
+1. Classify as Secret (correct)
+2. Place in a SEPARATE Secret manifest (e.g., `db-admin-secret.yaml`)
+3. Reference ONLY from database StatefulSet/Deployment or migration Job — NOT from the application Deployment's `envFrom`
+4. Document separation in ENV_VARIABLES.md with note: "Admin-only — not consumed by application pods"
+
+---
+
+## Compound Shebang Nounset Detection
+
+**Purpose:** Standard nounset detection (`grep -E 'set -[aeioux]*u'`) misses compound shebang flags like `#!/bin/bash -aeu` where nounset (`u`) is embedded in the shebang line flags.
+
+**Two-step detection procedure (BOTH steps REQUIRED):**
+
+```bash
+# Step 1: Body check — catches set -u, set -eu, set -euo pipefail, set -o nounset
+grep -E '(set -[aeioux]*u|set -o nounset)' entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null
+
+# Step 2: Shebang check — catches #!/bin/bash -aeu, #!/bin/bash -eu, etc.
+head -1 entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null | grep -E '(bash|sh) -[a-z]*u'
+```
+
+**Rule:** If EITHER step matches, all credential vars in that script must use `${VAR:-}` form (not bare `${VAR}`). The shebang `-aeu` flag activates nounset for the entire script without any `set` command in the body.
+
+## Placeholder String IRSA Block
+
+**Purpose:** Detect literal placeholder strings used as `env()`/`getenv()`/`System.getenv()` fallback arguments that prevent AWS/GCP SDK default credential provider chains from activating. When a non-empty literal (e.g., `your-key`, `YOUR_KEY`, `placeholder`, `changeme`) is passed as the fallback, the SDK receives that literal as a credential value and never falls through to IRSA/Workload Identity.
+
+**Detection:**
+```bash
+# Scan for common placeholder patterns as fallback arguments
+grep -rnE "(getenv|env|System\.getenv)\(['\"][A-Z_]*(KEY|SECRET|TOKEN)['\"],?\s*['\"]*(your-|YOUR_|placeholder|changeme|replace)" \
+  . --include='*.php' --include='*.java' --include='*.py' --include='*.js' --include='*.go' | grep -v 'vendor\|node_modules\|target/'
+```
+
+**Examples of IRSA-blocking placeholders:**
+```php
+// WRONG — literal placeholder blocks IRSA provider chain:
+$key = env('AWS_ACCESS_KEY_ID', 'your-access-key-id');
+$secret = env('AWS_SECRET_ACCESS_KEY', 'your-secret-access-key');
+
+// CORRECT — null/empty allows IRSA fallback:
+$key = env('AWS_ACCESS_KEY_ID');
+$secret = env('AWS_SECRET_ACCESS_KEY');
+```
+
+**Rule:** Any `env()`/`getenv()`/`System.getenv()` call for AWS/GCP credential fields that passes a non-empty literal string as the default value is an IRSA blocker. Replace with null/empty-string default (see per-language IRSA guard patterns in §IRSA Empty-String Guard).

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/docker-build-validation.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/docker-build-validation.md
@@ -1,0 +1,858 @@
+# Docker Build Validation
+
+## Purpose
+
+Validates that generated Dockerfiles produce runnable container images before any Kubernetes-level validation. Docker build tests fundamentally different things from kubeconform — it verifies COPY paths, package installs, compilation, user creation, and entrypoint execution. It is NOT a substitute for kubeconform (YAML schema), nor vice versa.
+
+## When to Run
+
+**Sub-Phase §17b** — after Dockerfile generation (§17), before Minikube/cluster validation (§18). This is Validation Tier 1.
+
+## Preconditions
+
+- Dockerfiles exist for all workloads in the Minimal Execution Set.
+- Source code is present in the transformation directory.
+- Docker daemon is accessible (`docker info` exits 0).
+
+## Procedure
+
+### Step 0: Native Compilation Verification (compiled languages only)
+
+**Purpose:** For compiled languages, the language-native build tool MUST be invoked and exit 0 on the host BEFORE `docker build` is attempted. This verifies that the source code compiles correctly and the resulting artifact exists at the path the Dockerfile's COPY instruction expects. Compiling at container runtime is prohibited.
+
+**When to run:** Before Step 0b (Interpreted Language Validation). This step applies to compiled languages only (Java, Go, C#, Rust, TypeScript). For interpreted languages, see Step 0b below.
+
+**Detection — determine if project requires host-side compilation:**
+
+| Build file present | Language | Compile required? |
+|---|---|---|
+| `pom.xml` | Java (Maven) | YES |
+| `build.gradle` / `build.gradle.kts` | Java (Gradle) | YES |
+| `go.mod` | Go | YES |
+| `.csproj` / `.sln` | C# / .NET | YES |
+| `Cargo.toml` | Rust | YES |
+| `package.json` with `"build"` script | TypeScript / Node.js | YES |
+| `composer.json` (PHP) | PHP | NO |
+| `requirements.txt` / `pyproject.toml` | Python | NO |
+| `Gemfile` | Ruby | NO |
+
+**Per-language compilation commands:**
+
+| Language | Command | Expected artifact path |
+|---|---|---|
+| Java (Maven) | `mvn package -DskipTests -B -q` | `target/*.jar` or `target/*.war` |
+| Java (Gradle) | `./gradlew build -x test --no-daemon` | `build/libs/*.jar` |
+| Go | `go build ./...` | Binary in current directory or `./cmd/*/` |
+| C# / .NET | `dotnet publish -c Release` | `bin/Release/net*/publish/` |
+| Rust | `cargo build --release` | `target/release/<binary>` |
+| Node.js/TS (build script) | `npm ci && npm run build` | `dist/` or `build/` directory |
+
+**Procedure:**
+
+1. **Detect project type** from build files present in repository root.
+
+2. **Check toolchain availability and version match:**
+   ```bash
+   # Java: verify JDK version matches project requirement
+   java -version 2>&1 | head -1
+   grep -oP '(?:java\.version|maven\.compiler\.source|maven\.compiler\.target|release)>\K[^<]+' pom.xml 2>/dev/null | head -1
+
+   # Go: verify go version >= go.mod directive
+   go version
+   grep '^go ' go.mod
+
+   # .NET: verify SDK version
+   dotnet --version
+
+   # Node.js: verify node version
+   node --version
+   ```
+
+3. **Run the compilation command:**
+   ```bash
+   # Example: Java/Maven
+   mvn package -DskipTests -B -q 2>&1 | tee /tmp/compile.log
+   COMPILE_EXIT=${PIPESTATUS[0]}
+   ```
+
+4. **Assert exit 0:**
+   ```bash
+   [ "$COMPILE_EXIT" -eq 0 ] && echo "COMPILATION OK" || echo "COMPILATION FAILED (exit $COMPILE_EXIT)"
+   ```
+
+5. **Verify artifact exists at expected Dockerfile COPY path:**
+   ```bash
+   # Java/Maven:
+   ls target/*.jar target/*.war 2>/dev/null | head -1 || echo "ARTIFACT MISSING"
+
+   # Java/Gradle:
+   ls build/libs/*.jar 2>/dev/null | head -1 || echo "ARTIFACT MISSING"
+
+   # Go (check binary was produced):
+   ls <expected-binary-path> 2>/dev/null || echo "ARTIFACT MISSING"
+
+   # .NET:
+   ls bin/Release/net*/publish/ 2>/dev/null || echo "ARTIFACT MISSING"
+
+   # Node.js/TS:
+   ls dist/ build/ 2>/dev/null || echo "ARTIFACT MISSING"
+   ```
+
+6. **Connection to Docker:** The Dockerfile COPY instruction references the artifact produced by this step. If artifact is absent, Docker build fails at COPY with `file not found`.
+
+**Failure handling:**
+
+| Failure type | Action |
+|---|---|
+| Toolchain not installed | Attempt `mise install <lang>@<version>`. If mise absent or install fails → record `CONDITIONAL PASS` with: "Toolchain unavailable — cannot verify compilation" |
+| Version mismatch (e.g., JDK 8 required, JDK 21 installed) | Attempt `mise install java@corretto-<required-version>` and retry. If mise absent or install fails → record `CONDITIONAL PASS` with: "JDK version mismatch — project requires X, host has Y" |
+| Compilation error (code bug) | FAIL — fix source before proceeding to Docker build |
+| Network timeout (dependency download) | Retry once. If still fails, record `CONDITIONAL PASS` with root cause |
+
+**Repeat-failure escalation:** If the native compile step fails in 2+ tasks for the same environmental reason (e.g., JDK version mismatch), the overall Criterion 13 result MUST be `CONDITIONAL PASS` — not `PASS`. Document root cause and affected tasks in the Three-Tier Validation table.
+
+**Multi-stage Dockerfile note:** Multi-stage Dockerfiles that compile inside the builder stage (e.g., `FROM maven:3.9 AS builder ... RUN mvn package`) are acceptable for image correctness. However, the host-side Step 0 verification gate is ALWAYS attempted first — it catches compilation errors early (before a potentially slow Docker build) and provides faster feedback. The sequence is always: (1) host-side compile/validate → (2) docker build. The host-side gate is only recorded as CONDITIONAL PASS when the required toolchain is unavailable and `mise install` fails.
+
+**Idempotence:** Running Step 0 twice produces the same artifact (build tools are idempotent for unchanged source). The second run is typically a no-op due to build caching.
+
+**pom.xml invariant check (Java only):** Before running `mvn package`, verify pom.xml is well-formed: `xmllint --noout pom.xml`. A malformed POM causes a cryptic Maven error unrelated to the actual compilation.
+
+
+
+### Step 0b: Interpreted Language Validation Gate
+
+**Purpose:** For interpreted languages, run language-native syntax checks, dependency resolution, and import verification on the host BEFORE `docker build`. This catches errors faster than waiting for a Docker build to fail.
+
+**When to run:** Before Step 1 (Docker Availability Check). This step applies to ALL projects with interpreted languages — multi-stage Dockerfiles do NOT exempt it.
+
+**Detection — determine if project requires host-side validation:**
+
+| Build file present | Language | Validation type |
+|---|---|---|
+| `composer.json` | PHP | VALIDATE |
+| `requirements.txt` / `pyproject.toml` / `Pipfile` | Python | VALIDATE |
+| `Gemfile` | Ruby | VALIDATE |
+| `package.json` (NO `build` script) | Node.js | VALIDATE |
+
+**Per-language validation commands:**
+
+| Language | Commands | Expected result |
+|---|---|---|
+| PHP | `find . -name '*.php' -not -path '*/vendor/*' \| xargs -P4 php -l 2>&1 \| grep -v 'No syntax errors'` | Empty output (no errors) |
+| PHP | `composer validate --no-check-publish 2>&1` | Exit 0 |
+| Python | `find . -name '*.py' -not -path '*/.venv/*' -not -path '*/site-packages/*' \| xargs python3 -m py_compile 2>&1` | Empty output (no errors) |
+| Python | `pip install -r requirements.txt --dry-run 2>&1` (if pip available) | Exit 0 |
+| Ruby | `find . -name '*.rb' -not -path '*/vendor/*' \| xargs ruby -c 2>&1 \| grep -v 'Syntax OK'` | Empty output |
+| Ruby | `bundle check` | Exit 0 (deps satisfied) |
+| Node.js | `node --check <entry-point.js>` | Exit 0 |
+| Node.js | `npm ci --dry-run 2>&1` (if package-lock.json present) | Exit 0 |
+
+**Procedure:**
+
+1. **Detect project type** from build files in repository root.
+2. **Check interpreter availability:**
+   ```bash
+   command -v php && php --version
+   command -v python3 && python3 --version
+   command -v ruby && ruby --version
+   command -v node && node --version
+   ```
+3. **If interpreter absent — attempt mise install:**
+   ```bash
+   command -v mise && mise install 2>/dev/null
+   ```
+   If mise installs the interpreter, retry. If mise is absent or fails, record CONDITIONAL PASS.
+
+4. **Run the validation commands** (see per-language table above).
+
+5. **Assert exit 0 / empty error output.** Any syntax error or unresolved dependency = FAIL.
+
+**Failure handling:**
+
+| Failure type | Action |
+|---|---|
+| Interpreter not installed, mise absent/fails | Record `CONDITIONAL PASS` with: "Interpreter unavailable — cannot verify syntax" |
+| Version mismatch (e.g., Python 3.12 required, 3.9 installed) | Attempt `mise install python@<version>`. If fails, record `CONDITIONAL PASS` |
+| Syntax error in source code | FAIL — fix source before proceeding to Docker build |
+| Dependency resolution failure (missing package) | FAIL — fix dependencies before Docker build |
+| Network timeout during dependency download | Retry once. If still fails, record `CONDITIONAL PASS` |
+
+**Idempotence:** Running Step 0b twice produces the same result — syntax checks and dry-run installs are read-only operations.
+
+**Relationship to Step 0:** Step 0 (compiled languages) and Step 0b (interpreted languages) are mutually exclusive per language — a project uses one or the other. For mixed-language projects (e.g., PHP + TypeScript asset build), BOTH steps apply to their respective languages.
+
+### Step 1: Docker Availability Check
+
+```bash
+docker info > /dev/null 2>&1 && echo "DOCKER_AVAILABLE=true" || echo "DOCKER_AVAILABLE=false"
+```
+
+If Docker is unavailable, log an explicit warning:
+```
+WARNING: Docker not available — Tier 1 validation (docker build + smoke test) skipped.
+Unverifiable assertions: COPY source paths, package install success, compilation,
+entrypoint execution, non-root user creation. Proceeding to Tier 2 (kubeconform).
+```
+Then execute the **Static Verification Checklist** below, set build status to `SKIPPED`, and proceed to Tier 2. Do NOT attempt workarounds.
+
+### Step 2: Docker Build (mandatory exit 0)
+
+For each Dockerfile in the Minimal Execution Set:
+
+```bash
+# Single-stage or final-stage build
+docker build -t <app-name>:local -f <Dockerfile-path> <build-context>
+
+# Multi-stage with named target
+docker build -t <app-name>:local --target <stage-name> -f <Dockerfile-path> <build-context>
+```
+
+**Exit 0 is mandatory.** If build fails, fix the Dockerfile before any further validation.
+
+**Multi-module projects** (Java/Maven): Build context must be the project root:
+```bash
+docker build -t app:local -f submodule/Dockerfile .
+```
+
+### Step 3: Smoke Test (optional but recommended)
+
+After successful build, verify the entrypoint starts without immediate crash:
+
+```bash
+docker run --rm -d --name smoke-test <app-name>:local
+sleep 5
+docker logs smoke-test 2>&1 | tail -20
+docker inspect smoke-test --format='{{.State.Status}}'  # must be "running"
+docker stop smoke-test
+```
+
+**Per-stack quick verification commands** (alternative to full startup):
+
+| Stack | Smoke Command | Expected |
+|-------|--------------|----------|
+| Node.js | `docker run --rm <app>:local node -e 'process.exit(0)'` | Exit 0 |
+| PHP | `docker run --rm <app>:local php -v` | Exit 0, version printed |
+| Go | `docker run --rm <app>:local /app/<binary> --version` (or `--help`) | Exit 0 or 2 |
+| Java/Spring | `docker run --rm <app>:local java -jar /app/app.jar --help` | Exit 0 or 1 (Spring help) |
+| Python | `docker run --rm <app>:local python -c 'import app; print("OK")'` | Exit 0 |
+| Ruby/Rails | `docker run --rm <app>:local ruby -e 'puts "OK"'` | Exit 0 |
+| nginx | `docker run --rm <app>:local nginx -t` | "syntax is ok" |
+
+**Note:** Full application startup may require database/Redis connectivity. The smoke test verifies the image is runnable, not that all backing services connect. Connection errors in logs are acceptable at this stage — crash loops or missing binaries are NOT.
+
+### Step 4: Health Probe Path Verification (web services only)
+
+For web services with HTTP probes configured:
+
+```bash
+docker run --rm -d -p 8080:8080 --name probe-test <app-name>:local
+sleep 10
+curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/healthz
+# Expected: 200 (or configured probe path)
+docker stop probe-test
+```
+
+If probe returns 4xx/5xx due to missing backing services, this is acceptable IF the container itself started (did not crash). Document as: "Probe path requires backing service — verified in Tier 3 (cluster validation)."
+
+## Common Failure Patterns and Fixes
+
+| Failure | Cause | Fix |
+|---------|-------|-----|
+| `COPY failed: file not found` | Wrong build context or path | Adjust `-f` and context; verify file exists relative to context root |
+| `apt-get: package not found` | Wrong base image or package name | Check base image OS (Alpine vs Debian); use correct package manager |
+| `Permission denied` on COPY --chown | USER directive before group/user creation | Move `RUN useradd/adduser` BEFORE `COPY --chown` |
+| `exec format error` | Architecture mismatch (ARM vs x86) | Use `--platform linux/amd64` or matching base image |
+| Go build fails: missing module | go.sum not copied | Add `COPY go.sum .` before `RUN go mod download` |
+| Ruby `KeyError: key not found: "SECRET_KEY_BASE"` | `ENV.fetch` without default during asset precompile | Add dummy env vars to RUN line (see ruby-rails-patterns.md) |
+| npm ERR! missing workspace | Monorepo workspace not copied | Copy all workspace directories before `npm install` |
+
+## Ruby-Specific: ENV.fetch Audit Before Build
+
+Before running `docker build` on a Rails application:
+
+```bash
+# Find bare ENV.fetch calls (no second argument = KeyError if missing)
+grep -rn 'ENV\.fetch' config/ app/ lib/ --include='*.rb' | grep -v 'ENV\.fetch([^,]*,'
+```
+
+Each hit in class-level code or config/ERB that runs at build time (asset precompile) requires a dummy var in the Dockerfile RUN line:
+
+```dockerfile
+RUN SECRET_KEY_BASE=dummy RAILS_ENV=production \
+    bundle exec rake assets:precompile
+```
+
+## Multi-Stage COPY Exemption
+
+**Rule:** For each `COPY` instruction in a Dockerfile, check whether it contains `--from=`. If yes, skip host-path existence check entirely — the source path references a build-stage artifact or external image layer that does NOT exist on the local filesystem.
+
+**Detection — filter to only host-filesystem COPYs requiring path validation:**
+```bash
+# List COPY instructions that reference LOCAL paths (require validation)
+grep -v '^\s*#' Dockerfile | grep -P '^COPY(?!\s+--from)' | grep -v '\-\-from='
+
+# List COPY instructions from build stages (NO validation needed)
+grep -v '^\s*#' Dockerfile | grep '^COPY' | grep '\-\-from='
+```
+
+**Procedure:**
+1. For each COPY line WITHOUT `--from=`: verify the source path exists relative to the build context root.
+2. For each COPY line WITH `--from=<stage|image>`: document as EXPECTED — no path validation needed. These reference artifacts produced during earlier build stages or pulled from external images.
+
+**Example:**
+```dockerfile
+# Stage 1: build
+FROM golang:1.22 AS builder
+COPY go.mod go.sum ./          # ← VALIDATE: go.mod, go.sum must exist in build context
+RUN go build -o /app/server
+
+# Stage 2: runtime
+FROM gcr.io/distroless/static
+COPY --from=builder /app/server /app/server  # ← EXEMPT: references builder stage artifact
+```
+
+**Static Verification Checklist integration:** When Docker is unavailable (Point 1 of the static checklist), apply this exemption before reporting MISSING COPY SOURCE errors. Only non-`--from=` COPY paths are validated.
+
+## Verification
+
+After all builds pass:
+```bash
+docker images | grep ':local'
+# Each image in Minimal Execution Set should appear
+```
+
+**Idempotence check:** Running `docker build` again produces a cached result (exit 0, no layer rebuild unless source changed).
+
+## Static Verification Checklist (Tier 1 Unavailable)
+
+When Docker is NOT available, the worker MUST execute this five-point mandatory static checklist as a substitute for the actual build. This does NOT grant `PASSED` status — build remains `SKIPPED`.
+
+### Point 1: Verify COPY Source Paths Exist
+
+For every `COPY` instruction in each Dockerfile **that does NOT contain `--from=`**, confirm ALL source paths exist on disk. Multi-token COPY instructions (e.g., `COPY file1 file2 dir/ /dest/`) have multiple source tokens — validate ALL except the last (which is the destination):
+
+```bash
+# Extract COPY source paths (skip --from= lines, handle multi-token COPY, strip flags)
+grep -v '^\s*#' Dockerfile | grep '^COPY' | grep -v '\-\-from=' | sed 's/COPY\s*//' | sed 's/--[^ ]* //g' | while read line; do
+  # Split into tokens; all except last are sources
+  tokens=($line)
+  for ((i=0; i<${#tokens[@]}-1; i++)); do
+    src="${tokens[$i]}"
+    if [ ! -e "$src" ] && ! echo "$src" | grep -q '\*'; then
+      echo "MISSING COPY SOURCE: $src"
+    fi
+  done
+done
+# Output should be empty — any match = potential build failure
+```
+
+**COPY flag-token exclusion rule**: Strip ALL tokens starting with `--` (e.g., `--chown=1000:1000`, `--chmod=755`) before extracting source/destination paths. These are COPY instruction flags, NOT source paths.
+
+**COPY source path tokenization (Python — canonical implementation)**: When the bash read-loop produces false MISSING alerts (e.g., treating `COPY` keyword or `--flag` tokens as paths), use this Python tokenization as the authoritative implementation:
+```python
+import re
+with open('Dockerfile') as f:
+    for line in f:
+        line = line.strip()
+        if line.startswith('#') or not line.startswith('COPY'):
+            continue
+        if '--from=' in line:
+            continue
+        # Strip COPY keyword
+        rest = re.sub(r'^COPY\s+', '', line)
+        # Strip all --flag tokens
+        rest = re.sub(r'--\S+\s*', '', rest)
+        tokens = rest.split()
+        # All except last = sources; last = destination
+        sources = tokens[:-1]
+        for src in sources:
+            # Glob patterns (*) are valid — skip validation
+            if '*' not in src:
+                print(f"VALIDATE: {src}")
+```
+
+**PHP/Laravel configPath() pre-analysis step**: For PHP/Laravel projects, before writing or validating Dockerfile COPY instructions, check for non-standard config directory overrides:
+```bash
+grep -rn 'configPath\|useConfigPath' app/ bootstrap/ --include='*.php' 2>/dev/null | grep -v vendor
+```
+If a non-standard config path is found, ensure the Dockerfile COPYs that path in addition to the standard `config/` directory.
+
+**Comment-stripping pre-filter**: ALL Dockerfile instruction checks MUST strip comment lines first (`grep -v '^\s*#'`). A MIGRATION comment mentioning COPY, FROM, or HEALTHCHECK is documentation, not an instruction.
+
+**Note:** COPY instructions with `--from=` are EXEMPT — they reference build-stage artifacts not present on the host filesystem (see §Multi-Stage COPY Exemption above).
+
+### Point 2: Verify Base Image Tag is Pinned (ARG-Aware)
+
+```bash
+# Step 1: Collect ARG defaults declared before first FROM
+ARGS=$(grep -v '^\s*#' Dockerfile | sed -n '0,/^FROM/{ /^ARG /p }' | sed 's/ARG //' | tr '\n' ';')
+
+# Step 2: Collect declared stage aliases (FROM ... AS <alias>)
+ALIASES=$(grep -v '^\s*#' Dockerfile | grep -i '^FROM.*AS' | awk '{print $NF}' | tr '[:upper:]' '[:lower:]')
+
+grep -v '^\s*#' Dockerfile | grep '^FROM' | while read line; do
+  # Handle --platform= flag: image is last positional field before AS
+  image=$(echo "$line" | sed 's/--[^ ]* //g' | awk '{print $2}')
+  # Skip internal stage aliases (not external pulls)
+  if echo "$ALIASES" | grep -qx "$(echo "$image" | tr '[:upper:]' '[:lower:]')"; then
+    continue  # Internal alias — not an external image
+  fi
+  # ARG substitution: resolve $VAR or ${VAR} from collected ARGs
+  if echo "$image" | grep -qE '\$'; then
+    resolved="$image"
+    echo "$ARGS" | tr ';' '\n' | while IFS='=' read k v; do
+      resolved=$(echo "$resolved" | sed "s|\${$k}|$v|g; s|\$$k|$v|g")
+    done
+    image="$resolved"
+  fi
+  if echo "$image" | grep -qE ':latest$|^[^:]+$'; then
+    echo "UNPINNED BASE IMAGE: $image (use specific version tag)"
+  fi
+done
+```
+
+**ARG-aware FROM tag pinning rule**: Collect all `ARG key=value` declarations before the first `FROM` instruction. Substitute `${VAR}` and `$VAR` references in FROM image tokens before evaluating pinning. Example: `ARG NODE_VERSION=18-alpine` + `FROM node:${NODE_VERSION}` → resolves to `node:18-alpine` (pinned, PASS).
+
+**Multi-stage alias exception**: When a `FROM` line references a name declared as an alias by a previous `FROM ... AS <alias>` in the same Dockerfile, it is an internal stage reference — NOT an external image pull. Skip pinning validation for these.
+
+**FROM --platform= parsing**: Lines like `FROM --platform=$BUILDPLATFORM golang:1.22 AS builder` — the image name is NOT `$2` (which is the flag). Strip `--flag value` pairs first, then extract the image name.
+
+### Point 3: Verify Non-Root USER Instruction Present
+
+```bash
+if ! grep -v '^\s*#' Dockerfile | grep -q '^USER'; then
+  echo "WARNING: No USER instruction — container runs as root"
+fi
+```
+
+### Point 4: List Unverifiable Assertions
+
+Document the following as unverifiable without Docker:
+- Package install success (apt-get, apk, pip, npm, gem, nuget)
+- Compilation/build step success
+- Entrypoint binary execution
+- Runtime file permissions
+
+Add to task report:
+```
+UNVERIFIABLE (Docker unavailable):
+- [ ] Package installs exit 0
+- [ ] Application compiles successfully
+- [ ] Entrypoint binary exists and is executable
+- [ ] File permissions match runAsUser UID
+```
+
+### Point 5: Verify Compiled Artifact Presence (compiled languages only)
+
+For projects detected by Step 0 as requiring compilation, verify the expected artifact exists on disk even when Docker is unavailable:
+
+```bash
+# Java/Maven:
+ls target/*.jar target/*.war 2>/dev/null | head -1 || echo "COMPILED ARTIFACT MISSING — Step 0 may not have run"
+
+# Java/Gradle:
+ls build/libs/*.jar 2>/dev/null | head -1 || echo "COMPILED ARTIFACT MISSING"
+
+# Go:
+ls <expected-binary-path> 2>/dev/null || echo "COMPILED ARTIFACT MISSING"
+
+# .NET:
+ls bin/Release/net*/publish/ 2>/dev/null || echo "COMPILED ARTIFACT MISSING"
+
+# Node.js/TS:
+ls dist/ build/ 2>/dev/null || echo "COMPILED ARTIFACT MISSING"
+```
+
+If the artifact is missing AND Step 0 was not run (toolchain unavailable), document as: "Compiled artifact not verified — toolchain unavailable."
+
+### Validation Result When Docker Unavailable
+
+```json
+{
+  "container_build": "PASSED (skipped — tool unavailable)",
+  "container_build_reason": "Docker unavailable — static verification only",
+  "static_checklist": {
+    "copy_paths_exist": true,
+    "base_image_pinned": true,
+    "user_instruction_present": true,
+    "unverifiable_assertions_documented": true,
+    "compiled_artifact_present": true
+  },
+  "basic_tests": "PASSED",
+  "overall": "PASSED"
+}
+```
+
+**Rules:**
+1. Do NOT record `container_build: PASSED` (bare) when Docker was never executed — use `PASSED (skipped — tool unavailable)`.
+2. Overall result is NOT degraded when Tier 1 was skipped due to tool absence. Tool absence ≠ failure.
+3. Do NOT attempt to install Docker, start dockerd, or use alternative container runtimes.
+4. Document in TRANSFORMATION_SUMMARY.md: "Docker build validation skipped — Docker unavailable in execution environment. Static verification checklist passed."
+
+## Tier 3 Ask-Before-Skip Protocol
+
+**Purpose:** Tier 3 cluster validation must never be silently skipped. The user must be informed and asked whether they want to run it.
+
+**When to run:** During Sub-Phase §1 (Initial Setup), after determining execution preferences.
+
+**Decision flow:**
+
+1. Auto-detect cluster tools:
+```bash
+command -v minikube || command -v kind || command -v k3s || command -v kwokctl
+```
+
+2. If any tool detected → Tier 3 is available. Proceed to Tier 3 after Tier 1 passes (or immediately for KWOK — see §KWOK Tier 3 Independence below).
+
+3. If NO tool detected → **attempt kwokctl download** (30-second timeout):
+```bash
+curl -Lo /tmp/kwokctl "https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/kwokctl-linux-amd64"
+chmod +x /tmp/kwokctl
+```
+If download succeeds, proceed with Tier 3 using `--runtime=binary`. If `/usr/local/bin` is writable, create symlink: `ln -sf /tmp/kwokctl /usr/local/bin/kwokctl`. Otherwise use `/tmp/kwokctl` directly. If download fails, prompt the user.
+
+**CRITICAL: Download `kwokctl-linux-amd64` (NOT `kwok-linux-amd64`). These are SEPARATE binaries — kwok is the node simulator, kwokctl is the cluster manager. Do NOT symlink kwok as kwokctl.**
+
+4. If download also failed → **prompt the user** (30-second timeout; no response = N):
+```
+Tier 3 cluster validation (Minikube/kind/k3s/KWOK) was not auto-detected.
+Would you like to run Tier 3 cluster validation? [y/N]
+```
+
+5. If user responds **y**: attempt Tier 3 using the fallback chain below (Minikube → kind → k3s → KWOK).
+
+6. If user responds **N** or no response / timeout (30s): skip Tier 3 and log:
+```
+DECISION: Tier 3 cluster validation skipped (user opted out / not available).
+Status: PASSED (skipped — tool unavailable). Overall result unaffected.
+```
+
+6. **In fully automated (CI) mode** where no user prompt is possible: default to skip, emit a visible notice:
+```
+NOTICE: Tier 3 cluster validation skipped (non-interactive, no cluster tool detected).
+Status: PASSED (skipped — tool unavailable). Overall result unaffected.
+To run Tier 3 manually: kwokctl create cluster --runtime=binary && kubectl apply -f kubernetes/
+```
+
+7. **Record the decision** in both the task report AND TRANSFORMATION_SUMMARY.md Three-Tier Validation table. The table must show either `PASSED` (with tier reached), `SKIPPED (user opted out)`, or `SKIPPED (non-interactive, no cluster tool)` — never blank or ambiguous.
+
+**Tier 3 fallback chain (ordered):** Minikube → kind → k3s → KWOK
+
+**kwokctl kubectl passthrough warning**: Never use `kwokctl kubectl -- <args>` passthrough — it drops subcommand arguments and outputs kubectl help text. Always use the bundled kubectl binary directly with an explicit `--kubeconfig` flag.
+
+## ECS/Restricted Container Fallback (Tier 3)
+
+**Purpose:** When Tier 3 cluster validation is attempted in ECS tasks, restricted containers, or cgroup v1 environments, standard Minikube and k3s ≥v1.32 fail. This procedure documents the canonical fallback.
+
+**When to run:** During Tier 3 validation attempts, when early-abort signals are detected.
+
+**Early-abort signals (in order of detection):**
+
+| Signal | Source | Action |
+|--------|--------|--------|
+| `unshare: operation not permitted` | Minikube start | Skip Minikube entirely → try k3s |
+| `cgroup v1 support is unsupported` | k3s ≥v1.32 kubelet | Downgrade to k3s v1.28.15+k3s1 |
+| Port 6443 `ServiceUnavailable` | k3s API server | Use port 6444 instead |
+| `Minikube --driver=none` requires Docker even with conntrack/crictl | Minikube | Skip Minikube → use k3s |
+
+**Canonical k3s v1.28 fallback procedure:**
+
+```bash
+# Install k3s v1.28.15+k3s1 (API-server-only, no agent)
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=v1.28.15+k3s1 \
+  INSTALL_K3S_EXEC='server --disable-agent --snapshotter=native --flannel-backend=none' sh -
+
+# Wait for API server
+sleep 10
+
+# kubeconfig location
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# If port 6443 returns ServiceUnavailable, try 6444
+kubectl get nodes --server=https://127.0.0.1:6444 2>/dev/null && \
+  sed -i 's/6443/6444/' /etc/rancher/k3s/k3s.yaml
+
+# Apply manifests — Namespace FIRST (MANDATORY)
+kubectl apply -f kubernetes/namespace.yaml && sleep 2
+kubectl apply -f kubernetes/
+```
+
+**Rules:**
+1. Do NOT iterate on Minikube failures in ECS — skip directly to k3s.
+2. k3s ≥v1.32 requires cgroup v2. In cgroup v1 environments, use v1.28.x.
+3. `--disable-agent` prevents kubelet startup (which fails on cgroup v1).
+4. `--snapshotter=native` avoids overlayfs requirements.
+5. `--flannel-backend=none` skips CNI (not needed for API-server-only validation).
+6. All kubectl commands must run in same shell invocation with K3S process.
+7. If k3s v1.28 also fails, abort Tier 3 and fall back to Tier 2 (kubeconform). Tier 2 is sufficient.
+
+**Source:** Kubernetes 1.31+ moved cgroup v1 to maintenance mode (https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/).
+
+## k3s Restricted Container Bootstrap
+
+**Purpose:** When Tier 3 is attempted inside ECS tasks or other restricted containers where standard k3s install fails (no systemd, overlayfs unavailable, cgroup v1), use this ready-to-paste bootstrap sequence.
+
+**When to run:** During Tier 3 validation attempts in restricted environments, after overlayfs EPERM or standard k3s installer failure.
+
+**Early-abort signals** (add to existing table):
+
+| Signal | Source | Action |
+|--------|--------|--------|
+| `overlayfs: permission denied` | k3s data dir init | Use `--snapshotter=native` |
+| `EPERM` on `/var/lib/rancher` overlay | k3s mount | Switch to native snapshotter |
+
+**Preconditions:** curl available, /tmp writable, root or sudo available.
+
+**Procedure (5 steps):**
+
+**Step 1 — Create sudo passthrough stub** (when real sudo is unavailable):
+```bash
+printf '#!/bin/sh\nexec "$@"' > /usr/local/bin/sudo && chmod +x /usr/local/bin/sudo
+```
+
+**Step 2 — Create systemctl no-op stub** (k3s installer expects systemctl):
+```bash
+printf '#!/bin/sh\nexit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl
+```
+
+**Step 3 — Create /dev/kmsg FIFO** (kubelet writes kernel messages here):
+```bash
+rm -f /dev/kmsg && mkfifo /dev/kmsg
+```
+
+**Step 4 — Launch k3s API-server-only** (no agent, no overlayfs):
+```bash
+nohup setsid k3s server \
+  --disable-agent \
+  --snapshotter=native \
+  --write-kubeconfig-mode 644 \
+  --flannel-backend=none \
+  > /tmp/k3s.log 2>&1 &
+sleep 15  # API server bootstrap takes ~10-15s
+```
+
+**Step 5 — Patch kubeconfig port** (k3s may bind to 6444 instead of 6443):
+```bash
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+kubectl get nodes 2>/dev/null || \
+  sed -i 's/127.0.0.1:6443/127.0.0.1:6444/' /etc/rancher/k3s/k3s.yaml
+kubectl get nodes  # Should succeed now
+```
+
+**Verification:** `kubectl get nodes` returns a node in Ready or NotReady state (NotReady is expected with --disable-agent).
+
+**Post-bootstrap manifest apply:**
+```bash
+kubectl apply -f kubernetes/namespace.yaml && sleep 2
+kubectl apply -f kubernetes/
+kubectl get all -n <namespace>
+```
+
+**Abort criteria:** If k3s also fails after these 5 steps (e.g., kernel too old, SELinux blocking), abort Tier 3 entirely. Tier 2 (kubeconform) is sufficient for validation.
+
+**Idempotence:** Running the procedure twice is safe — k3s detects existing process. The stubs are idempotent file overwrites.
+
+**Source:** k3s --disable-agent flag documentation (https://github.com/k3s-io/k3s/issues/5118); Kubernetes 1.31+ moved cgroup v1 to maintenance mode (https://kubernetes.io/blog/2024/08/14/kubernetes-1-31-moving-cgroup-v1-support-maintenance-mode/).
+
+## KWOK Operational Checklist
+
+Consolidated checklist for all KWOK cluster operations. Use this as the single reference for KWOK validation.
+
+### Step 0: Stale-Cluster Cleanup (MANDATORY before every creation)
+Before creating ANY new cluster, ALWAYS delete stale clusters to avoid hangs on version mismatch:
+```bash
+/tmp/kwokctl get clusters 2>/dev/null
+# Delete the target cluster name if it already exists:
+/tmp/kwokctl delete cluster --name validation 2>/dev/null || true
+```
+Run this unconditionally — it is a no-op if no stale cluster exists.
+
+### Flag Syntax Note
+Prefer space-separated `--name validation` over equals-form `--name=validation`. The equals form is unreliable in some subcommand contexts and with shell variable expansion.
+
+### Cluster Existence and Reuse Check
+Before creating a new cluster, check if one already exists and delete stale clusters:
+```bash
+/tmp/kwokctl get clusters 2>/dev/null
+# If target cluster name appears, delete it (covered by Step 0 above):
+/tmp/kwokctl delete cluster --name validation 2>/dev/null || true
+```
+If no stale cluster exists, proceed to create.
+
+### Kubeconfig Paths by Runtime Mode
+| Runtime Mode | Kubeconfig Location |
+|---|---|
+| `--runtime=binary` | `~/.kwok/clusters/<name>/kubeconfig.yaml` |
+| `--runtime=docker` | `~/.kwok/clusters/<name>/kubeconfig.yaml` |
+| `--runtime=kind` | Use `kind get kubeconfig --name <name>` |
+
+### Cached Binary Discovery
+Before downloading kwokctl or kubeconform from CDN, check for cached binaries from prior tasks:
+```bash
+find /tmp -name kwokctl -type f -executable 2>/dev/null | head -1
+find /tmp -name kubeconform -type f -executable 2>/dev/null | head -1
+```
+If found, use the cached binary directly — skip the download step.
+
+**kubeconform integrity check**: After locating a cached kubeconform binary, verify it produces sane output before trusting it: `<binary> --help 2>&1 | grep -q 'Usage'`. If this fails, the binary may be corrupt or a different tool — re-download.
+
+### kwokctl v0.7.0 API Changes
+- `kwokctl version` is NOT a valid subcommand — do not use. Available commands: config, create, delete, get, hack, logs, scale, snapshot, start, stop.
+- **`kwokctl get kubeconfig-path` does NOT EXIST** — the correct command is `kwokctl get kubeconfig --name <cluster>` which prints kubeconfig YAML to stdout. Redirect to file: `kwokctl get kubeconfig --name <cluster> > /tmp/kwok.kubeconfig && export KUBECONFIG=/tmp/kwok.kubeconfig` (command substitution causes file-name-too-long error — always redirect).
+- **FALLBACK when `kwokctl get kubeconfig` fails or produces empty output**: Use the fixed path directly: `export KUBECONFIG=~/.kwok/clusters/<name>/kubeconfig.yaml` — this file always exists after successful cluster creation.
+- `--name` flag for `get kubeconfig`: use space-separated form `kwokctl get kubeconfig --name <cluster>` (not equals-form).
+- Use `kwokctl get clusters` (or `command -v kwokctl`) for binary presence check.
+- `kwokctl kubectl -- <args>` (double-dash separator) is NOT supported — drops arguments, outputs kubectl help, exits 0 as false success.
+- The passthrough is unreliable — always use standalone kubectl with explicit `--kubeconfig`.
+- **kubectl v1.33+ note**: `kubectl version --short` is removed. Use `kubectl version --client=true` to verify kubectl binary version without contacting a server.
+
+### kwokctl --name Bug Workaround
+The `--name` flag in `kwokctl kubectl` subcommands defaults to 'kwok' regardless of the specified cluster name. **NEVER use `kwokctl kubectl --name=<cluster>`** — it silently targets the wrong cluster.
+
+**Workaround**: Use the embedded kubectl binary directly. The PRIMARY discovery method is `find`:
+```bash
+KWOK_KUBECTL=$(find $HOME/.kwok/cache -name kubectl -type f | head -1)
+KUBECONFIG=$HOME/.kwok/clusters/<cluster-name>/kubeconfig.yaml
+$KWOK_KUBECTL --kubeconfig=$KUBECONFIG <command>
+```
+
+**Warning**: Do NOT assume a fixed path like `~/.kwok/clusters/<name>/bin/kubectl` — the binary location varies by kwokctl version and platform. The `find` command is the only reliable discovery method.
+
+If `find` returns empty, the cluster may not have finished downloading binaries — wait and retry.
+
+### Namespace-First Apply (MANDATORY)
+`kubectl apply -f kubernetes/` processes files alphabetically. Namespace must be applied first:
+```bash
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/namespace.yaml && sleep 2
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/
+```
+If namespace.yaml does not exist, skip this step.
+
+### 00-namespace.yaml Naming Convention
+
+**Always name the Namespace manifest `00-namespace.yaml`** so it sorts first alphabetically when using `kubectl apply -f kubernetes/`. This prevents "namespace not found" errors caused by ConfigMap/Deployment manifests sorting before `namespace.yaml`.
+
+**Source:** kubectl apply -f directory applies manifests in alphabetical order — https://kubernetes.io/docs/reference/kubectl/generated/kubectl/
+
+**Two-step apply is STILL required for KWOK validation** (belt-and-suspenders):
+```bash
+kubectl apply -f kubernetes/00-namespace.yaml && sleep 2
+kubectl apply -f kubernetes/
+```
+
+## Post-kubeconform Placement Assertions
+
+**Purpose:** kubeconform validates schema structure but does NOT catch field misplacement or semantic errors that cause silent runtime failures.
+
+**When to run:** Immediately after `kubeconform -strict` passes (Tier 2).
+
+**Assertion 1 — CronJob activeDeadlineSeconds location:**
+```python
+import yaml
+from pathlib import Path
+for f in Path('kubernetes').glob('*.yaml'):
+    with open(f) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if doc and doc.get('kind') == 'CronJob':
+                if 'activeDeadlineSeconds' in doc.get('spec', {}):
+                    print(f'FAIL: {f} — activeDeadlineSeconds at spec root (must be spec.jobTemplate.spec)')
+                jt_spec = doc.get('spec', {}).get('jobTemplate', {}).get('spec', {})
+                if 'activeDeadlineSeconds' in jt_spec:
+                    print(f'OK: {f} — activeDeadlineSeconds correctly placed')
+```
+
+**Assertion 2 — Secret keys with dots (envFrom incompatible):**
+```python
+import yaml
+from pathlib import Path
+for f in Path('kubernetes').glob('*.yaml'):
+    with open(f) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if doc and doc.get('kind') == 'Secret':
+                for k in list(doc.get('stringData', {}).keys()) + list(doc.get('data', {}).keys()):
+                    if '.' in k or '/' in k:
+                        print(f'WARNING: {f} — key "{k}" contains dots/slashes, will be skipped by envFrom')
+                        print(f'  → Use explicit env[].valueFrom.secretKeyRef with a SCREAMING_SNAKE name')
+```
+
+**Rule:** If Assertion 2 finds dotted keys, switch affected keys from envFrom bulk injection to per-key `valueFrom.secretKeyRef` with valid env var names (SCREAMING_SNAKE_CASE).
+
+## KWOK Binary Runtime Fallback (Tier 3) — Canonical 5-Step Procedure
+
+**Purpose:** When Minikube, kind, and k3s all fail (no container runtime, kernel too old, restricted environment), KWOK provides API-server-only validation using pre-compiled Kubernetes binaries without any container runtime.
+
+**When to run:** During Tier 3 validation attempts, after k3s also fails. KWOK is the lightest option — Linux-only, no container runtime required.
+
+**Tier 3 fallback chain (ordered):** Minikube → kind → k3s → KWOK
+
+**Preconditions:** Linux environment, curl available, /tmp writable.
+
+### KWOK Tier 3 Independence from Tier 1
+
+The Tier 1 (Docker build) prerequisite for Tier 3 applies to Minikube/kind/k3s — which require a built container image. For KWOK `--runtime=binary`, Tier 3 can proceed **regardless of Tier 1 status** because KWOK validates only Kubernetes API acceptance (schema, selectors, resource relationships), not container execution. When Tier 1 is SKIPPED but KWOK is available, proceed directly to KWOK validation.
+
+### Namespace Ordering (MANDATORY)
+
+`kubectl apply -f kubernetes/` processes files alphabetically. Files like `configmap.yaml` or `deployment.yaml` sort before `namespace.yaml`, causing "namespace not found" errors when resources target a custom namespace.
+
+**ALWAYS apply namespace.yaml FIRST in a separate kubectl command with sleep 2 before applying remaining manifests:**
+```bash
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/namespace.yaml && sleep 2
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/
+```
+
+**If namespace.yaml does not exist** (all resources target pre-existing namespaces like `default`), skip this step.
+
+**Alternative**: Rename the namespace file to `00-namespace.yaml` so it sorts first alphabetically. However, the two-step apply is the REQUIRED procedure for KWOK validation because it is guaranteed to work regardless of file naming.
+
+**Source:** kubectl processes directory contents alphabetically (https://www.baeldung.com/ops/kubectl-entire-directory — "kubectl will recurse over each file in the directory").
+
+### Anti-Patterns (DO NOT USE)
+
+1. **DO NOT use `kwokctl kubectl --` passthrough** — it drops subcommand arguments, outputs kubectl help text, and exits 0 (false success). Always use standalone kubectl with explicit kubeconfig.
+2. **DO NOT use `kwokctl version`** — this subcommand does not exist in v0.7.0 and produces unhelpful output.
+3. **DO NOT rely on `kwokctl kubectl --name=<cluster>` subcommands** — the `--name` flag defaults to 'kwok' regardless of the specified cluster name (https://kwok.sigs.k8s.io/docs/generated/kwokctl/ — `--name string cluster name (default "kwok")`). Example: `kwokctl kubectl --name=validation get pods` silently targets the 'kwok' cluster, NOT 'validation'. Always use the bundled kubectl binary at `~/.kwok/clusters/<name>/bin/kubectl` with explicit `--kubeconfig` — never `kwokctl kubectl` subcommands.
+
+### Canonical Procedure
+
+```bash
+# Step 1: Download kwokctl
+curl -Lo /tmp/kwokctl "https://github.com/kubernetes-sigs/kwok/releases/download/v0.7.0/kwokctl-linux-amd64"
+chmod +x /tmp/kwokctl
+
+# Step 2: Create cluster with binary runtime (no Docker/containerd needed)
+/tmp/kwokctl create cluster --name validation --runtime binary
+sleep 3  # API server needs ~2-3s to become ready after cluster creation
+
+# Step 3: Extract kubeconfig and locate bundled kubectl via find (PRIMARY method)
+export KUBECONFIG=~/.kwok/clusters/validation/kubeconfig.yaml
+KUBECTL=$(find $HOME/.kwok/cache -name kubectl -type f | head -1)
+# If KUBECTL is empty, wait 5s and retry — cluster may still be downloading binaries
+[ -z "$KUBECTL" ] && sleep 5 && KUBECTL=$(find $HOME/.kwok/cache -name kubectl -type f | head -1)
+
+# Step 4: Apply manifests using standalone kubectl — Namespace FIRST (MANDATORY)
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/namespace.yaml && sleep 2
+$KUBECTL --kubeconfig $KUBECONFIG apply -f kubernetes/
+
+# Step 5: Verify resources accepted by API server
+$KUBECTL --kubeconfig $KUBECONFIG get all -n <namespace>
+```
+
+**Cluster name verification**: Before Step 3, confirm cluster was created:
+```bash
+/tmp/kwokctl get clusters
+# Expected output includes "validation"
+```
+
+**What KWOK validates:** Kubernetes API server schema validation (equivalent to kubeconform but using the real API server), resource relationships (Service→Deployment selector resolution), RBAC, ConfigMap/Secret references. Pods will show as "Running" (KWOK simulates node/pod lifecycle) but NO actual containers execute.
+
+**What KWOK does NOT validate:** Container image existence, Dockerfile correctness, actual application startup, volume mounts, network connectivity. These require Tier 1 (Docker build) which should have already passed.
+
+**Abort criteria:** If kwokctl fails to create cluster (e.g., binary download fails, Linux version too old), abort Tier 3 entirely. Tier 2 (kubeconform) is sufficient.
+
+**Cleanup:**
+```bash
+/tmp/kwokctl delete cluster --name validation
+```
+
+**Source:** https://kwok.sigs.k8s.io/docs/user/kwokctl-platform-specific-binaries/ — "When running kwokctl with binary runtime (kwokctl create cluster --runtime=binary), kwokctl will download Kubernetes binaries from dl.k8s.io and use them to create cluster. Only works on Linux."

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/dotnet-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/dotnet-patterns.md
@@ -1,0 +1,532 @@
+# C#/.NET Patterns Reference
+
+C# and .NET-specific containerisation gotchas for Phase 2 transformation. Applies when `.csproj` or `.sln` is present.
+
+## Table of Contents
+
+1. [Environment Variable Enumeration](#environment-variable-enumeration)
+2. [IConfiguration Bridge Pattern](#iconfiguration-bridge-pattern)
+3. [AWSSDK.S3 DI with IRSA](#awssdk-s3-di-with-irsa)
+4. [appsettings.json Env Var Override](#appsettingsjson-env-var-override)
+5. [Non-Root Dockerfile](#non-root-dockerfile)
+6. [Kestrel Port Configuration](#kestrel-port-configuration)
+7. [Health Check Registration](#health-check-registration)
+8. [EF Core efbundle Migration Job](#ef-core-efbundle-migration-job)
+9. [SignalR Redis Backplane](#signalr-redis-backplane)
+10. [CRONJOB_MODE Toggle Pattern](#cronjob-mode-toggle-pattern)
+11. [Startup-Eager ConnectionMultiplexer](#startup-eager-connectionmultiplexer)
+
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify .NET source compiles, tests pass, and the application publishes — all BEFORE `docker build`.
+
+### Commands
+```bash
+# 1. Restore + Build (excludes test projects)
+dotnet build --no-restore -c Release 2>&1 || dotnet build -c Release 2>&1
+# Expected: exit 0
+
+# 2. Unit tests (exclude integration)
+dotnet test --filter "Category!=Integration&Category!=Database" --no-build 2>&1
+# Expected: exit 0 or no test projects found
+
+# 3. Publish (verify artifact)
+dotnet publish -c Release -o /tmp/dotnet-publish 2>&1
+# Expected: exit 0 with DLL in output dir
+```
+
+### Expected Output
+- Step 1: "Build succeeded" + exit 0
+- Step 2: Exit 0 (tests pass) or "No test projects found"
+- Step 3: Exit 0 with published output
+
+### CONDITIONAL PASS Triggers
+- `dotnet` not installed and `mise install dotnet` fails → CONDITIONAL PASS
+- SDK version mismatch (global.json requires X, host has Y) → CONDITIONAL PASS
+- NuGet restore failure (network timeout after 1 retry) → CONDITIONAL PASS
+
+### Toolchain Bootstrap
+```bash
+# Check .NET availability
+command -v dotnet && dotnet --version
+# If absent, try mise
+command -v mise && mise install dotnet 2>/dev/null
+export DOTNET_ROOT=$HOME/.local/share/mise/installs/dotnet/$(ls $HOME/.local/share/mise/installs/dotnet/ 2>/dev/null | sort -V | tail -1)
+export PATH=$DOTNET_ROOT:$PATH
+dotnet --version
+```
+
+### Validated Example Repositories
+- NOT YET VALIDATED AGAINST REAL REPO — commands inferred from .NET documentation. Mark as validated when a .NET project passes through the pipeline.
+
+
+## Environment Variable Enumeration
+
+### Toolchain Bootstrap Fallback (.NET / mise)
+
+When `dotnet` is absent from PATH after `mise install`:
+```bash
+export DOTNET_ROOT=$HOME/.local/share/mise/installs/dotnet/$(ls $HOME/.local/share/mise/installs/dotnet/ 2>/dev/null | sort -V | tail -1)
+export PATH=$DOTNET_ROOT:$PATH
+dotnet --version  # Verify
+```
+
+**Rule:** After `mise install` or `mise use`, always export `DOTNET_ROOT` and prepend it to `PATH`. Without this, `dotnet` commands resolve to the wrong SDK or fail silently.
+
+```bash
+# Primary: GetEnvironmentVariable calls
+grep -rhoP 'GetEnvironmentVariable\("([A-Za-z][A-Za-z0-9_]+)"\)' . --include='*.cs' | sort -u
+
+# Secondary: IConfiguration indexer access
+grep -rhoP 'Configuration\["([A-Za-z][A-Za-z0-9_:]+)"\]' . --include='*.cs' | sort -u
+
+# Tertiary: appsettings.json keys (these become env vars via __ separator)
+python3 -c "
+import json
+def flatten(obj, prefix=''):
+    for k,v in obj.items():
+        key = f'{prefix}__{k}' if prefix else k
+        if isinstance(v, dict): yield from flatten(v, key)
+        else: yield key
+d = json.load(open('appsettings.json'))
+for k in sorted(flatten(d)): print(k)
+"
+```
+
+**Convention**: .NET maps `Section:Key` in appsettings to env var `Section__Key` (double underscore). Both forms resolve to the same IConfiguration key.
+
+## IConfiguration Bridge Pattern
+
+```csharp
+// Program.cs / Startup.cs
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddEnvironmentVariables();  // MUST be last — highest priority
+
+// Service DI
+builder.Services.Configure<DatabaseOptions>(
+    builder.Configuration.GetSection("Database"));
+```
+
+**Rule**: `AddEnvironmentVariables()` MUST be the last configuration source. Environment variables override all JSON/XML config files. Without this call, env vars are ignored entirely.
+
+## AWSSDK.S3 DI with IRSA
+
+```csharp
+// IRSA-compatible S3 client registration
+builder.Services.AddSingleton<IAmazonS3>(sp =>
+{
+    var accessKey = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID") ?? "";
+    var secretKey = Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY") ?? "";
+
+    var config = new AmazonS3Config
+    {
+        RegionEndpoint = RegionEndpoint.GetBySystemName(
+            Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1")
+    };
+
+    if (!string.IsNullOrEmpty(accessKey) && !string.IsNullOrEmpty(secretKey))
+    {
+        return new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey), config);
+    }
+    // Falls through to IRSA/instance profile when keys are empty
+    return new AmazonS3Client(config);
+});
+```
+
+**Detection**: `grep -rn 'AWSSDK\|AmazonS3\|IAmazonS3' . --include='*.cs' --include='*.csproj'`
+
+## appsettings.json Env Var Override
+
+.NET Core maps hierarchical JSON keys to environment variables with `__` separator:
+
+```json
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost;..."
+  },
+  "Logging": {
+    "LogLevel": { "Default": "Information" }
+  }
+}
+```
+
+**Env var overrides:**
+```yaml
+# ConfigMap
+ConnectionStrings__DefaultConnection: ""
+Logging__LogLevel__Default: "Warning"
+```
+
+**Rule**: Every appsettings.json value that differs between environments MUST have a corresponding ConfigMap/Secret entry using `__` notation.
+
+## Non-Root Dockerfile
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+WORKDIR /app
+COPY --from=build /app/publish .
+USER appuser
+ENTRYPOINT ["dotnet", "MyApp.dll"]
+```
+
+**Alpine variant** (mcr.microsoft.com/dotnet/aspnet:8.0-alpine):
+```dockerfile
+RUN addgroup -S appgroup && adduser -S -G appgroup appuser
+```
+
+**Kubernetes manifest**: `runAsUser: 65534, runAsGroup: 65534` (or match UID/GID from Dockerfile). Full container securityContext:
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: [ALL]
+```
+
+## Kestrel Port Configuration
+
+```csharp
+// Program.cs
+builder.WebHost.ConfigureKestrel(opts =>
+{
+    var port = int.Parse(Environment.GetEnvironmentVariable("PORT") ?? "8080");
+    opts.ListenAnyIP(port);
+});
+```
+
+**Alternative — ASPNETCORE_URLS env var:**
+```yaml
+# ConfigMap
+ASPNETCORE_URLS: "http://+:8080"
+```
+
+**Rule**: Use `ASPNETCORE_URLS` (preferred) or explicit Kestrel configuration. Default port 5000/5001 (HTTP/HTTPS) requires TLS certificates — switch to plain HTTP behind reverse proxy in Kubernetes.
+
+## Health Check Registration
+
+```csharp
+// Program.cs
+builder.Services.AddHealthChecks()
+    .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)
+    .AddRedis(builder.Configuration["Redis:ConnectionString"]!);
+
+app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/ready", new HealthCheckOptions
+{
+    Predicate = check => check.Tags.Contains("ready")
+});
+```
+
+**Probe mapping:**
+```yaml
+livenessProbe:
+  httpGet: { path: /healthz, port: 8080 }
+readinessProbe:
+  httpGet: { path: /ready, port: 8080 }
+```
+
+## EF Core efbundle Migration Job
+
+**Trigger:** Entity Framework Core migrations that must run before application startup.
+
+**Problem:** Running `dotnet ef database update` requires the .NET SDK in production. `efbundle` creates a standalone executable.
+
+**Build-time bundle generation:**
+```bash
+dotnet ef migrations bundle --self-contained -r linux-x64 -o efbundle
+```
+
+**Kubernetes Job manifest:**
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-migrate
+spec:
+  template:
+    spec:
+      containers:
+      - name: migrate
+        image: app-image:latest
+        command: ["./efbundle", "--connection", "$(ConnectionStrings__DefaultConnection)"]
+        env:
+        - name: ConnectionStrings__DefaultConnection
+          valueFrom:
+            secretKeyRef:
+              name: app-secret
+              key: ConnectionStrings__DefaultConnection
+      restartPolicy: Never
+  backoffLimit: 3
+```
+
+**Rule:** Run migration Job BEFORE application Deployment. Use `initContainers` or Job ordering (annotations/Helm hooks) to ensure migration completes first.
+
+**Detection:** `grep -rn 'DbContext\|OnModelCreating\|Migration' . --include='*.cs' | head -5`
+
+## SignalR Redis Backplane
+
+**Trigger:** ASP.NET Core SignalR with multiple replicas (HPA minReplicas > 1).
+
+**Problem:** SignalR maintains in-memory connection mappings. Without a backplane, messages from one pod do not reach clients connected to other pods.
+
+**Solution — Redis backplane:**
+```csharp
+// Program.cs
+builder.Services.AddSignalR()
+    .AddStackExchangeRedis(Environment.GetEnvironmentVariable("REDIS_URL") ?? "localhost:6379", options =>
+    {
+        options.Configuration.ChannelPrefix = RedisChannel.Literal("MyApp");
+    });
+```
+
+**Dependencies (add to .csproj):**
+```xml
+<PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.*" />
+```
+
+**NetworkPolicy:** Web Deployment needs egress to Redis (TCP 6379).
+
+**Detection:** `grep -rn 'MapHub\|AddSignalR\|HubConnection' . --include='*.cs'`
+
+**Rule:** If SignalR is detected AND HPA minReplicas > 1, add Redis backplane. Without it, real-time features break across multiple pods.
+
+## SignalR Nginx Ingress Annotations
+
+**Trigger:** SignalR hub behind nginx Ingress controller.
+
+**Problem:** SignalR WebSocket connections are long-lived. Default nginx proxy timeouts (60s) drop the WebSocket transport, forcing fallback to Long Polling (higher latency, more server load).
+
+**Solution — add annotations to Ingress:**
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "7"
+    # Enable WebSocket upgrade
+    nginx.ingress.kubernetes.io/websocket-services: "app-service"
+```
+
+**Detection:**
+```bash
+grep -rn 'MapHub\|UseSignalR\|AddSignalR' . --include='*.cs' && echo "SignalR detected — add WS Ingress annotations"
+```
+
+**Rule:** When SignalR is detected AND Ingress uses nginx controller, add `proxy-read-timeout: 3600` and `proxy-send-timeout: 3600`. Without these, WebSocket transport fails silently and clients fall back to Long Polling.
+
+**Nginx Ingress annotations for SignalR WebSocket:**
+
+When SignalR is behind an nginx Ingress controller, default proxy timeouts (60s) disconnect WebSocket clients, causing constant reconnection storms.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "7"
+```
+
+**Rule:** When SignalR uses WebSocket transport AND the application is behind nginx Ingress, add `proxy-read-timeout: 3600` and `proxy-send-timeout: 3600` annotations. Without these, WebSocket connections drop every 60 seconds.
+
+## CRONJOB_MODE Toggle Pattern
+
+**Trigger:** .NET application that runs both as a web API and as periodic background jobs, with a mode toggle to select behaviour at runtime.
+
+**Problem:** Using a single Docker image with an env var toggle (`CRONJOB_MODE=true`) to switch between web and job mode is a decomposition anti-pattern.
+
+**Solution — separate entry points via Dockerfile targets:**
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+COPY --from=build /app/publish .
+
+FROM base AS web
+ENTRYPOINT ["dotnet", "MyApp.dll"]
+
+FROM base AS worker
+ENTRYPOINT ["dotnet", "MyApp.dll", "--run-job", "cleanup"]
+```
+
+**Kubernetes manifests:**
+```yaml
+# deployment-web.yaml
+containers:
+- name: web
+  image: app:latest  # targets 'web' stage
+  
+# cronjob-cleanup.yaml
+containers:
+- name: cleanup
+  image: app:latest  # targets 'worker' stage
+  command: ["dotnet", "MyApp.dll", "--run-job", "cleanup"]
+```
+
+**Detection:** `grep -rn 'CRONJOB_MODE\|RUN_MODE\|JOB_MODE' . --include='*.cs' --include='*.json'`
+
+**Rule:** Replace mode-toggle env vars with separate Dockerfile targets and distinct Kubernetes workload manifests (Deployment vs CronJob).
+
+## Startup-Eager ConnectionMultiplexer
+
+**Trigger:** StackExchange.Redis `ConnectionMultiplexer.Connect()` called during DI registration or app startup.
+
+**Problem:** `ConnectionMultiplexer.Connect()` opens a TCP connection to Redis immediately at startup — before the first request arrives. If the NetworkPolicy egress to Redis is missing, the pod hangs at startup or crashes with a timeout.
+
+```csharp
+// This runs at DI registration time — connection opens IMMEDIATELY
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+    ConnectionMultiplexer.Connect(
+        Environment.GetEnvironmentVariable("REDIS_URL") ?? "localhost:6379"
+    )
+);
+```
+
+**NetworkPolicy impact:** The web Deployment's egress NetworkPolicy MUST include Redis (TCP 6379) even if the primary use of Redis appears to be "on-demand" (sessions, caching). The connection opens at startup.
+
+**Egress trigger:** This is a startup-eager connection. Add Redis egress rule to the workload's NetworkPolicy even if no explicit `REDIS_HOST` env var exists — the connection string may be embedded in `appsettings.json` or a composite connection string.
+
+**Detection:**
+```bash
+grep -rn 'ConnectionMultiplexer\.Connect\|AddStackExchangeRedis\|GetDatabase()' . --include='*.cs'
+```
+
+**Startup resilience:** Wrap in retry logic to handle Redis unavailability at startup:
+```csharp
+builder.Services.AddSingleton<IConnectionMultiplexer>(sp =>
+{
+    var config = ConfigurationOptions.Parse(
+        Environment.GetEnvironmentVariable("REDIS_URL") ?? "localhost:6379");
+    config.AbortOnConnectFail = false;  // Don't crash on startup if Redis is slow
+    config.ConnectRetry = 3;
+    return ConnectionMultiplexer.Connect(config);
+});
+```
+
+## InboundClaimTypeMap.Clear() for JWT Auth
+
+**Trigger:** .NET applications using JWT bearer authentication with `Microsoft.AspNetCore.Authentication.JwtBearer`.
+
+**Problem:** By default, `JwtSecurityTokenHandler` maps standard JWT claim types to long XML namespace URIs (e.g., `sub` → `http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier`). This breaks claim-based authorization policies that check for `sub`, `email`, etc.
+
+**Detection:**
+```bash
+grep -rn 'AddJwtBearer\|JwtBearerDefaults' . --include='*.cs' | grep -v 'test\|Test'
+grep -rn 'InboundClaimTypeMap' . --include='*.cs'
+```
+
+**Rule:** If JWT auth is configured AND `InboundClaimTypeMap.Clear()` is NOT present, add it in the auth configuration:
+```csharp
+// Program.cs — BEFORE AddAuthentication
+JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+```
+
+Without this, `User.FindFirst("sub")` returns null even when the JWT contains the `sub` claim. This is a silent auth failure that manifests as 403 responses in production.
+
+## Xabaril Health Check Packages
+
+**Trigger:** .NET applications using `AspNetCore.HealthChecks.*` packages (Xabaril ecosystem) for health check endpoints.
+
+**Problem:** The main package `AspNetCore.HealthChecks.UI` and infrastructure-specific packages (`*.SqlServer`, `*.Redis`, `*.NpgSql`) must match versions. Version mismatches cause `MissingMethodException` at startup.
+
+**Detection:**
+```bash
+grep -rn 'AspNetCore.HealthChecks\|AddHealthChecks\|MapHealthChecks' . --include='*.cs' --include='*.csproj'
+```
+
+**Common packages requiring version alignment:**
+- `AspNetCore.HealthChecks.SqlServer`
+- `AspNetCore.HealthChecks.NpgSql`
+- `AspNetCore.HealthChecks.Redis`
+- `AspNetCore.HealthChecks.UI`
+
+**Rule:** When migrating health check configuration, verify all `AspNetCore.HealthChecks.*` packages in `.csproj` use the same major.minor version. Add the health check endpoint to probe configuration:
+```csharp
+app.MapHealthChecks("/health", new HealthCheckOptions { Predicate = _ => true });
+```
+
+## DefaultAzureCredential OS Bypass
+
+**Trigger:** .NET applications using `Azure.Identity.DefaultAzureCredential` for Azure service authentication.
+
+**Problem:** `DefaultAzureCredential` reads `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` via `System.Environment.GetEnvironmentVariable()` — bypassing `IConfiguration` entirely. These variables do NOT appear in `appsettings.json` or through the `IConfiguration` indexer pattern. Pass 1 grep on `*.json`/configuration files misses them.
+
+**Detection:**
+```bash
+grep -rn 'DefaultAzureCredential\|Azure\.Identity' . --include='*.cs' --include='*.csproj' | grep -v 'test\|Test'
+```
+
+**Rule:** When `Azure.Identity` is present in dependencies:
+1. Pass 3 (Direct OS env reads) is MANDATORY — these vars bypass IConfiguration
+2. Add to ENV_VARIABLES.md: `AZURE_TENANT_ID` (ConfigMap), `AZURE_CLIENT_ID` (ConfigMap), `AZURE_CLIENT_SECRET` (Secret)
+3. For Kubernetes with Workload Identity (AKS equivalent of IRSA): `AZURE_CLIENT_SECRET` uses empty-string Secret pattern, ServiceAccount gets `azure.workload.identity/client-id` annotation
+
+## Tests/ Compile Inclusion Exclusion
+
+**Trigger:** .NET solution with `Tests/` or `*.Tests` project in the solution file.
+
+**Problem:** During Docker multi-stage build, if the solution file references test projects and test project dependencies are not restored, `dotnet build` fails with missing reference errors. Test projects typically reference `xunit`, `NUnit`, or `MSTest` packages not needed in production.
+
+**Detection:**
+```bash
+grep -n '\.Tests\|\.Test\|\.IntegrationTests' *.sln 2>/dev/null
+```
+
+**Fix — exclude test projects in Dockerfile:**
+```dockerfile
+# Option A: Build specific project only (preferred)
+RUN dotnet publish src/MyApp/MyApp.csproj -c Release -o /app/publish
+
+# Option B: If solution-level build is required, remove test projects first
+RUN dotnet sln remove tests/MyApp.Tests/MyApp.Tests.csproj && \
+    dotnet publish -c Release -o /app/publish
+```
+
+**Rule:** Production Dockerfiles MUST either target a specific non-test project with `dotnet publish <project>.csproj` or remove test projects from the solution before building. Never rely on `dotnet build` of the entire solution in a production Docker image.
+
+## SignalR Method-Level Auth
+
+**Trigger:** ASP.NET Core SignalR hubs with `[Authorize]` attributes on individual hub methods rather than the hub class.
+
+**Problem:** Method-level `[Authorize]` on SignalR hub methods does NOT prevent unauthenticated WebSocket connections — it only prevents method invocation AFTER connection. The health/readiness probe's WebSocket handshake path is NOT affected, but auth middleware ordering matters.
+
+**Detection:**
+```bash
+grep -rn '\[Authorize\]' . --include='*.cs' | grep -i 'Hub'
+```
+
+**Rule:** When SignalR uses auth:
+1. Apply `[Authorize]` at hub CLASS level (not just method level) for consistent behavior
+2. Ensure probe paths are OUTSIDE the SignalR hub route group
+3. Map health check before auth middleware: `app.MapHealthChecks("/health")` must precede `app.UseAuthorization()`
+
+## Dotted-Key ConfigMap envFrom Limitation
+
+**Trigger:** .NET appsettings.json keys using the `Section:Key` convention mapped to `Section__Key` env vars when using envFrom bulk injection.
+
+**Problem:** While .NET uses `__` (double underscore) as the section separator for env vars, some configurations use dotted keys directly in ConfigMap (e.g., `Logging:LogLevel:Default`). These work with explicit `env[]` injection but are silently skipped by `envFrom` because `:` is invalid in env var names.
+
+**Detection:**
+```bash
+python3 -c "
+import yaml
+with open('kubernetes/configmap.yaml') as f:
+    for doc in yaml.safe_load_all(f):
+        if doc and doc.get('kind') == 'ConfigMap':
+            for k in doc.get('data', {}).keys():
+                if ':' in k or '.' in k:
+                    print(f'INCOMPATIBLE KEY: {k} — skipped by envFrom')
+"
+```
+
+**Rule:** All .NET ConfigMap keys used with `envFrom` MUST use the double-underscore convention (`Section__Key`), NOT colon or dot separators. For keys that must contain special characters, use explicit `env[].valueFrom.configMapKeyRef`.
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/go-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/go-patterns.md
@@ -1,0 +1,575 @@
+# Go Patterns Reference
+
+Go-specific operations for Kubernetes containerisation transformation. Applies when `go.mod` is present.
+
+## Table of Contents
+
+0. [Sandbox Go Bootstrap](#sandbox-go-bootstrap)
+1. [go mod tidy Workflow](#go-mod-tidy-workflow)
+2. [go.sum Hash Retrieval](#gosum-hash-retrieval)
+3. [go vet vs go build](#go-vet-vs-go-build)
+4. [viper.AutomaticEnv() Detection](#viper-automaticenv-detection)
+5. [viper.SetEnvKeyReplacer Ordering](#viper-setenvkeyreplacer-ordering)
+6. [Viper Test Isolation](#viper-test-isolation)
+7. [Typed Env Helpers and Three-Pass Grep](#typed-env-helpers-and-three-pass-grep)
+8. [Digit-Inclusive Regex for Env Var Names](#digit-inclusive-regex)
+9. [aws-sdk-go v1 Type Traps](#aws-sdk-go-v1-type-traps)
+10. [Middleware Factory Closures](#middleware-factory-closures)
+11. [Credential Sweep Locations](#credential-sweep-locations)
+12. [gRPC Health Probes](#grpc-health-probes)
+13. [Fiber Logger Output Nil-Panic](#fiber-logger-output-nil-panic)
+14. [Go Runtime Env Vars](#go-runtime-env-vars)
+15. [S3 Mock Testing with httptest](#s3-mock-testing-with-httptest)
+16. [go mod tidy Timing](#go-mod-tidy-timing)
+17. [Code Removal Import Audit](#code-removal-import-audit)
+18. [IRSA Empty-String Guard](#irsa-empty-string-guard)
+19. [Route-Group-to-Bounded-Context Algorithm](#route-group-to-bounded-context-algorithm)
+20. [Config Struct Domain Split](#config-struct-domain-split)
+21. [Inline DB Migration → Job Extraction](#inline-db-migration-job-extraction)
+22. [Viper AutomaticEnv Key-to-ConfigMap Alignment](#viper-automaticenv-key-to-configmap-alignment)
+23. [Test-File Scoping for Removals](#test-file-scoping-for-removals)
+24. [Gin/Chi/Fiber Health Probe Ordering](#ginchifiber-health-probe-ordering)
+
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify Go source compiles, passes vet, and basic tests run — all BEFORE `docker build`. This consolidates the existing Sandbox Go Bootstrap into a formal validation gate.
+
+### Commands
+```bash
+# 1. Vet all packages (includes test files)
+go vet ./...
+# Expected: exit 0
+
+# 2. Build all packages (production code only)
+go build ./...
+# Expected: exit 0
+
+# 3. Unit tests (short mode, excludes long-running/integration)
+go test ./... -short -count=1 2>&1
+# Exit 0 = PASS; infrastructure failures = CONDITIONAL PASS
+
+# 4. Verify binary at expected path (if applicable)
+ls <expected-binary-path> 2>/dev/null || go build -o /tmp/app-binary ./cmd/...
+```
+
+### Expected Output
+- Step 1: No output (exit 0 = all clean)
+- Step 2: Exit 0
+- Step 3: Exit 0 or infrastructure-only failures
+- Step 4: Binary exists
+
+### CONDITIONAL PASS Triggers
+- `go` not installed and `mise install go` fails → CONDITIONAL PASS
+- Go version mismatch (go.mod directive > host version) → CONDITIONAL PASS
+- `go mod download` network failure (after 1 retry) → CONDITIONAL PASS
+
+### Toolchain Bootstrap
+See §Sandbox Go Bootstrap (above) and §Mise/asdf Toolchain Bootstrap for the full procedure.
+
+### Validated Example Repositories
+- NOT YET VALIDATED AGAINST REAL REPO — commands inferred from Go documentation and existing §Sandbox Go Bootstrap. Mark as validated when a Go project passes through the pipeline.
+
+
+## Sandbox Go Bootstrap
+
+```bash
+# Step 1: Check if go is available
+go version
+# Step 2: If absent — try system path
+export PATH=$PATH:/usr/local/go/bin && go version
+# Step 3: Try mise shims
+mise install golang && mise use go@latest && export PATH=$HOME/.local/share/mise/shims:$PATH
+# Step 4: Install from go.dev (match go.mod directive)
+GO_VERSION=1.22.4
+curl -sL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar xz -C /usr/local
+export PATH=$PATH:/usr/local/go/bin
+```
+
+If all steps fail, fall back to structural analysis only.
+
+## go mod tidy Workflow
+
+When removing a library:
+1. Remove the `require` directive (direct dependency line only)
+2. Run `go mod tidy` — removes transitive deps and updates `go.sum`
+3. Never manually edit transitive dependency lines
+4. If `go mod tidy` fails with "missing go.sum entry", run `go mod download` first
+
+## go.sum Hash Retrieval
+
+When Go toolchain is unavailable:
+```bash
+curl -s "https://sum.golang.org/lookup/<module>@<version>"
+```
+
+## go vet vs go build
+
+| Command | Compiles _test.go? | Use When |
+|---------|-------------------|----------|
+| `go build ./...` | No | Verify production code |
+| `go vet ./...` | Yes | Verify ALL code including tests |
+
+## viper.AutomaticEnv() Detection
+
+**If `AutomaticEnv()` IS present**: every config key is overridable via env var. Factor 3 compatible.
+
+**If NOT present**: Factor 3 Blocker — must add `AutomaticEnv()` or explicit `BindEnv` calls.
+
+```bash
+grep -rn 'AutomaticEnv\|BindEnv' .
+```
+
+## viper.SetEnvKeyReplacer Ordering
+
+Replacer MUST be set BEFORE `AutomaticEnv()` AND BEFORE `ReadInConfig()`:
+```go
+// CORRECT ORDER:
+viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+viper.AutomaticEnv()
+viper.ReadInConfig()  // Must be AFTER AutomaticEnv + Replacer
+```
+
+Env var derivation: `section.sub-key` → `SECTION_SUB_KEY`.
+
+**Common trap**: If `ReadInConfig()` is called before `AutomaticEnv()`, config-file values take precedence and env vars are ignored for those keys.
+
+## Viper Test Isolation
+
+Tests that modify viper global state MUST use `viper.Reset()` + `t.Cleanup`:
+
+```go
+func TestConfig(t *testing.T) {
+    viper.Reset()
+    t.Cleanup(func() { viper.Reset() })
+    
+    t.Setenv("DATABASE_HOST", "testhost")
+    viper.AutomaticEnv()
+    
+    assert.Equal(t, "testhost", viper.GetString("DATABASE_HOST"))
+}
+```
+
+**Rule**: Never rely on viper global state persisting between tests. Always reset before and cleanup after. `t.Setenv` marks test as `t.Parallel()`-incompatible — no manual cleanup needed for env vars.
+
+## Typed Env Helpers and Three-Pass Grep
+
+```go
+func getEnvInt64OrDefault(key string, defaultVal int64) int64 {
+    val := os.Getenv(key)
+    if val == "" { return defaultVal }
+    parsed, err := strconv.ParseInt(val, 10, 64)
+    if err != nil { return defaultVal }
+    return parsed
+}
+```
+
+**Three-pass env var enumeration** — standard `os.Getenv` grep misses custom helpers and Viper keys:
+
+```bash
+# Pass 1: Standard os.Getenv
+grep -rhoP 'os\.Getenv\("([A-Za-z][A-Za-z0-9_]+)"\)' . --include='*.go' | sort -u
+
+# Pass 2: Custom helpers (getEnv, GetEnvOrDefault, envOr, etc.)
+grep -rn 'getEnv\|GetEnv\|envOr\|EnvOr\|MustGetEnv' . --include='*.go' | grep -v '_test.go'
+
+# Pass 3: Viper Get* calls — derive env var name via replacer rules
+grep -rhoP 'viper\.Get\w+\("([^"]+)"\)' . --include='*.go' | \
+  grep -oP '"[^"]+"' | tr -d '"' | \
+  sed 's/[.-]/_/g' | tr '[:lower:]' '[:upper:]' | sort -u
+```
+
+**Pass 3 explanation**: When `viper.AutomaticEnv()` + `SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))` is active, every `viper.GetString("database.host")` call resolves to env var `DATABASE_HOST`. Pass 3 applies the replacer rules to viper keys to derive the expected env var names.
+
+**Rule**: When enumerating env vars for ENV_VARIABLES.md in Go/Viper projects, always run ALL THREE passes. Custom helpers (Pass 2) and Viper keys (Pass 3) are invisible to Pass 1 alone.
+
+## Digit-Inclusive Regex
+
+When extracting env var names from Go source, the regex MUST be `[A-Za-z][A-Za-z0-9_]+` (digit-inclusive):
+
+```bash
+# CORRECT: catches S3_BUCKET_V2, PORT_8080, AWS_S3_BUCKET
+grep -rhoP '[A-Za-z][A-Za-z0-9_]+' ...
+
+# WRONG: misses vars with digits
+grep -rhoP '[A-Z][A-Z_]+' ...
+```
+
+This applies to ALL language patterns, not just Go.
+
+## aws-sdk-go v1 Type Traps
+
+- `s3.PutObjectInput.Body` is `io.ReadSeeker` — `bytes.Buffer` does NOT satisfy. Use `bytes.NewReader(data)`.
+- `*string`/`*int64` wrappers: use `aws.String()`, `aws.Int64()`.
+
+## Middleware Factory Closures
+
+```go
+func AuthMiddleware(secret string) func(http.Handler) http.Handler {
+    if secret == "" { panic("AUTH_SECRET must not be empty") }
+    return func(next http.Handler) http.Handler { /* ... */ }
+}
+```
+
+**Migration impact**: Startup-time validation in outer function fails if env var empty — correct behaviour for required config.
+
+## Credential Sweep Locations
+
+```bash
+# (1) Config files
+grep -rn 'password\|secret\|token\|apikey' . --include='*.yaml' --include='*.toml' --include='*.json'
+# (2) Hardcoded string constants
+grep -rn '".*password.*"\|".*secret.*"' . --include='*.go' | grep -v '_test.go'
+# (3) viper.SetDefault with credentials (CRITICAL)
+grep -rn 'SetDefault.*password\|SetDefault.*secret\|SetDefault.*token' . --include='*.go'
+```
+
+**Critical**: `viper.SetDefault("database.password", "secret123")` executes on every pod start if config file is missing — expected state in containers.
+
+## gRPC Health Probes
+
+**Dockerfile addition**:
+```dockerfile
+FROM golang:1.22 AS health-probe
+RUN GOBIN=/out go install github.com/grpc-ecosystem/grpc-health-probe@latest
+
+FROM <base>
+COPY --from=health-probe /out/grpc_health_probe /usr/local/bin/
+```
+
+**Probe config**:
+```yaml
+livenessProbe:
+  exec:
+    command: ["grpc_health_probe", "-addr=:50051"]
+```
+
+**Pre-requisite**: gRPC server MUST register health service. Verify:
+```bash
+grep -rn 'RegisterHealthServer\|health\.NewServer' . --include='*.go'
+```
+If absent, add `health.RegisterHealthServer(grpcServer, health.NewServer())` — probes will fail without this.
+
+## Fiber Logger Output Nil-Panic
+
+Fiber's `logger.New()` panics if `Output` is explicitly set to `nil`:
+
+```go
+// BAD: panics at runtime
+app.Use(logger.New(logger.Config{
+    Output: nil,
+}))
+
+// GOOD: omit Output field (defaults to os.Stdout)
+app.Use(logger.New(logger.Config{
+    Format: "[${time}] ${status} - ${method} ${path}\n",
+}))
+
+// GOOD: explicit os.Stdout
+app.Use(logger.New(logger.Config{
+    Output: os.Stdout,
+}))
+```
+
+**Detection**: `grep -rn 'logger\.New\|logger\.Config' . --include='*.go'`
+
+## Go Runtime Env Vars
+
+These env vars are consumed by the Go runtime itself and MUST be excluded from orphan-key checks in Criterion 10(C):
+
+- `GOMAXPROCS`, `GOMEMLIMIT`, `GOGC`, `GODEBUG`
+- `GOPATH`, `GOROOT`, `GOPROXY`, `GONOSUMCHECK`
+
+**Criterion 10 rules**:
+- **10(A)**: GOMEMLIMIT/GOMAXPROCS MUST have ConfigMap entries when set for container tuning.
+- **10(C)**: Do NOT flag these as "orphaned ConfigMap keys" — consumed by Go runtime, invisible to `os.Getenv()` grep. Only the orphan check (C) is waived.
+
+**Standard ConfigMap additions for Go projects**:
+```yaml
+data:
+  GOMAXPROCS: "2"
+  GOMEMLIMIT: "400MiB"
+```
+
+**Rule**: Do NOT flag these as "orphaned ConfigMap keys". They are consumed by the Go runtime, not by `os.Getenv()` calls in application code. They belong in ConfigMap IF explicitly set for container tuning.
+
+## S3 Mock Testing with httptest
+
+For unit tests that exercise S3 client code without network:
+
+```go
+func TestS3Upload(t *testing.T) {
+    // Create fake S3 endpoint
+    server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusOK)
+    }))
+    defer server.Close()
+
+    // Configure AWS SDK to use test server
+    cfg, _ := config.LoadDefaultConfig(context.TODO(),
+        config.WithEndpointResolverWithOptions(
+            aws.EndpointResolverWithOptionsFunc(func(service, region string, opts ...interface{}) (aws.Endpoint, error) {
+                return aws.Endpoint{URL: server.URL, SigningRegion: "us-east-1"}, nil
+            }),
+        ),
+        config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("test", "test", "")),
+    )
+    client := s3.NewFromConfig(cfg, func(o *s3.Options) { o.UsePathStyle = true })
+    // ... test with client
+}
+```
+
+## go mod tidy Timing
+
+**Critical ordering**: `go mod tidy` modifies the `go` directive in `go.mod` if dependencies require a newer Go version. This can break reproducible builds.
+
+```bash
+# SAFE sequence:
+go get <new-dependency>
+go mod tidy
+go build ./...  # Verify after tidy
+
+# DANGER: go get can bump the go directive
+# Always check: git diff go.mod | grep '^+go '
+```
+
+**Rule**: Run `go mod tidy` AFTER all dependency additions/removals, but BEFORE `go build`. If `go mod tidy` bumps the `go` directive, verify the CI/CD toolchain supports that version.
+
+## Code Removal Import Audit
+
+```bash
+# Verify no remaining usages before removing import
+grep -rn '<package_alias>\.' . --include='*.go' | grep -v '^\s*//'
+```
+
+**Rule**: NEVER remove an import without confirming zero non-comment usages remain.
+
+## IRSA Empty-String Guard
+
+`viper.GetString()` returns `""` for unset keys, but passing `""` to AWS SDK does NOT fall through to IRSA:
+
+```go
+// BAD: empty string prevents IRSA fallback
+accessKey := viper.GetString("aws.access_key_id")
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+)
+
+// GOOD: guard with non-empty check
+accessKey := viper.GetString("aws.access_key_id")
+secretKey := viper.GetString("aws.secret_access_key")
+var opts []func(*config.LoadOptions) error
+if accessKey != "" && secretKey != "" {
+    opts = append(opts, config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+    ))
+}
+cfg, _ := config.LoadDefaultConfig(ctx, opts...)
+```
+
+**Detection:**
+```bash
+grep -rn 'GetString.*access_key\|GetString.*secret_key\|NewStaticCredentials' . --include='*.go'
+```
+
+## Route-Group-to-Bounded-Context Algorithm
+
+For Go HTTP projects using routers (gin, fiber, chi, mux), identify decomposition candidates by route groups:
+
+**Step 1: Extract route registrations**
+```bash
+# Gin
+grep -rn '\.GET\|\.POST\|\.PUT\|\.DELETE\|\.Group(' . --include='*.go' | grep -v '_test.go'
+# Chi
+grep -rn 'r\.Route\|r\.Get\|r\.Post\|r\.Mount(' . --include='*.go'
+# Fiber
+grep -rn 'app\.Get\|app\.Post\|app\.Group(' . --include='*.go'
+```
+
+**Step 2: Group by URL prefix**
+Each `router.Group("/api/uploads")` or `r.Mount("/api/orders", ...)` is a bounded context.
+
+**Step 3: Map groups to service candidates**
+Each route group with ≥3 endpoints AND its own data model = decomposition candidate. Groups that only proxy to a shared handler are NOT independent candidates.
+
+## Config Struct Domain Split
+
+Go projects often have a single monolithic `Config` struct. For decomposition, split by domain:
+
+**Before (monolith):**
+```go
+type Config struct {
+    DBHost    string `mapstructure:"database.host"`
+    S3Bucket  string `mapstructure:"s3.bucket"`
+    SMTPHost  string `mapstructure:"smtp.host"`
+}
+```
+
+**After (domain-split):**
+```go
+type DatabaseConfig struct { Host string `mapstructure:"database.host"` }
+type StorageConfig struct { S3Bucket string `mapstructure:"s3.bucket"` }
+type NotificationConfig struct { SMTPHost string `mapstructure:"smtp.host"` }
+```
+
+**Impact on ENV_VARIABLES.md:** Each domain config maps to a K8s Scope classification.
+
+## Inline DB Migration → Job Extraction
+
+Go projects often run DB migrations inline at startup:
+
+```go
+// BEFORE: blocks startup, runs on EVERY pod start
+func main() {
+    db := connectDB()
+    migrate.Up(db, "migrations/")
+    startHTTPServer()
+}
+```
+
+**Extract to Kubernetes Job:**
+```go
+// cmd/migrate/main.go
+func main() {
+    db := connectDB()
+    if err := migrate.Up(db, "migrations/"); err != nil { log.Fatal(err) }
+}
+```
+
+**Rule:** DB migrations that run DDL MUST be extracted to a Job.
+
+## Viper AutomaticEnv Key-to-ConfigMap Alignment
+
+When viper uses `AutomaticEnv()` with a key replacer, ConfigMap keys must match the env var name that viper expects:
+
+```go
+viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
+viper.AutomaticEnv()
+// Config key "database.host" → env var "DATABASE_HOST"
+// Config key "redis-url" → env var "REDIS_URL"
+```
+
+**Alignment gate**: For every viper config key used in the application, compute the expected env var name using the replacer rules, then verify that exact key exists in the ConfigMap. Mismatches cause silent fallback to config-file or zero values.
+
+```bash
+# Find all viper.Get* calls and extract keys
+grep -rhoP 'viper\.Get\w+\("([^"]+)"\)' . --include='*.go' | \
+  sed 's/[.-]/_/g' | tr '[:lower:]' '[:upper:]' | sort -u > /tmp/viper_expected.txt
+# Compare against ConfigMap keys
+python3 -c "import yaml; d=yaml.safe_load(open('kubernetes/configmap.yaml')); [print(k) for k in sorted(d.get('data',{}).keys())]" > /tmp/cm_keys.txt
+comm -23 /tmp/viper_expected.txt /tmp/cm_keys.txt
+```
+
+## Test-File Scoping for Removals
+
+Before finalising any task that removes a struct field, type, or method:
+```bash
+grep -rn '<Name>' . --include='*_test.go'
+```
+If matches found, include those test files in the same task scope. Leaving `_test.go` with undefined references breaks `go vet ./...` across task boundaries.
+
+## Gin/Chi/Fiber Health Probe Ordering
+
+**Problem:** In Go HTTP frameworks, middleware registered with `router.Use()` applies only to routes registered AFTER the `Use()` call. Health/readiness probe endpoints registered AFTER global auth middleware receive 401/403 from K8s liveness/readiness checks, blocking pod readiness.
+
+**Rule:** Health probe routes MUST be registered BEFORE any global auth middleware.
+
+**Gin — CORRECT ordering:**
+```go
+router := gin.New()
+
+// 1. Register health probes FIRST (no auth)
+router.GET("/healthz", healthHandler)
+router.GET("/readyz", readyHandler)
+
+// 2. THEN apply auth middleware
+router.Use(authMiddleware())
+
+// 3. Register protected routes
+api := router.Group("/api")
+api.GET("/users", usersHandler)
+```
+
+**Gin — WRONG (probes receive 401):**
+```go
+router := gin.New()
+router.Use(authMiddleware())     // Auth applied globally first
+router.GET("/healthz", healthHandler) // Probe is AFTER auth — gets 401!
+```
+
+**Chi:**
+```go
+r := chi.NewRouter()
+// Health routes BEFORE middleware stack
+r.Get("/healthz", healthHandler)
+r.Group(func(r chi.Router) {
+    r.Use(authMiddleware)
+    r.Get("/api/users", usersHandler)
+})
+```
+
+**Fiber:**
+```go
+app := fiber.New()
+app.Get("/healthz", healthHandler)  // Before Use()
+app.Use(authMiddleware)
+app.Get("/api/users", usersHandler)
+```
+
+**Detection:**
+```bash
+# Find where health routes are registered relative to Use() calls
+grep -n '\.Use\|healthz\|readyz\|/health' . --include='*.go' -r | sort -t: -k2 -n
+# If Use(auth...) line number < health route line number → potential issue
+```
+
+**Source:** Gin middleware applies only to subsequently registered routes (https://medium.techkoalainsights.com/5-advanced-gin-middleware-chaining-patterns-most-developers-get-wrong-performance-tips-and-eee719306a68).
+
+## Mise/asdf Toolchain Bootstrap
+
+**Trigger:** Go project with `.tool-versions` or `.mise.toml` in repo root.
+
+**Problem:** The Go binary may not be available in PATH until mise/asdf activates the correct version. Build/test/vet commands fail with "go: command not found".
+
+**Bootstrap procedure:**
+```bash
+# Check for mise config
+if [ -f .tool-versions ] || [ -f .mise.toml ]; then
+  mise install golang 2>/dev/null || mise install go 2>/dev/null
+  export PATH=$HOME/.local/share/mise/shims:$PATH
+fi
+go version  # Verify
+```
+
+**Rule:** Before ANY `go build`, `go vet`, or `go test` command, check for mise/asdf config and activate. This applies to both Sub-Phase §17 (Dockerfile) and Sub-Phase §13 (test verification).
+
+## Post-Externalisation Test Sync (Go)
+
+**Trigger:** After adding `os.Getenv()` calls for configuration that previously had hardcoded values.
+
+**Problem:** Go tests using `os.Getenv()` return empty string when the var isn't set in the test environment, causing test failures or unexpected behaviour.
+
+**Fix — set env in test setup:**
+```go
+func TestMain(m *testing.M) {
+    os.Setenv("DB_HOST", "localhost")
+    os.Setenv("DB_PORT", "5432")
+    code := m.Run()
+    os.Exit(code)
+}
+```
+
+**Rule:** After externalising any config to env var reads, verify test suite still passes. If tests fail due to empty env vars, add `os.Setenv()` in `TestMain` or test fixtures.
+
+## IRSA-Scope-Only Service Category
+
+**Trigger:** Go services that ONLY use AWS SDK (no HTTP endpoint, no database — pure S3/SQS worker).
+
+**Problem:** For services that only interact with AWS and have no other backing services, the manifest requirements are minimal: ServiceAccount with IRSA annotation, no Redis/DB egress needed.
+
+**Rule:** When a Go service's only external dependency is AWS (detected by `grep -rn 'aws-sdk-go' go.mod`), generate:
+- ServiceAccount with `eks.amazonaws.com/role-arn` annotation
+- NetworkPolicy with DNS + HTTPS (443) egress only
+- No Redis/DB egress rules
+- ConfigMap with AWS_DEFAULT_REGION only (credentials via IRSA)
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/java-jvm-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/java-jvm-patterns.md
@@ -1,0 +1,2403 @@
+# Java/Maven/Gradle Patterns Reference (covers Maven AND Gradle)
+
+Java, Maven, and Gradle-specific containerisation gotchas for Phase 2 transformation. Applies when `pom.xml` OR `build.gradle`/`build.gradle.kts` is present. **This file applies to ANY project with pom.xml OR build.gradle — not Maven-only.**
+
+## ⚠ Host-Side Compilation Mandate
+
+**Host-side compilation (`mvn package -DskipTests` or `./gradlew build -x test`) MUST succeed before `docker build` is attempted.** This is a hard prerequisite — not optional.
+
+**Rationale:** Compilation errors caught at Step 0 (pre-Docker) provide faster feedback and clearer error messages than failures buried in a Docker build log. Compiling inside Docker (multi-stage) is acceptable for image correctness but does NOT replace the host-side verification gate.
+
+**Commands:**
+- Maven: `mvn package -DskipTests -B -q`
+- Maven Wrapper: `./mvnw package -DskipTests -B`
+- Gradle: `./gradlew build -x test --no-daemon`
+
+**Verification:** Exit code 0 AND artifact exists:
+```bash
+# Maven:
+ls target/*.jar target/*.war 2>/dev/null | head -1
+
+# Gradle:
+ls build/libs/*.jar 2>/dev/null | head -1
+```
+
+**If toolchain version mismatch prevents compilation** (e.g., project requires JDK 8 but host has JDK 21), record `CONDITIONAL PASS` with root cause — do NOT silently skip. See `references/docker-build-validation.md` §Step 0 for the full procedure.
+
+**Maven offline mode limitation:** `mvn -o package` fails for any uncached artifact. If the local Maven cache (`~/.m2/repository`) does not contain all dependencies, online mode is required for the first build. Do NOT use `-o` for the host-side compilation gate unless you have confirmed all dependencies are cached.
+
+
+## Java Toolchain Bootstrap via mise
+
+**Purpose:** Resolve JDK version mismatches by installing the required version via mise before compilation.
+
+### Procedure
+```bash
+# 1. Detect required Java version from pom.xml or build.gradle
+JAVA_VER=$(grep -oP '(?:java\.version|maven\.compiler\.release|maven\.compiler\.source)>\K[^<]+' pom.xml 2>/dev/null | head -1)
+[ -z "$JAVA_VER" ] && JAVA_VER=$(grep -oP 'sourceCompatibility\s*=\s*[\x27"]?\K[0-9]+' build.gradle 2>/dev/null)
+
+# 2. Attempt mise install
+if command -v mise >/dev/null 2>&1 && [ -n "$JAVA_VER" ]; then
+  mise install java@corretto-$JAVA_VER 2>/dev/null || mise install java@temurin-$JAVA_VER 2>/dev/null
+  export JAVA_HOME=$(mise where java 2>/dev/null)
+  export PATH=$JAVA_HOME/bin:$PATH
+fi
+
+# 3. Verify
+java -version 2>&1 | head -1
+```
+
+### When to Use
+Before the Host-Side Compilation Mandate (above), when `java -version` shows a version mismatch with the project requirement. Always attempt before recording CONDITIONAL PASS.
+
+### Validated Example Repositories
+- **Shopizer** (github.com/shopizer-ecommerce/shopizer): JDK 21 via `mise install java@corretto-21`; `mvn package -DskipTests` exits 0, produces 193MB JAR. Validated 2026-06.
+- **OpenMRS-core** (github.com/openmrs/openmrs-core): JDK 21 required; mise bootstrap resolves version mismatch. Validated 2026-06.
+
+
+## Table of Contents
+
+1. [Maven Offline Fallback](#maven-offline-fallback)
+2. [Maven Wrapper Detection](#maven-wrapper-detection)
+3. [Maven Compile Timeout Fallback](#maven-compile-timeout-fallback)
+4. [Gradle Dispatch Condition](#gradle-dispatch-condition)
+5. [Hibernate Property Placeholders](#hibernate-property-placeholders)
+6. [Spring @Value Namespace Bridging](#spring-value-namespace-bridging)
+7. [JDBC URL Segment Composition](#jdbc-url-segment-composition)
+8. [Liquibase Startup Probe Timing](#liquibase-startup-probe-timing)
+9. [Embedded Tomcat Scope Pitfall](#embedded-tomcat-scope-pitfall)
+10. [env.getProperty Null Return](#envgetproperty-null-return)
+11. [Spring Session Redis in Tests](#spring-session-redis-in-tests)
+12. [Quartz Job Lifecycle](#quartz-job-lifecycle)
+13. [Quartz JDBC Clustering](#quartz-jdbc-clustering)
+14. [Multi-Module DDL Race](#multi-module-ddl-race)
+15. [Spring Profile Default Preservation](#spring-profile-default-preservation)
+16. [Multi-Profile SPRING_PROFILES_ACTIVE Composition](#multi-profile-composition)
+17. [Commented-Out Property Detection and Activation](#commented-out-property-detection)
+18. [Spring Auto-Config Exclusion for Standalone Jobs](#spring-auto-config-exclusion)
+19. [Quartz DataSource Isolation](#quartz-datasource-isolation)
+20. [Shared Maven Module Refactoring](#shared-maven-module-refactoring)
+21. [Copy-Startup Init Container for readOnlyRootFilesystem](#copy-startup-init-container)
+22. [WAR-Embedded Liquibase Job](#war-embedded-liquibase-job)
+23. [Infinispan JGroups KUBE_PING](#infinispan-jgroups-kube-ping)
+24. [Spring XML + Boot Hybrid Safety](#spring-xml-boot-hybrid)
+25. [ReflectionTestUtils for @Value Fields](#reflectiontestutils)
+26. [JdbcTemplate Varargs Mockito Stub](#jdbctemplate-varargs-mockito)
+27. [H2/Dev Profile Exclusion](#h2-dev-profile-exclusion)
+28. [Spring CronJob CommandLineRunner Bridge](#spring-cronjob-commandlinerunner-bridge)
+29. [Criterion 10D Three-Pass Inventory](#criterion-10d-three-pass-inventory)
+30. [Java Interface Default Method Override Rules](#java-interface-default-method-override-rules)
+31. [Spring Session 4.x in Traditional WAR (non-Boot)](#spring-session-non-boot-war)
+32. [Multi-Module Maven Dockerfile Build Context](#multi-module-maven-dockerfile)
+33. [Alpine JRE HEALTHCHECK (wget not curl)](#alpine-jre-healthcheck)
+34. [Spring Non-Boot Dependency Guard](#spring-non-boot-dependency-guard)
+35. [Tomcat WAR emptyDir Inventory](#tomcat-war-emptydir-inventory)
+36. [Liquibase 4.4+ searchPath](#liquibase-44-searchpath)
+37. [camelCase @Value Env-Lowercasing Conflict](#camelcase-value-env-lowercasing)
+38. [PropertiesFactoryBean Action Protocol](#propertiesfactorybean-action-protocol)
+39. [WAR-to-JAR Packaging Check](#war-to-jar-packaging-check)
+40. [Spring XML PPC + Boot PSPC Hybrid](#spring-xml-ppc-boot-pspc-hybrid)
+41. [Factory-Method Singleton Refactor](#factory-method-singleton-refactor)
+42. [ActiveProfiles Test Activation](#activeprofiles-test-activation)
+43. [Required-Secret Test Shadow Rule](#required-secret-test-shadow-rule)
+44. [Graceful Shutdown Check](#graceful-shutdown-check)
+45. [Multi-Module Test Shadow](#multi-module-test-shadow)
+46. [terminationGracePeriodSeconds Formula](#terminationgraceperiodseconds-formula)
+47. [Quartz initialize-schema Restart Risk](#quartz-initialize-schema-restart-risk)
+48. [Broadened IRSA Trigger](#broadened-irsa-trigger)
+49. [Service-Specific IAM Policy Templates](#service-specific-iam-policy-templates)
+50. [Mixed-Indent sed Fallback](#mixed-indent-sed-fallback)
+51. [@ConfigurationProperties vs XML PPC](#configurationproperties-vs-xml-ppc)
+52. [Startup-Script Write-Tracing](#startup-script-write-tracing)
+53. [Tomcat /bin subPath Mount](#tomcat-bin-subpath-mount)
+54. [mvn package vs mvn compile](#mvn-package-vs-mvn-compile)
+55. [Java Version Pre-Migration Check](#java-version-pre-migration-check)
+56. [SCREAMING_SNAKE_CASE Circular Placeholder](#screaming-snake-case-circular-placeholder)
+57. [SPRING_PROFILES_ACTIVE Mandatory ConfigMap](#spring-profiles-active-mandatory-configmap)
+58. [Infinispan !cloud Profile-Guard](#infinispan-cloud-profile-guard)
+59. [@PropertySource Requirement for @ConfigurationProperties with XML PPC](#propertysource-requirement)
+60. [Alpine Shebang Compatibility](#alpine-shebang-compatibility)
+61. [JVM Flag Ordering in Entrypoint Scripts](#jvm-flag-ordering)
+62. [Log4j2/Logback File-Only Logger Redirect](#log4j2-file-only-logger-redirect)
+63. [S3 ListObjectsV2 Pagination](#s3-listobjectsv2-pagination)
+64. [IAM Policy Two-Statement Split](#iam-policy-two-statement-split)
+
+## Tomcat WAR Deployment (setenv.sh elimination)
+
+**Trigger:** Traditional Tomcat WAR application using `setenv.sh` for JVM/CATALINA_OPTS configuration.
+
+**Problem:** `setenv.sh` is sourced by `catalina.sh` at startup. With `readOnlyRootFilesystem: true`, runtime generation of `setenv.sh` fails. Furthermore, values baked into `setenv.sh` cannot be overridden via Kubernetes env vars.
+
+**Solution — export CATALINA_OPTS/JAVA_OPTS via ConfigMap env vars:**
+```yaml
+# ConfigMap
+data:
+  CATALINA_OPTS: "-Xmx512m -Xms256m -Djava.io.tmpdir=/tmp"
+  JAVA_OPTS: "-Dfile.encoding=UTF-8"
+```
+
+Tomcat's `catalina.sh` reads `CATALINA_OPTS` and `JAVA_OPTS` from the environment automatically — no `setenv.sh` needed.
+
+**Detection:**
+```bash
+grep -rn 'setenv\.sh\|CATALINA_OPTS\|JAVA_OPTS' . --include='*.sh' --include='Dockerfile' | grep -v '#'
+```
+
+**Rule:** Remove all `setenv.sh` generation from entrypoint scripts. Replace with ConfigMap-injected env vars (`CATALINA_OPTS`, `JAVA_OPTS`). Document in ENV_VARIABLES.md.
+
+### Infinispan JGroups Dual-Port NetworkPolicy
+
+When Infinispan/JGroups KUBE_PING is configured (see §23), the NetworkPolicy MUST allow BOTH JGroups ports:
+
+```yaml
+# NetworkPolicy egress for Infinispan cluster communication
+egress:
+- ports:
+  - port: 7800   # JGroups TCP transport
+    protocol: TCP
+  - port: 7801   # JGroups FD (failure detection)
+    protocol: TCP
+  to:
+  - podSelector:
+      matchLabels:
+        app: <app-label>  # Same app — peer-to-peer
+```
+
+**Rule:** When Infinispan/JGroups is detected, add BOTH port 7800 (transport) and 7801 (failure detection) to the pod-to-pod NetworkPolicy egress. Missing port 7801 causes cluster split-brain under network jitter.
+
+## HikariCP API Misuse Detection
+
+**Trigger:** Spring Boot or raw HikariCP configuration in Java applications.
+
+**Problem:** HikariCP methods have non-obvious semantics that cause connection pool exhaustion or silent misconfiguration:
+
+| Method | Misuse | Correct Usage |
+|---|---|---|
+| `setIdleTimeout(0)` | Disables idle timeout → connections never returned | Use `setIdleTimeout(600000)` (10min) |
+| `setMaxLifetime(0)` | Disables max lifetime → stale connections | Use `setMaxLifetime(1800000)` (30min, must be < DB wait_timeout) |
+| `setConnectionTimeout(0)` | Infinite wait for connection → thread starvation | Use `setConnectionTimeout(30000)` (30s) |
+| `setMinimumIdle(maxPoolSize)` | Pool never shrinks → waste under low load | Use `setMinimumIdle(2)` for variable load |
+
+**Detection:**
+```bash
+grep -rn 'setIdleTimeout\|setConnectionTimeout\|setMaxLifetime\|setMinimumIdle' . --include='*.java' --include='*.properties' --include='*.yml' | grep -v test
+```
+
+**Rule:** Flag any `(0)` value for timeout/lifetime settings as a potential connection pool exhaustion bug. Document in INFRASTRUCTURE_REQUIREMENTS.md with recommended production values.
+
+## Spring Boot jar Packaging — tomcat-embed-jasper scope
+
+**Trigger:** Spring Boot JAR projects using JSP views that have `tomcat-embed-jasper` with `<scope>provided</scope>`.
+
+**Problem:** Similar to `spring-boot-starter-tomcat` scope=provided, marking `tomcat-embed-jasper` as provided in a JAR-packaged application causes JSP rendering to fail silently (404 on all JSP views) because the JSP engine is excluded from the fat JAR.
+
+**Detection:**
+```bash
+grep -B2 -A2 'provided' pom.xml | grep -i 'jasper\|tomcat-embed-jasper'
+find . -name '*.jsp' | head -5  # Confirm JSPs exist
+```
+
+**Rule:** For `<packaging>jar</packaging>` with JSP views: remove `<scope>provided</scope>` from `tomcat-embed-jasper`. This is the same pattern as §spring-boot-starter-tomcat scope=provided but for the JSP engine specifically.
+
+## Gradle Dispatch
+
+**Trigger:** `build.gradle` or `build.gradle.kts` present (no pom.xml, or both present).
+
+**Rule:** When `build.gradle` is present, use Gradle commands instead of Maven. This reference file applies to BOTH Maven and Gradle Java projects.
+
+**Detection:**
+```bash
+ls build.gradle build.gradle.kts 2>/dev/null && echo "GRADLE" || echo "MAVEN"
+```
+
+**Key differences from Maven:**
+| Concern | Maven | Gradle |
+|---------|-------|--------|
+| Build | `mvn package -DskipTests` | `./gradlew build -x test` |
+| Test | `mvn test` | `./gradlew test` |
+| Dependency list | `mvn dependency:tree` | `./gradlew dependencies` |
+| Wrapper | `./mvnw` | `./gradlew` |
+| Offline | `mvn -o` | `./gradlew --offline` |
+
+**Dockerfile for Gradle:**
+```dockerfile
+FROM gradle:8-jdk21 AS builder
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+COPY --from=builder /home/gradle/src/build/libs/*.jar /app/app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+```
+
+## Graceful Shutdown Check
+
+**Trigger:** Spring Boot applications deployed as Kubernetes Deployments.
+
+**Problem:** Without `server.shutdown=graceful`, Spring Boot immediately closes all connections on SIGTERM — in-flight requests receive connection-reset errors.
+
+**Detection:**
+```bash
+grep -rn 'server\.shutdown\|spring\.lifecycle' src/main/resources/ --include='*.properties' --include='*.yml' --include='*.yaml'
+```
+
+**Fix — add to application.properties (or ConfigMap):**
+```properties
+server.shutdown=graceful
+spring.lifecycle.timeout-per-shutdown-phase=25s
+```
+
+**Kubernetes manifest alignment:**
+```yaml
+terminationGracePeriodSeconds: 30  # Must be > timeout-per-shutdown-phase
+```
+
+**Rule:** ALL Spring Boot Deployments (not Jobs/CronJobs) MUST have `server.shutdown=graceful` configured. Without it, `terminationGracePeriodSeconds` is ineffective — Spring kills connections immediately regardless of the grace period.
+
+## Quartz JDBC Clustering
+
+**Trigger:** Quartz Scheduler with `org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX` AND HPA replicas > 1.
+
+**Problem:** Without JDBC clustering configuration, multiple pods fire the same scheduled jobs simultaneously. File-based or RAM JobStore does not coordinate across pods.
+
+**Prerequisites:**
+1. Quartz tables must exist in the database (schema DDL: `tables_postgres.sql` / `tables_mysql.sql` from Quartz distribution)
+2. Dedicated DataSource for Quartz (see §Quartz DataSource Isolation)
+
+**Required properties (ConfigMap or application.properties):**
+```properties
+org.quartz.jobStore.isClustered=true
+org.quartz.jobStore.clusterCheckinInterval=20000
+org.quartz.scheduler.instanceId=AUTO
+org.quartz.jobStore.class=org.quartz.impl.jdbcjobstore.JobStoreTX
+org.quartz.jobStore.driverDelegateClass=org.quartz.impl.jdbcjobstore.PostgreSQLDelegate
+org.quartz.jobStore.dataSource=quartzDS
+```
+
+**Detection:**
+```bash
+grep -rn 'quartz\|JobStore\|@Scheduled\|CronTrigger' . --include='*.java' --include='*.properties' --include='*.xml' --include='*.yml'
+```
+
+**Rule:** If Quartz uses JDBC JobStore AND the Deployment has HPA (or replicas > 1), `isClustered=true` and `instanceId=AUTO` are MANDATORY. Document Quartz schema creation as a pre-deployment DBA action in INFRASTRUCTURE_REQUIREMENTS.md.
+
+## Maven Offline Fallback
+
+If `mvn` is unavailable or times out:
+```bash
+xmllint --noout pom.xml
+grep -A3 '<dependency>' pom.xml | grep -E 'groupId|artifactId|version|scope'
+grep -B2 -A2 'provided' pom.xml | grep -i tomcat
+```
+
+## Maven Wrapper Detection
+
+```bash
+find . -name mvnw -type f
+```
+
+If present, use `./mvnw` instead of `mvn`. If neither available, fall back to XML analysis.
+
+## Maven Compile Timeout Fallback
+
+When Maven compile times out (common in sandboxed environments):
+
+```bash
+# Step 1: Validate POM structure without downloading
+xmllint --noout pom.xml && echo "POM valid"
+
+# Step 2: Minimal validation with existing cache
+mvn validate -o 2>/dev/null || echo "Offline validate failed — proceed with static analysis"
+
+# Step 3: Static dependency analysis as substitute
+grep -A5 '<dependency>' pom.xml | grep -oP '<artifactId>\K[^<]+'
+```
+
+**Rule**: If `mvn compile` fails after 2 attempts (timeout or network), fall back to `xmllint` + `bash -n` for structural validation. Do NOT block on Maven availability.
+
+## Hibernate Property Placeholders
+
+```xml
+<property name="hibernate.connection.url">${DATABASE_URL}</property>
+```
+
+**Critical**: Hibernate passes literal `${VAR}` as connection string on unresolved placeholders.
+
+## Spring @Value Namespace Bridging
+
+```properties
+# application.properties
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:app}
+```
+
+**Convention**: External env vars = SCREAMING_SNAKE. Spring properties = dot notation. Bridge in `application.properties`.
+
+## System.getenv() Secondary Scan
+
+The §15 source-authoritative env var grep for Java/Spring typically scans only `.properties`/`.yml` for Spring `${}` bridge syntax. This MISSES direct `System.getenv()` calls in `.java` source files.
+
+**Mandatory two-command scan for Java projects:**
+
+```bash
+# Command 1: Spring bridge syntax in properties/yml (existing)
+grep -rhoP '\$\{([A-Z][A-Z0-9_]+)[}:]' src/ --include='*.properties' --include='*.yml' | sort -u
+
+# Command 2: Direct Java env reads (NEW — must also run)
+grep -rhoP 'System\.getenv\("([A-Z][A-Z0-9_]+)"\)' src/ --include='*.java' | sort -u
+```
+
+Both outputs contribute to ENV_VARIABLES.md. Any var found by Command 2 but not by Command 1 is a direct env var read bypassing Spring property bridging — it still needs a ConfigMap/Secret entry.
+
+## JDBC URL Segment Composition
+
+When a startup script assembles JDBC URL at runtime, set ConfigMap default to empty string for the composed URL. For direct Spring usage:
+```properties
+spring.datasource.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:app}
+```
+
+Each segment gets its own ConfigMap key.
+
+## Liquibase Startup Probe Timing
+
+```yaml
+startupProbe:
+  httpGet: { path: /actuator/health, port: 8080 }
+  failureThreshold: 30
+  periodSeconds: 10
+  # Budget: 300s for initial migration
+```
+
+Rule: For Liquibase/Flyway apps, `startupProbe.failureThreshold × periodSeconds ≥ 300s`. This is an instance of the generalised first-boot init sizing rule in SKILL.md Criterion 8(d) — applies to any schema initialisation tool running at first pod start.
+
+## Embedded Tomcat Scope Pitfall
+
+```xml
+<!-- BAD: breaks containers — silent startup exit -->
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-tomcat</artifactId>
+    <scope>provided</scope>
+</dependency>
+```
+
+**Detection**: `grep -B2 -A2 'provided' pom.xml | grep -i 'tomcat\|jetty\|undertow'`
+
+**Phase 2 mandate:** If detected during Phase 1, removing `<scope>provided</scope>` from the embedded servlet container dependency is REQUIRED in Phase 2 §11 (Build/Release/Run). This is a silent runtime blocker — the container builds successfully but the application exits immediately on startup because Spring Boot cannot find an embedded servlet container. Fix BEFORE docker build. **Do NOT defer** — workers MUST NOT assess this as "non-blocking". For `<packaging>jar</packaging>`, ALWAYS remove `<scope>provided</scope>` from spring-boot-starter-tomcat. This is a known CrashLoopBackOff pattern.
+
+## env.getProperty Null Return
+
+```java
+// BAD: NPE if key missing
+String host = env.getProperty("database.host");
+// GOOD:
+String host = env.getProperty("database.host", "localhost");
+```
+
+## Spring Session Redis in Tests
+
+After adding Redis for sessions, add to ALL test property files:
+```properties
+spring.session.store-type=none
+management.health.redis.enabled=false
+spring.data.redis.repositories.enabled=false
+```
+
+**Required-secret test shadow gate**: After externalising ANY property to `${VAR}` (no default), verify the corresponding test resource file exists. If missing, tests fail with `IllegalArgumentException: Could not resolve placeholder`. Run detection:
+```bash
+# Find properties with no default that were just added/changed
+grep -rn '\${[A-Z_]*}' src/main/resources/*.properties src/main/resources/*.yml 2>/dev/null | grep -v ':'
+# For each match, verify test shadow:
+for f in $(grep -rl '\${[A-Z_]*}' src/main/resources/ 2>/dev/null); do
+  BASENAME=$(basename "$f")
+  [ -f "src/test/resources/$BASENAME" ] || echo "MISSING TEST SHADOW: src/test/resources/$BASENAME"
+done
+```
+
+## Quartz Job Lifecycle
+
+`SpringBeanJobFactory.autowireBean(job)` does NOT invoke `@PostConstruct`:
+
+```java
+// BAD: @PostConstruct never fires for Quartz jobs
+// GOOD: initialise in execute() or use @Bean provider
+```
+
+**Quartz JDBC schema**: If using `JobStoreTX`, Quartz tables must exist before app starts. Document as pre-deployment DBA action.
+
+## Quartz JDBC Clustering
+
+**Trigger:** `spring-boot-starter-quartz` in dependencies AND Quartz configured with `JobStoreTX` (JDBC-backed job store).
+
+**Problem:** When running multiple pod replicas with Quartz JDBC mode, Quartz uses database row-level locks for cluster coordination. Without proper configuration, jobs execute on ALL pods simultaneously (duplicate execution).
+
+**Required properties for clustered Quartz:**
+```properties
+spring.quartz.job-store-type=jdbc
+spring.quartz.properties.org.quartz.jobStore.isClustered=true
+spring.quartz.properties.org.quartz.jobStore.clusterCheckinInterval=20000
+spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO
+```
+
+**Pre-deployment requirements:**
+1. Quartz tables must exist in database (create via `tables_postgres.sql` / `tables_mysql_innodb.sql` from Quartz distribution)
+2. Document as a Job manifest (Liquibase/Flyway migration) or DBA action in INFRASTRUCTURE_REQUIREMENTS.md
+3. All pods must use the same database instance
+
+**Detection:**
+```bash
+grep -rn 'quartz\|JobStore\|@Scheduled\|SchedulerFactoryBean' . --include='*.java' --include='*.properties' --include='*.yml'
+```
+
+**NetworkPolicy impact:** Quartz JDBC pods need egress to the database (TCP 5432/3306) for lock coordination — separate from application DB queries.
+
+**CronJob extraction decision:** If Quartz is used purely for scheduling (not complex job state machines), prefer extracting to Kubernetes CronJob manifests with `concurrencyPolicy: Forbid` — eliminates the clustering complexity entirely.
+
+## Multi-Module DDL Race
+
+Multiple Spring Boot modules with `ddl-auto=update` sharing same DB → lock contention.
+
+**Mitigation:**
+1. Use Flyway/Liquibase in a dedicated migration Job
+2. Set `ddl-auto=validate` in all application modules
+3. Run migration Job before application Deployments
+
+## Spring Profile Default Preservation
+
+```properties
+# application-prod.properties (AFTER migration)
+spring.datasource.url=jdbc:mysql://${DB_HOST:prod-mysql}:${DB_PORT:3306}/${DB_NAME:appdb}
+```
+
+**Rule**: Each profile's default reflects its intended environment.
+
+## Multi-Profile SPRING_PROFILES_ACTIVE Composition
+
+For multi-module applications with multiple active profiles:
+
+```yaml
+# ConfigMap
+SPRING_PROFILES_ACTIVE: "prod,cache,messaging"
+```
+
+**Rules:**
+1. Never hardcode profile activation — always via env var
+2. Profile composition order matters: later profiles override earlier ones
+3. Each module may need different profile combinations → separate ConfigMap entries per workload
+4. Detection: `grep -rn 'spring.profiles.active\|@Profile\|@ActiveProfiles' . --include='*.java' --include='*.properties' --include='*.yml'`
+
+## Commented-Out Property Detection and Activation
+
+Spring properties commented out in `application.properties` may be required for containerised deployment:
+
+```bash
+grep -n '^#.*\${\|^#.*localhost\|^#.*redis\|^#.*spring\.session' src/main/resources/application*.properties
+```
+
+**Common patterns requiring activation:**
+```properties
+# BEFORE (commented out in dev):
+#spring.session.store-type=redis
+# AFTER (activated for container deployment):
+spring.session.store-type=redis
+spring.redis.host=${REDIS_HOST:localhost}
+```
+
+## Spring Auto-Config Exclusion for Standalone Jobs
+
+**Trigger:** Spring Boot application used as a standalone batch job or CronJob.
+
+```java
+@SpringBootApplication(exclude = {
+    DataSourceAutoConfiguration.class,  // If job doesn't need DB
+    WebMvcAutoConfiguration.class       // Always exclude for non-web jobs
+})
+public class BatchJobApplication {
+    public static void main(String[] args) {
+        SpringApplication app = new SpringApplication(BatchJobApplication.class);
+        app.setWebApplicationType(WebApplicationType.NONE);
+        app.run(args);
+    }
+}
+```
+
+**Kubernetes impact:** Container with `--spring.main.web-application-type=none` → no HTTP port → probe type (c) (exec only).
+
+## Quartz DataSource Isolation
+
+**Problem:** Quartz JDBC JobStore shares the application DataSource. With PgBouncer in transaction mode, advisory locks break.
+
+```java
+@Bean
+@QuartzDataSource
+public DataSource quartzDataSource() {
+    HikariDataSource ds = new HikariDataSource();
+    ds.setJdbcUrl(System.getenv("QUARTZ_JDBC_URL"));
+    ds.setMaximumPoolSize(5);
+    return ds;
+}
+```
+
+## Shared Maven Module Refactoring
+
+**Trigger:** Multi-module Maven project where decomposition requires separate Docker images but modules share common code.
+
+```dockerfile
+FROM maven:3.9 AS builder
+COPY pom.xml .
+COPY common/ common/
+COPY web/ web/
+RUN mvn -pl common,web -am package -DskipTests
+
+FROM eclipse-temurin:21-jre-alpine
+COPY --from=builder web/target/web.jar /app/app.jar
+```
+
+**Rule:** The `common` module is built in EVERY image that needs it (via `-pl common,<target> -am`).
+
+## Copy-Startup Init Container for readOnlyRootFilesystem
+
+**Trigger:** Java/Tomcat applications requiring startup scripts that write to the filesystem.
+
+**Solution — init container copies startup artifacts to emptyDir:**
+```yaml
+initContainers:
+- name: copy-startup
+  image: app-image:latest
+  command: ['sh', '-c', 'cp -r /app/startup/* /startup/ && cp -r /app/webapps/* /webapps/']
+  volumeMounts:
+  - name: startup-scripts
+    mountPath: /startup
+  - name: webapps
+    mountPath: /webapps
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities: { drop: ["ALL"] }
+```
+
+**Rule**: Any file written at startup (not runtime) should be prepared in an init container and shared via emptyDir.
+
+## WAR-Embedded Liquibase Job
+
+**Trigger:** WAR file containing Liquibase changelogs that must run as a pre-deployment Job.
+
+**Solution — extract and run from WAR:**
+```yaml
+containers:
+- name: liquibase-migrate
+  image: app-image:latest
+  command:
+  - sh
+  - -c
+  - |
+    cd /tmp
+    jar xf /app/app.war WEB-INF/lib/ WEB-INF/classes/db/
+    java -cp "WEB-INF/lib/*:WEB-INF/classes" \
+      liquibase.integration.commandline.LiquibaseCommandLine \
+      --url="jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}" \
+      --username="${DB_USER}" --password="${DB_PASSWORD}" \
+      --changeLogFile=db/changelog-master.xml \
+      --searchPath=WEB-INF/classes update
+```
+
+## Infinispan JGroups KUBE_PING
+
+**Trigger:** `infinispan` or `jgroups` in dependencies.
+
+**Problem:** JGroups defaults to UDP multicast, blocked in Kubernetes.
+
+**Solution — KUBE_PING discovery:**
+```xml
+<config xmlns="urn:org:jgroups">
+  <jgroups>
+    <TCP bind_addr="${jgroups.bind.address:SITE_LOCAL}" />
+    <kubernetes.KUBE_PING port_range="0" namespace="${KUBE_NAMESPACE}" labels="app=${APP_LABEL}" />
+  </jgroups>
+  <cache-container name="app-cache">
+    <transport cluster="${CLUSTER_NAME:app-cluster}" />
+  </cache-container>
+</config>
+```
+
+**Infinispan 15.x XML element ordering**: `<jgroups>` MUST appear before `<cache-container>`. Within `<cache-container>`, `<transport>` MUST be the first child.
+
+**Detection:** `grep -rn 'jgroups\|infinispan\|JChannel\|KUBE_PING' . --include='*.java' --include='*.xml'`
+
+## Spring XML + Boot Hybrid Safety
+
+**Trigger:** `@ImportResource("classpath:applicationContext.xml")` with Spring Boot auto-configuration.
+
+**Rules:**
+1. Check for XML-defined DataSource conflicting with Boot's auto-configured one
+2. If XML defines `<bean id="dataSource">`, either remove it OR add `spring.datasource.*` properties that align
+3. Detection: `grep -rn 'ImportResource\|ClassPathXmlApplicationContext' . --include='*.java'`
+
+## ReflectionTestUtils for @Value Fields
+
+When testing classes with `@Value` injected fields:
+```java
+ReflectionTestUtils.setField(service, "databaseHost", "test-host");
+```
+
+## JdbcTemplate Varargs Mockito Stub
+
+```java
+// GOOD: Use any() for varargs
+when(jdbcTemplate.query(anyString(), any(RowMapper.class), any())).thenReturn(results);
+```
+
+## H2/Dev Profile Exclusion
+
+**Detection:** `grep -A3 'h2' pom.xml | grep -v 'scope.*test'`
+
+**Fix:** Ensure H2 is `<scope>test</scope>` or in a dev-only profile.
+
+## Spring CronJob CommandLineRunner Bridge
+
+**Solution — CommandLineRunner that invokes job logic and exits**:
+```java
+@SpringBootApplication
+public class CronJobRunner implements CommandLineRunner {
+    @Autowired private MyJobLogic jobLogic;
+    @Autowired private ApplicationContext applicationContext;
+    @Override
+    public void run(String... args) throws Exception {
+        jobLogic.execute();
+        SpringApplication.exit(applicationContext, () -> 0);
+    }
+}
+```
+
+**CronJob timing offset**: Schedule 10-15 minutes before intended fire time to account for Spring Boot startup.
+
+**Javadoc cron anti-pattern**: Do NOT copy Javadoc cron expressions (Spring `*/N` format with seconds) directly into Kubernetes CronJob `schedule:` — Kubernetes uses standard 5-field cron syntax.
+
+## Criterion 10D Three-Pass Inventory
+
+For Java/Spring projects, env var enumeration requires three passes:
+```bash
+# Pass 1: ${VAR} with or without default
+grep -rhoP '\$\{([A-Z][A-Z0-9_]+)[}:]' src/ | tr -d '{}:' | sort -u
+# Pass 2: @Value annotations
+grep -rhoP '@Value\("\$\{([A-Z][A-Z0-9_]+)' src/ | grep -oP '[A-Z][A-Z0-9_]+' | sort -u
+# Pass 3: @PropertySource files → grep those property files
+grep -rn '@PropertySource' src/ --include='*.java'
+```
+
+**Dual PropertyPlaceholderConfigurer**: Legacy Spring XML projects may have multiple `PropertyPlaceholderConfigurer` beans loading different `.properties` files — scan ALL referenced files.
+
+## Java Interface Default Method Override Rules
+
+Three rules that cause compilation failures if violated:
+
+**Rule 1**: Cannot reduce access from public. Interface default methods are implicitly `public`.
+
+**Rule 2**: Static class methods do NOT implement interface instance methods.
+
+**Rule 3**: Overrides cannot add checked exceptions absent from interface signature. Wrap in unchecked or use try-catch internally.
+
+**Detection:** `grep -rn 'default\s\+\w\+\s\+\w\+(.*)\s*{' . --include='*.java'`
+
+## Spring Session 4.x in Traditional WAR (non-Boot)
+
+**Trigger:** `<packaging>war</packaging>` AND no `spring-boot-starter-parent`.
+
+**Critical rules:**
+1. Use `@EnableRedisIndexedHttpSession` (not deprecated `@EnableRedisHttpSession`)
+2. Do NOT extend `AbstractHttpSessionApplicationInitializer` — causes dual ContextLoaderListener conflict
+3. Wire via web.xml `DelegatingFilterProxy` as FIRST filter
+4. Dependencies: `spring-session-data-redis` + `lettuce-core` directly (NOT spring-boot-starter-data-redis)
+
+**Detection:** `grep '<packaging>war</packaging>' pom.xml && grep -L 'spring-boot-starter-parent' pom.xml`
+
+## Multi-Module Maven Dockerfile Build Context
+
+**Trigger:** Multi-module Maven project where Dockerfiles live in sub-modules.
+
+**Solution — project-root build context:**
+```dockerfile
+# MIGRATION: Build with: docker build -f shopizer-web/Dockerfile .
+FROM maven:3.9-eclipse-temurin-21 AS builder
+COPY pom.xml /build/pom.xml
+COPY shopizer-core/ /build/shopizer-core/
+COPY shopizer-web/ /build/shopizer-web/
+WORKDIR /build
+RUN mvn -pl shopizer-core,shopizer-web -am package -DskipTests
+```
+
+**Rule:** Always invoke `docker build -f <submodule>/Dockerfile .` from project root.
+
+## Alpine JRE HEALTHCHECK (wget not curl)
+
+Eclipse Temurin `*-jre-alpine` images do NOT include `curl`:
+```dockerfile
+# GOOD: use BusyBox wget
+HEALTHCHECK CMD wget --spider -q http://localhost:8080/actuator/health || exit 1
+```
+
+**Detection:** `grep -n 'FROM.*alpine' Dockerfile | grep -i 'jre\|temurin'`
+
+## Spring Non-Boot Dependency Guard
+
+**Problem:** Using `spring-boot-starter-*` in non-Boot WAR causes auto-configuration failures.
+
+**Rule:** In non-Boot WAR applications, NEVER use Boot starters. Use underlying libraries directly.
+
+## Tomcat WAR emptyDir Inventory
+
+**Trigger:** Tomcat-based WAR applications with `readOnlyRootFilesystem: true`.
+
+Tomcat requires multiple writable paths at runtime:
+
+| emptyDir Mount | Purpose |
+|---|---|
+| `/tmp` | Java temp files, session serialisation |
+| `/usr/local/tomcat/webapps` | WAR extraction (if not pre-extracted) |
+| `/usr/local/tomcat/logs` | Access/error log fallback |
+| `/usr/local/tomcat/work` | JSP compilation, Servlet temp |
+| `/usr/local/tomcat/temp` | Tomcat temp directory |
+| `/usr/local/tomcat/conf/Catalina` | Auto-generated context XML |
+| `/usr/local/tomcat/bin` | Conditional: if startup scripts write PID/lock files here |
+
+**Detection:** `grep -rn 'tomcat\|catalina\|servlet' pom.xml Dockerfile | grep -iv 'test'`
+
+**Init container pattern**: If WAR must be extracted at startup, use copy-startup init container to extract to webapps emptyDir before main container starts.
+
+**chown-chmod scope invariant**: When the Dockerfile or init container runs both `chown -R UID` and `chmod -R g+rw` on Tomcat directories, the set of directories in the chown command MUST cover ALL directories in the chmod command. Mismatched scope causes "permission denied" at runtime when a chmod'd directory is owned by root.
+
+## Liquibase 4.4+ searchPath
+
+**Trigger:** Liquibase ≥4.4 with changelogs inside WAR/JAR `WEB-INF/classes/` directory.
+
+**Problem:** Liquibase 4.4+ requires `--searchPath` for sub-changelog `<include>` resolution when run outside the WAR/JAR classloader (e.g., from an extracted Job container).
+
+**Before (fails):**
+```bash
+java -cp "WEB-INF/lib/*:WEB-INF/classes" liquibase.integration.commandline.LiquibaseCommandLine \
+  --changeLogFile=db/changelog-master.xml update
+```
+
+**After (works):**
+```bash
+java -cp "WEB-INF/lib/*:WEB-INF/classes" liquibase.integration.commandline.LiquibaseCommandLine \
+  --changeLogFile=db/changelog-master.xml \
+  --searchPath=WEB-INF/classes update
+```
+
+**Detection:** `grep -rn '<include\|<includeAll' src/main/resources/db/ | grep -v '^#'`
+
+**Source:** Liquibase docs — "The search path is the list of base physical locations where given changelog paths can be found." (https://docs.liquibase.com/reference-guide/parameters/search-path)
+
+## camelCase @Value Env-Lowercasing Conflict
+
+**Trigger:** Startup scripts that lowercase env var names before passing to the application (e.g., `tr [:upper:] [:lower:]` for prefix stripping like `OMRS_EXTRA_`).
+
+**Problem:** Lowercasing transforms `camelCase` Spring `@Value` property names into all-lowercase, breaking resolution. E.g., `autoCreateUser` becomes `autocreateuser` which Spring cannot match.
+
+**Workaround — Secret-mounted `.properties` file:**
+```yaml
+# kubernetes/secret.yaml
+stringData:
+  spring-extra.properties: |
+    autoCreateUser=true
+    someProperty.nestedValue=example
+```
+
+```yaml
+# In Deployment container spec:
+volumeMounts:
+- name: spring-extra
+  mountPath: /config/spring-extra.properties
+  subPath: spring-extra.properties
+env:
+- name: SPRING_CONFIG_ADDITIONAL_LOCATION
+  value: "/config/"
+```
+
+**Detection:** `grep -rn 'tr.*upper.*lower\|sed.*y/A-Z/a-z/' entrypoint*.sh startup*.sh docker-entrypoint*.sh`
+
+## PropertiesFactoryBean Action Protocol
+
+**Trigger:** Spring XML-based applications loading properties via `PropertiesFactoryBean` or `util:properties`.
+
+**Problem:** Properties loaded via `PropertiesFactoryBean` bypass `${VAR}` placeholder resolution — they return the literal string `${DB_HOST}` instead of resolving the env var.
+
+**Detection:**
+```bash
+grep -rn 'PropertiesFactoryBean\|util:properties' . --include='*.xml' --include='*.java'
+```
+
+**Action Protocol:**
+1. **Detect** — grep as above. If matches found, proceed.
+2. **Do NOT** add `${VAR:default}` syntax to files loaded by PropertiesFactoryBean — it will be treated as a literal string, not resolved.
+3. **Add MIGRATION comment** — `# MIGRATION: PropertiesFactoryBean loads literal values — env var placeholders are NOT resolved. Use PropertySourcesPlaceholderConfigurer or inject via @Value instead.`
+4. **Document code fix path** — In INFRASTRUCTURE_REQUIREMENTS.md or TRANSFORMATION_SUMMARY.md, recommend: inject `Environment` bean and call `env.getProperty()`, or replace PFB with `@PropertySource` + `PropertySourcesPlaceholderConfigurer`.
+5. **Document affected properties** in ENV_VARIABLES.md with note: "Requires code refactoring — PFB bypass".
+
+**Circular Placeholder Pitfall:** The placeholder variable name MUST differ from the property key. `FOO=${FOO:default}` throws `IllegalArgumentException: Circular placeholder reference 'FOO'`. Use a distinct env var name:
+```properties
+# BAD — circular reference:
+database.password=${database.password:secret}
+
+# GOOD — distinct env var name:
+database.password=${DB_PASSWORD:secret}
+```
+
+## WAR-to-JAR Packaging Check
+
+**Trigger:** Converting traditional WAR application to executable Spring Boot JAR.
+
+**Pre-migration checklist:**
+```bash
+# 1. Verify spring-boot-starter-tomcat is NOT scope=provided
+grep -B2 -A2 'provided' pom.xml | grep -i 'tomcat\|jetty\|undertow'
+# 2. Check for web.xml (must be migrated to Java config)
+find . -name 'web.xml' -not -path '*/test/*'
+# 3. Check for JSP (requires extra dependency for JAR packaging)
+find . -name '*.jsp' | head -5
+```
+
+**Rule:** For packaging=jar: `spring-boot-starter-tomcat` must NOT have `<scope>provided</scope>`. If JSPs exist, add `tomcat-embed-jasper` dependency.
+
+## Spring XML PPC + Boot PSPC Hybrid
+
+**Trigger:** Application with BOTH `PropertyPlaceholderConfigurer` (PPC) in XML AND Spring Boot's `PropertySourcesPlaceholderConfigurer` (PSPC).
+
+**Problem:** PPC and PSPC have different resolution order. When both are active, PPC may resolve a placeholder from a properties file while PSPC resolves the same placeholder from env vars — whichever runs first wins, leading to inconsistent behaviour.
+
+**Solution:**
+```xml
+<!-- Add to XML config to make PPC defer to Boot PSPC -->
+<bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+  <property name="ignoreUnresolvablePlaceholders" value="true"/>
+  <property name="order" value="2"/>
+  <!-- Boot PSPC has order=0 (highest priority) by default -->
+</bean>
+```
+
+**Detection:** `grep -rn 'PropertyPlaceholderConfigurer\|PropertySourcesPlaceholderConfigurer' . --include='*.xml' --include='*.java'`
+
+## Factory-Method Singleton Refactor
+
+**Trigger:** Spring XML beans using `factory-method` for singleton creation (common in legacy apps).
+
+**Problem:** `factory-method` singletons hold in-memory state that breaks under horizontal scaling.
+
+**Detection:**
+```bash
+grep -rn 'factory-method\|factory-bean' . --include='*.xml'
+```
+
+**Assessment:** For each factory-method bean, determine if it holds mutable state:
+- Stateless factory (creates config objects) → safe, no change needed
+- Stateful factory (connection pools, caches, registries) → must externalise state or use distributed alternative
+
+**Rule:** Flag factory-method beans that accumulate state as horizontal-scaling warnings. Document in INFRASTRUCTURE_REQUIREMENTS.md if distributed alternative is needed.
+
+## ActiveProfiles Test Activation
+
+**Trigger:** Spring test classes using `@ActiveProfiles` to activate specific configuration for tests.
+
+**Problem:** After migration, test profiles may reference removed properties or missing beans.
+
+**Detection:**
+```bash
+grep -rn '@ActiveProfiles' . --include='*.java' | grep -oP '"([^"]+)"' | sort -u
+```
+
+**Rule:** For each active profile referenced in tests:
+1. Verify the corresponding `application-<profile>.properties/yml` exists
+2. Verify env-var-backed properties have test defaults
+3. Add `spring.session.store-type=none` if Redis is not available in test context
+
+**Common test profile additions after migration:**
+```properties
+# application-test.properties
+spring.session.store-type=none
+spring.redis.host=localhost
+management.health.redis.enabled=false
+```
+
+## Required-Secret Test Shadow Rule
+
+**Trigger:** Properties files containing `${SECRET}` with no default value (colon separator absent) — these are production-required secrets that cause startup failures in test contexts.
+
+**Problem:** When a properties file has `${DB_PASSWORD}` (no default), tests fail with `IllegalArgumentException: Could not resolve placeholder 'DB_PASSWORD'` unless the test environment provides the value.
+
+**Detection:**
+```bash
+# Find all ${VAR} references without a :default
+grep -rn '\${[A-Z_]*}' src/main/resources/*.properties src/main/resources/*.yml 2>/dev/null | grep -v ':'
+```
+
+**Rule:** For each match, verify a corresponding test resource exists:
+```bash
+# For each properties file with required secrets:
+for f in $(grep -rl '\${[A-Z_]*}' src/main/resources/ | grep -v ':'); do
+  BASENAME=$(basename "$f")
+  if [ ! -f "src/test/resources/$BASENAME" ]; then
+    echo "MISSING TEST SHADOW: src/test/resources/$BASENAME"
+  fi
+done
+```
+
+**Fix:** Create `src/test/resources/<same-filename>` with safe test defaults:
+```properties
+# src/test/resources/application.properties (test shadow)
+db.password=${DB_PASSWORD:test-password}
+api.secret=${API_SECRET:test-secret-value}
+```
+
+**Alternative — test profile override:**
+```properties
+# src/test/resources/application-test.properties
+db.password=test-password
+api.secret=test-secret-value
+```
+Activate via `@ActiveProfiles("test")` in test classes.
+
+## Multi-Module Test Shadow
+
+**Trigger:** Multi-module Maven/Gradle projects where dependent modules have `@SpringBootTest` classes that transitively load the parent module's context.
+
+**Problem:** When you externalise a property in module A (e.g., `${DB_PASSWORD}` with no default), tests in module B that `@Import` or `@ContextConfiguration` module A's beans fail with `Could not resolve placeholder` — even if module B's own test resources have the property defined, the inherited context from module A does not.
+
+**Detection:**
+```bash
+# Find all modules with @SpringBootTest that depend on the migrated module
+grep -rn '@SpringBootTest\|@ContextConfiguration\|@Import' . --include='*.java' | \
+  grep -v 'src/main' | awk -F: '{print $1}' | sed 's|/src/test.*||' | sort -u
+```
+
+**Rule:** After externalising ANY property to `${VAR}` (no default) in module A:
+1. Identify ALL modules that transitively depend on A (check parent pom `<modules>` or Gradle `dependencies`)
+2. For each dependent module with `@SpringBootTest`: verify `src/test/resources/application-test.properties` (or equivalent) provides the value
+3. If missing: create the test shadow file OR add `@TestPropertySource(properties = {"VAR=test-value"})` to test classes
+
+**Gradle multi-module variant:**
+```bash
+# Find test dependencies across subprojects
+grep -rn "implementation project\|testImplementation project" . --include='*.gradle' --include='*.kts'
+```
+
+## terminationGracePeriodSeconds Formula
+
+**Trigger:** Spring Boot Deployments with `server.shutdown=graceful` or custom `timeout-per-shutdown-phase`.
+
+**Formula:** `terminationGracePeriodSeconds = max(graceful_shutdown_timeout + 10, 30)`
+
+| Application Config | Value | terminationGracePeriodSeconds |
+|---|---|---|
+| `spring.lifecycle.timeout-per-shutdown-phase=25s` | 25 | 35 |
+| `spring.lifecycle.timeout-per-shutdown-phase=60s` | 60 | 70 |
+| `spring.lifecycle.timeout-per-shutdown-phase=120s` | 120 | 130 |
+| Default (no config) | 30 | 40 |
+
+**Detection:**
+```bash
+grep -rn 'timeout-per-shutdown-phase\|graceful-shutdown' src/main/resources/ --include='*.properties' --include='*.yml'
+```
+
+**Rule:** Workers MUST NOT set `terminationGracePeriodSeconds: 30` as a blanket default. Always derive from the application's actual graceful shutdown timeout. The +10s buffer accounts for SIGTERM delivery latency, container runtime overhead, and pre-stop hook execution, ensuring kubelet SIGKILL fires only AFTER the application's own graceful window expires.
+
+## Quartz initialize-schema Restart Risk
+
+**Trigger:** Spring Boot Quartz with `spring.quartz.jdbc.initialize-schema=always`.
+
+**Problem:** `initialize-schema=always` runs Quartz DDL on EVERY pod start. In Kubernetes with rolling updates, two pods may run DDL simultaneously, causing table-already-exists or lock-contention errors that crash startup.
+
+**WRONG:**
+```properties
+spring.quartz.jdbc.initialize-schema=always
+```
+
+**CORRECT:**
+```properties
+spring.quartz.jdbc.initialize-schema=never
+# Handle schema creation via Flyway/Liquibase migration Job
+```
+
+**Detection:**
+```bash
+grep -rn 'initialize-schema' src/main/resources/ --include='*.properties' --include='*.yml'
+```
+
+**Rule:** For Kubernetes deployments, use `initialize-schema=never` and manage Quartz tables via a dedicated migration Job (Flyway/Liquibase). Document schema creation as a pre-deployment requirement in INFRASTRUCTURE_REQUIREMENTS.md.
+
+## Broadened IRSA Trigger
+
+**Trigger:** Source contains ANY AWS SDK client builder — not just S3.
+
+**Detection (broadened from S3-only to all AWS services):**
+```bash
+grep -rn 'AmazonS3\|AmazonSQS\|AmazonSNS\|AmazonDynamoDB\|AmazonSES\|AWSClientBuilder\|spring-cloud-aws\|software\.amazon\.awssdk' . --include='*.java' --include='*.xml' --include='*.gradle' --include='*.kts' | grep -v 'src/test'
+```
+
+**Services requiring IRSA (identical pattern for all):**
+- S3 (AmazonS3Client / S3Client)
+- SQS (AmazonSQSClient / SqsClient)
+- SNS (AmazonSNSClient / SnsClient)
+- DynamoDB (AmazonDynamoDBClient / DynamoDbClient)
+- SES (AmazonSimpleEmailServiceClient / SesClient)
+
+**Rule:** If ANY AWS SDK client builder is found in source (excluding test files), apply the full IRSA pattern: ServiceAccount with role-arn annotation, empty-string Secret entries, conditional credential injection. The IRSA pattern is identical regardless of which AWS service is consumed.
+
+**Test-file exclusion:** SDK usage appearing ONLY in `*Test.java`, `*IT.java`, or `src/test/` does NOT trigger IRSA.
+
+## Service-Specific IAM Policy Templates
+
+**S3 (file storage) — two-statement format (see §64 IAM Policy Two-Statement Split):**
+```json
+[
+  {
+    "Effect": "Allow",
+    "Action": ["s3:ListBucket"],
+    "Resource": "arn:aws:s3:::BUCKET_NAME"
+  },
+  {
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+    "Resource": "arn:aws:s3:::BUCKET_NAME/*"
+  }
+]
+```
+
+**SQS (message queue):**
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sqs:SendMessage", "sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+  "Resource": "arn:aws:sqs:REGION:ACCOUNT:QUEUE_NAME"
+}
+```
+
+**SNS (notifications):**
+```json
+{
+  "Effect": "Allow",
+  "Action": ["sns:Publish"],
+  "Resource": "arn:aws:sns:REGION:ACCOUNT:TOPIC_NAME"
+}
+```
+
+**DynamoDB (NoSQL):**
+```json
+{
+  "Effect": "Allow",
+  "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:UpdateItem", "dynamodb:DeleteItem", "dynamodb:Query"],
+  "Resource": "arn:aws:dynamodb:REGION:ACCOUNT:table/TABLE_NAME"
+}
+```
+
+**Rule:** Include the appropriate IAM policy template in INFRASTRUCTURE_REQUIREMENTS.md §4 based on which AWS services the application uses. Always use least-privilege (specific resource ARNs, not `*`).
+
+## Mixed-Indent sed Fallback
+
+**Problem:** `editor str_replace` and `sed -i` fail silently on files with mixed indentation (tabs + spaces) because the search string's whitespace does not match exactly.
+
+**Detection:**
+```bash
+# Check for mixed indent in target file
+grep -Pn '^\t' file.properties && grep -Pn '^ ' file.properties && echo "MIXED INDENT DETECTED"
+```
+
+**Fallback — Python str.replace():**
+```bash
+python3 -c "
+f='FILE_PATH'
+old='''OLD_TEXT'''
+new='''NEW_TEXT'''
+c=open(f).read()
+assert old in c, f'Text not found in {f}'
+c=c.replace(old, new, 1)
+open(f,'w').write(c)
+"
+```
+
+**Rule:** If `editor str_replace` reports "text not found" despite `grep` confirming the text exists, AND `cat -A file` reveals mixed tabs/spaces, fall back to Python `str.replace()`. Python handles mixed indentation, multi-byte Unicode, and multi-line replacements correctly. Use sed only for confirmed single-line ASCII-only substitutions.
+
+## @ConfigurationProperties vs XML PPC
+
+**Trigger:** Spring Boot application using `@ConfigurationProperties` alongside legacy XML-defined `PropertyPlaceholderConfigurer` (PPC).
+
+**Problem:** `@ConfigurationProperties` binds properties via relaxed binding (camelCase, kebab-case, SCREAMING_SNAKE). But XML PPC resolves `${VAR}` placeholders literally — mixing both in the same application causes some properties to resolve from env vars (via Boot PSPC) and others to resolve from static files (via XML PPC), depending on which configurer processes them first.
+
+**Detection:**
+```bash
+grep -rn '@ConfigurationProperties' . --include='*.java'
+grep -rn 'PropertyPlaceholderConfigurer' . --include='*.xml'
+# Both present = conflict risk
+```
+
+**Resolution:** 
+1. If XML PPC exists, add `ignoreUnresolvablePlaceholders=true` and `order=2` (see §Spring XML PPC + Boot PSPC Hybrid).
+2. For `@ConfigurationProperties` classes: verify env var binding works by confirming `@EnableConfigurationProperties` is present AND `AddEnvironmentVariables()` is in the configuration chain.
+3. Document which properties are resolved via which mechanism in ENV_VARIABLES.md.
+
+**Rule:** When both `@ConfigurationProperties` and XML PPC exist, the XML PPC MUST have `order=2` (lower priority) to let Boot's PSPC resolve env vars first. Without this, XML-defined defaults silently override env var injection.
+
+## Maven Wrapper Version Guard
+
+**Trigger:** Maven Wrapper (`./mvnw`) present with Maven < 3.6.1.
+
+**Problem:** `--no-transfer-progress` flag was added in Maven 3.6.1. Using it with older wrapper versions causes `Unknown lifecycle phase "--no-transfer-progress"` error during Docker build.
+
+**Detection:**
+```bash
+# Check wrapper version (in .mvn/wrapper/maven-wrapper.properties)
+grep 'distributionUrl' .mvn/wrapper/maven-wrapper.properties 2>/dev/null | grep -oP '\d+\.\d+\.\d+'
+```
+
+**Rule:** If Maven version < 3.6.1, use `-B` (batch mode, suppresses download progress) instead of `--no-transfer-progress`:
+```dockerfile
+# Maven >= 3.6.1:
+RUN ./mvnw package -DskipTests --no-transfer-progress
+
+# Maven < 3.6.1:
+RUN ./mvnw package -DskipTests -B
+```
+
+
+## Spring 6-Field to Kubernetes 5-Field Cron Conversion
+
+**Trigger:** Spring `@Scheduled(cron="...")` or Quartz cron expressions being extracted to Kubernetes CronJob `schedule:` field.
+
+**Problem:** Spring/Quartz uses 6-field cron syntax (seconds minutes hours day-of-month month day-of-week). Kubernetes uses standard 5-field cron (minutes hours day-of-month month day-of-week). Copying Spring cron directly into K8s CronJob produces invalid schedules.
+
+**Conversion table:**
+
+| Spring 6-field | Meaning | K8s 5-field | Notes |
+|---|---|---|---|
+| `0 0 */6 * * *` | Every 6 hours at :00:00 | `0 */6 * * *` | Drop leading `0` (seconds) |
+| `0 30 2 * * *` | Daily at 02:30:00 | `30 2 * * *` | Drop leading `0` |
+| `*/30 * * * * *` | Every 30 seconds | `* * * * *` | Sub-minute not supported; use `activeDeadlineSeconds: 30` |
+| `0 0 0 * * MON-FRI` | Weekdays at midnight | `0 0 * * MON-FRI` | Drop leading `0` |
+| `0 0/15 * * * ?` | Every 15 minutes | `*/15 * * * *` | Drop seconds, convert `0/15` to `*/15`, drop `?` |
+
+**Rule:** Always drop the FIRST field (seconds) when converting Spring/Quartz cron to Kubernetes. Add a YAML comment in the CronJob manifest documenting the original Spring expression:
+```yaml
+spec:
+  schedule: "0 */6 * * *"  # Converted from Spring: 0 0 */6 * * *
+```
+
+**Source:** Kubernetes CronJob uses standard 5-field cron: minute, hour, day-of-month, month, day-of-week (https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/).
+
+
+## CronJob activeDeadlineSeconds Placement
+
+**Trigger:** Kubernetes CronJob manifests using `activeDeadlineSeconds` for hang-detection (distroless exception or general timeout).
+
+**Problem:** `activeDeadlineSeconds` placed at the CronJob `spec` root is rejected by kubeconform strict mode. It belongs in `jobTemplate.spec.activeDeadlineSeconds`.
+
+**WRONG:**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+spec:
+  schedule: "0 */6 * * *"
+  activeDeadlineSeconds: 3600  # REJECTED by kubeconform strict
+  jobTemplate:
+    spec:
+      template: ...
+```
+
+**CORRECT:**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600  # Correct location
+      template: ...
+```
+
+**Detection:**
+```bash
+# Find misplaced activeDeadlineSeconds in CronJob manifests
+python3 -c "
+import yaml
+from pathlib import Path
+for f in Path('kubernetes').glob('*cronjob*.yaml'):
+    with open(f) as fh:
+        for doc in yaml.safe_load_all(fh):
+            if doc and doc.get('kind') == 'CronJob':
+                if 'activeDeadlineSeconds' in doc.get('spec', {}):
+                    print(f'MISPLACED: {f} — activeDeadlineSeconds at spec root')
+"
+```
+
+**Rule:** For CronJob manifests, `activeDeadlineSeconds` MUST be at `spec.jobTemplate.spec.activeDeadlineSeconds`. This applies to ALL CronJob manifests regardless of whether probes are present.
+
+**Source:** https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/ — "The .spec.jobTemplate defines a template for the Jobs that the CronJob creates [...] It has exactly the same schema as a Job, except that it is nested."
+
+
+## Startup-Script Write-Tracing
+
+**Trigger:** Startup/entrypoint scripts that write files at container boot — determines emptyDir requirements for `readOnlyRootFilesystem: true`.
+
+**Pre-step** (run BEFORE deciding emptyDir mounts):
+```bash
+# Trace all writes performed by startup scripts
+grep -nE 'cat\s*>|tee\s|echo.*>|cp\s|mv\s|sed\s+-i|install\s' entrypoint*.sh startup*.sh docker-entrypoint.sh 2>/dev/null | grep -v '^\s*#'
+```
+
+**Rule:** Every path written by a startup script must have either an emptyDir mount or a copy-startup init container. If the write target is under WORKDIR and not /tmp, use the init-container pattern from §21 (Copy-Startup Init Container).
+
+**Decision tree:**
+1. Writes to `/tmp` or `/var/run` → covered by standard emptyDir mounts
+2. Writes to application directory (e.g., `./config/generated.xml`) → init-container pattern
+3. Writes to `/usr/local/tomcat/bin` (PID/lock files) → subPath mount (see §53)
+
+## Tomcat /bin subPath Mount
+
+**Trigger:** Tomcat startup scripts writing PID or lock files to `/usr/local/tomcat/bin/`.
+
+**Problem:** `readOnlyRootFilesystem: true` blocks writes to `/usr/local/tomcat/bin/` where `catalina.sh` writes `catalina.pid`. Mounting an emptyDir at `/usr/local/tomcat/bin` would hide the actual scripts.
+
+**Solution — subPath mount for specific file:**
+```yaml
+volumeMounts:
+- name: tomcat-run
+  mountPath: /usr/local/tomcat/bin/catalina.pid
+  subPath: catalina.pid
+volumes:
+- name: tomcat-run
+  emptyDir: {}
+```
+
+**Detection:**
+```bash
+grep -rn 'CATALINA_PID\|catalina\.pid' entrypoint*.sh startup*.sh Dockerfile 2>/dev/null
+```
+
+**Rule:** Use subPath mount when only specific files need write access within a directory containing read-only binaries/scripts. Full emptyDir mount would hide existing directory content.
+
+## mvn package vs mvn compile
+
+**Trigger:** Multi-module Maven reactor builds in Docker.
+
+**Problem:** `mvn compile` does NOT package artifacts or run plugins that produce JARs/WARs. Dependent modules referencing `<packaging>jar</packaging>` of sibling modules fail at link time if only compile phase ran.
+
+**Rule:**
+- Single-module project: `mvn package -DskipTests` produces the deployable artifact
+- Multi-module project: `mvn -pl module-a,module-b -am package -DskipTests` builds target modules AND all required ancestors
+- NEVER use `mvn compile` in Dockerfile — it does not produce target/*.jar
+
+**Detection:**
+```bash
+grep -c '<module>' pom.xml  # >0 = multi-module
+grep 'mvn compile' Dockerfile  # WRONG — should be mvn package
+```
+
+## Java Version Pre-Migration Check
+
+**Trigger:** Before writing the Dockerfile FROM line for any Java project.
+
+**Procedure:**
+```bash
+# Check pom.xml for Java version
+grep -oP '(?:java\.version|maven\.compiler\.source|maven\.compiler\.target|release)>\K[^<]+' pom.xml | head -1
+# Check Gradle
+grep -oP 'sourceCompatibility\s*=\s*['\''"]?\K[0-9]+' build.gradle 2>/dev/null
+```
+
+**Rule:** The Dockerfile base image Java version MUST match the project's declared version. Mismatches cause compilation failures or runtime `UnsupportedClassVersionError`. Common mappings: `1.8`/`8` → `eclipse-temurin:8-jdk`, `11` → `eclipse-temurin:11-jdk`, `17` → `eclipse-temurin:17-jdk`, `21` → `eclipse-temurin:21-jdk`.
+
+## SCREAMING_SNAKE_CASE Circular Placeholder
+
+**Trigger:** Spring properties using `${SAME_NAME}` where the property key matches the env var name exactly.
+
+**Problem:** `PropertySourcesPlaceholderConfigurer` resolves `${X}` by looking up property "X". If the property file defines `X=${X:default}`, the resolution is: property "X" → placeholder "${X}" → property "X" → circular reference → `IllegalArgumentException`.
+
+**Before (circular):**
+```properties
+DB_PASSWORD=${DB_PASSWORD:secret}
+```
+
+**After (distinct names):**
+```properties
+# Use dot-notation property with SCREAMING_SNAKE env var
+spring.datasource.password=${DB_PASSWORD:secret}
+```
+
+**Detection:**
+```bash
+grep -nP '^([A-Z][A-Z0-9_]+)\s*=\s*\$\{\1' src/main/resources/*.properties 2>/dev/null
+```
+
+**Rule:** The property key (left side of =) MUST differ from the placeholder variable name (inside ${}). Spring resolves environment variables first, so `spring.datasource.password=${DB_PASSWORD}` works because "DB_PASSWORD" is resolved from the environment, not from the same properties file.
+
+## SPRING_PROFILES_ACTIVE Mandatory ConfigMap
+
+**Trigger:** Multi-profile Spring applications (detected via `@Profile` annotations or multiple `application-*.properties` files).
+
+**Detection:**
+```bash
+find src/main/resources -name 'application-*.properties' -o -name 'application-*.yml' | wc -l
+grep -rn '@Profile' src/ --include='*.java' | wc -l
+```
+
+**Rule:** If the project has ≥2 profile-specific config files OR ≥1 `@Profile` annotation, `SPRING_PROFILES_ACTIVE` MUST appear in the ConfigMap. Without it, Spring activates the "default" profile — production-specific beans (cache, messaging, JDBC clustering) remain inactive.
+
+**ConfigMap entry:**
+```yaml
+data:
+  SPRING_PROFILES_ACTIVE: "prod"
+```
+
+**ENV_VARIABLES.md entry:** `SPRING_PROFILES_ACTIVE` — Active Spring profiles, comma-separated. K8s Scope: ConfigMap. Default: "prod".
+
+## Infinispan !cloud Profile-Guard
+
+**Trigger:** Infinispan/JGroups configuration with a `!cloud` (not-cloud) profile guard in Spring.
+
+**Problem:** Legacy apps wrap Infinispan JGroups config under `@Profile("!cloud")` — meaning the cluster transport is disabled when the `cloud` profile is active. If `SPRING_PROFILES_ACTIVE` includes "cloud" or "prod,cloud", the Infinispan cache silently falls back to local-only mode (no clustering).
+
+**Detection:**
+```bash
+grep -rn '@Profile.*!cloud\|spring\.profiles.*cloud' . --include='*.java' --include='*.xml' --include='*.properties'
+```
+
+**Resolution options:**
+1. Remove the `!cloud` guard if Kubernetes deployment needs clustering (replace JGroups UDP with KUBE_PING — see §23)
+2. Ensure `SPRING_PROFILES_ACTIVE` does NOT include "cloud" if the guard is intentional
+3. Add a Kubernetes-specific profile (`@Profile("kubernetes")`) that activates KUBE_PING transport
+
+**Rule:** Document the profile-guard in ENV_VARIABLES.md with a note explaining its impact on caching behaviour.
+
+## @PropertySource Requirement for @ConfigurationProperties with XML PPC
+
+**Trigger:** `@ConfigurationProperties` class that reads from a separate properties file loaded via XML `PropertyPlaceholderConfigurer` (PPC).
+
+**Problem:** Spring Boot's `@ConfigurationProperties` binds ONLY from `PropertySource`s registered in the Spring `Environment`. XML PPC loads properties into its own resolver but does NOT register them as a `PropertySource` — so `@ConfigurationProperties` never sees them.
+
+**Detection:**
+```bash
+# Find @ConfigurationProperties classes
+grep -rn '@ConfigurationProperties' . --include='*.java'
+# Find XML-only property loading
+grep -rn 'PropertyPlaceholderConfigurer' . --include='*.xml' | grep -oP 'location="[^"]*"'
+```
+
+**Fix — add @PropertySource to the @Configuration class:**
+```java
+@Configuration
+@PropertySource("classpath:custom.properties")
+@ConfigurationProperties(prefix = "app")
+public class AppConfig { ... }
+```
+
+**Rule:** When `@ConfigurationProperties` needs properties from a file loaded only by XML PPC, add an explicit `@PropertySource` annotation pointing to the same file. This registers the file in Spring's `Environment`, making its properties visible to the binder.
+
+## Spring Profile Override Sweep
+
+**Trigger:** After externalising base `application.properties`/`application.yml` properties, profile-specific override files may still contain hardcoded values that bypass the migration.
+
+**Problem:** Spring loads properties in order: `application.properties` → `application-{profile}.properties`. Profile-specific files OVERRIDE base properties. If a profile file has a hardcoded value for a property you just externalised in the base file, the env var injection is silently nullified at runtime.
+
+**Procedure — mandatory post-externalisation check:**
+```bash
+# Find all profile-specific config files
+find src/main/resources -name 'application-*.properties' -o -name 'application-*.yml' | while read f; do
+  # Check for non-placeholder values (lines without ${ that aren't comments)
+  grep -n '^[a-z]' "$f" | grep -v '^\s*#' | grep -v '\${' | head -20
+done
+```
+
+**Rule:** After externalising any property to `${ENV_VAR}` in the base config, grep ALL profile-specific files for the same property key. If found with a hardcoded value, either:
+1. Remove the line (let base config win), OR
+2. Replace with the same `${ENV_VAR:profile-specific-default}` pattern
+
+**Example:**
+```properties
+# application.properties (base — correctly externalised):
+spring.datasource.url=${DATABASE_URL}
+
+# application-prod.properties (OVERRIDE — silently re-hardcodes!):
+spring.datasource.url=jdbc:mysql://prod-db:3306/app  # BUG: overrides env var!
+```
+
+## Gradle Wrapper Two-COPY Dockerfile Pattern
+
+**Trigger:** Gradle project with `gradlew` wrapper script.
+
+**Problem:** `gradlew` requires both the wrapper script AND the `gradle/wrapper/` directory (containing `gradle-wrapper.jar` and `gradle-wrapper.properties`). A single `COPY . .` prevents Docker layer caching. The two-COPY pattern enables dependency caching.
+
+**Dockerfile pattern:**
+```dockerfile
+FROM gradle:8-jdk21 AS builder
+WORKDIR /app
+
+# Layer 1: Gradle wrapper + dependency resolution (cached unless build files change)
+COPY gradle ./gradle
+COPY gradlew ./
+COPY build.gradle settings.gradle ./
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+
+# Layer 2: Source code (changes frequently)
+COPY src ./src
+RUN ./gradlew build -x test --no-daemon
+```
+
+**Rule:** For Gradle projects, ALWAYS use the two-COPY pattern:
+1. First COPY: `gradle/` directory + `gradlew` + build files → `RUN ./gradlew dependencies`
+2. Second COPY: `src/` → `RUN ./gradlew build`
+
+**chmod requirement:** The `gradlew` script needs execute permission. Add `RUN chmod +x gradlew` after COPY if the file loses permissions during Docker COPY.
+
+## Latin-1 Properties Encoding Guard
+
+**Trigger:** Java `.properties` files containing non-ASCII characters (accents, CJK, etc.).
+
+**Problem:** Java `.properties` files are loaded as ISO-8859-1 (Latin-1) by default. If a properties file was saved as UTF-8 and contains non-ASCII characters, they will be garbled at runtime. When modifying properties files during migration, preserve the original encoding.
+
+**Detection:**
+```bash
+file -i src/main/resources/*.properties | grep -v 'iso-8859-1\|us-ascii\|utf-8'
+# Any match = unexpected encoding — investigate
+```
+
+**Rule:** When writing to `.properties` files programmatically during migration:
+1. Detect the original encoding: `file -i <file>`
+2. If ISO-8859-1: use Python `open(f, 'w', encoding='latin-1')` or ensure only ASCII+Latin-1 characters
+3. If UTF-8 with non-ASCII: preserve UTF-8 encoding but note that `ResourceBundle` will misread it unless `PropertyResourceBundle(Reader)` constructor is used (Java 9+)
+
+**Safe migration approach:** Use Unicode escapes for non-ASCII in .properties:
+```properties
+# Instead of: greeting=Héllo
+greeting=H\u00e9llo
+```
+
+## Azure Blob Connection String Externalisation
+
+**Trigger:** Java/Spring project using Azure Blob Storage with connection strings.
+
+**Problem:** Azure connection strings follow the pattern `DefaultEndpointsProtocol=https;AccountName=X;AccountKey=Y;EndpointSuffix=core.windows.net`. The variable NAME (e.g., `AZURE_STORAGE_CONNECTION_STRING`) does not contain credential keywords like "password" — but the VALUE embeds the `AccountKey` which IS a credential.
+
+**Rule:** This is a canonical example of the **value-content-supersedes-name** rule. Classify as Secret regardless of variable name:
+
+```yaml
+# kubernetes/secret.yaml
+stringData:
+  AZURE_STORAGE_CONNECTION_STRING: "replace-with-azure-connection-string"
+```
+
+**Detection:**
+```bash
+grep -rn 'DefaultEndpointsProtocol\|AccountKey\|azure.*connection.*string' src/ config/ --include='*.properties' --include='*.yml' --include='*.yaml' --include='*.java'
+```
+
+**Spring property externalisation:**
+```properties
+# application.properties
+azure.storage.connection-string=${AZURE_STORAGE_CONNECTION_STRING}
+```
+
+**ENV_VARIABLES.md entry:** `AZURE_STORAGE_CONNECTION_STRING` — Azure Storage connection string (contains AccountKey). K8s Scope: Secret.
+
+## DB-Stored Runtime Configuration (Java)
+
+**Trigger:** Java frameworks that persist settings in database tables (OpenMRS `GlobalProperty`, custom `app_settings` tables).
+
+**Problem:** Workers may attempt to add ConfigMap/Secret keys for settings stored in database tables. These values are configured via the admin UI at runtime, not injected via environment variables.
+
+**Rule:** Do NOT add ConfigMap/Secret keys for DB-stored configuration values. Document them in INFRASTRUCTURE_REQUIREMENTS.md §2 or §5b as "post-install admin configuration". Still add NetworkPolicy egress rules for relay hosts referenced by DB-stored config.
+
+**Detection:**
+```bash
+grep -rn 'GlobalProperty\|app_settings\|system_setting\|config_property' . --include='*.java' --include='*.xml' | grep -v test
+```
+
+## Alpine Shebang Compatibility
+
+**Trigger:** Entrypoint scripts (`entrypoint.sh`, `docker-entrypoint.sh`, `startup.sh`) used with `*-alpine` base images (e.g., `eclipse-temurin:21-jre-alpine`).
+
+**Problem:** Alpine Linux uses BusyBox ash as `/bin/sh`. `/bin/bash` does not exist by default. Entrypoint scripts with `#!/bin/bash` fail with "exec format error" or "not found" at container startup.
+
+**Detection:**
+```bash
+grep -n '#!/bin/bash' entrypoint*.sh docker-entrypoint.sh startup*.sh 2>/dev/null
+grep -n 'FROM.*alpine' Dockerfile
+# Both present = startup failure
+```
+
+**WRONG:**
+```bash
+#!/bin/bash
+exec java -jar /app/app.jar
+```
+
+**CORRECT:**
+```bash
+#!/bin/sh
+exec java -jar /app/app.jar
+```
+
+**Rule:** For `*-alpine` base images, ALL entrypoint scripts MUST use `#!/bin/sh`. No bash-specific syntax is allowed: no `[[ ]]`, no arrays, no process substitution `<()`, no `${var//pattern/replace}`. Use POSIX-compatible alternatives.
+
+**Source:** Alpine Linux uses BusyBox ash — https://wiki.alpinelinux.org/wiki/Shell_management
+
+## JVM Flag Ordering in Entrypoint Scripts
+
+**Trigger:** Java entrypoint scripts that assemble `java` command with JVM tuning flags.
+
+**Problem:** JVM flags (`-Xmx`, `-Xms`, `-XX:*`, `-D*`) placed AFTER `-jar` are silently treated as application arguments, not JVM options. The application ignores them without error.
+
+**WRONG:**
+```bash
+#!/bin/sh
+exec java -jar /app/app.jar -Xmx512m -Djava.io.tmpdir=/tmp
+```
+
+**CORRECT:**
+```bash
+#!/bin/sh
+exec java -Xmx512m -Xms256m -Djava.io.tmpdir=/tmp -jar /app/app.jar
+```
+
+**Detection:**
+```bash
+grep -n '\-jar.*\-X\|\-jar.*\-D' entrypoint*.sh docker-entrypoint.sh startup*.sh Dockerfile 2>/dev/null
+# Any match = flags after -jar (silently ineffective)
+```
+
+**Rule:** ALL `-X*` and `-D*` flags MUST precede the `-jar` argument. Pattern: `exec java [JVM_FLAGS] -jar /app/app.jar [APP_ARGS]`.
+
+## Log4j2/Logback File-Only Logger Redirect
+
+**Trigger:** Logging transformation (§5) removing `RollingFile` or `FileAppender` elements from `log4j2.xml` or `logback.xml`.
+
+**Problem:** Named loggers with `additivity="false"` and exclusive file-appender references produce zero output after file appenders are removed. The logger silently drops all messages because it has no remaining appender.
+
+**Detection (pre-removal audit):**
+```bash
+grep -B2 'AppenderRef' src/main/resources/log4j2.xml | grep -v Console
+# For each match with additivity="false", check if Console is referenced:
+grep -A5 'additivity="false"' src/main/resources/log4j2.xml | grep -c 'Console'
+# If count = 0 for any logger, that logger needs Console added before removal
+```
+
+**Rule:** Before removing ANY `RollingFile`/`FileAppender` element, scan ALL named loggers for exclusive file-appender references (`additivity="false"` + no `<AppenderRef ref="Console"/>`). Add `<AppenderRef ref="Console"/>` to such loggers BEFORE removing file appenders.
+
+## S3 ListObjectsV2 Pagination
+
+**Trigger:** Java S3 SDK code that lists bucket contents (file browsers, backup verification, bulk operations).
+
+**Problem:** `listObjectsV2` returns max 1000 keys per request. Without pagination, the application silently processes only the first page.
+
+**CORRECT (do-while with isTruncated):**
+```java
+ListObjectsV2Request request = ListObjectsV2Request.builder()
+    .bucket(bucket).prefix(prefix).build();
+ListObjectsV2Response response;
+do {
+    response = s3Client.listObjectsV2(request);
+    response.contents().forEach(obj -> process(obj));
+    request = request.toBuilder()
+        .continuationToken(response.nextContinuationToken()).build();
+} while (response.isTruncated());
+```
+
+**Detection:**
+```bash
+grep -rn 'listObjects\|ListObjectsV2' . --include='*.java' | grep -v test
+# Check if continuation/pagination logic exists nearby
+```
+
+**Rule:** Every `listObjectsV2` call MUST use the do-while pagination pattern with `isTruncated()` check. Single-call listing is a data-loss bug for buckets with >1000 objects.
+
+## IAM Policy Two-Statement Split
+
+**Trigger:** S3 IAM policies in INFRASTRUCTURE_REQUIREMENTS.md §4.
+
+**Problem:** `s3:ListBucket` operates on the BUCKET ARN (`arn:aws:s3:::BUCKET`), while object operations (`s3:GetObject`, `s3:PutObject`, `s3:DeleteObject`) operate on the OBJECT ARN (`arn:aws:s3:::BUCKET/*`). Combining them in one statement with `BUCKET/*` causes `AccessDenied` on `ListBucket`.
+
+**WRONG (single statement):**
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+  "Resource": "arn:aws:s3:::BUCKET_NAME/*"
+}
+```
+
+**CORRECT (two statements):**
+```json
+[
+  {
+    "Effect": "Allow",
+    "Action": ["s3:ListBucket"],
+    "Resource": "arn:aws:s3:::BUCKET_NAME"
+  },
+  {
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+    "Resource": "arn:aws:s3:::BUCKET_NAME/*"
+  }
+]
+```
+
+**Rule:** S3 IAM policies MUST split into two statements: `ListBucket` on bucket ARN, object operations on `bucket/*` ARN. This applies to all IAM policy templates in INFRASTRUCTURE_REQUIREMENTS.md §4.
+
+## JDBC-Backed Scheduler Override Rule
+
+**Trigger:** Quartz JDBC JobStore, ShedLock, or similar JDBC-based distributed scheduler already configured.
+
+**Problem:** Workers may generate a Kubernetes CronJob for tasks managed by a JDBC-backed scheduler. Since the scheduler already provides distributed coordination (row-level locks prevent duplicate execution across pods), a CronJob would cause double execution.
+
+**Rule:** If the scheduler uses `JobStoreTX`, ShedLock's `LockProvider`, or any JDBC-backed coordination mechanism, do NOT generate a separate CronJob manifest. Document the existing coordination mechanism in INFRASTRUCTURE_REQUIREMENTS.md and add NetworkPolicy egress for the scheduler's DB connection.
+
+**Detection:**
+```bash
+grep -rn 'JobStoreTX\|ShedLock\|LockProvider\|net.javacrumbs' . --include='*.java' --include='*.properties' --include='*.xml'
+```
+
+## Tomcat WAR vs Spring Boot terminationGracePeriodSeconds
+
+**Trigger:** Traditional Tomcat WAR deployment (non-Spring Boot) vs embedded Spring Boot application.
+
+**Problem:** Tomcat WAR applications do NOT have `server.shutdown=graceful` — they rely on Tomcat's `unloadDelay` (default 2000ms). Spring Boot applications use `spring.lifecycle.timeout-per-shutdown-phase`.
+
+| Deployment | Grace Period | terminationGracePeriodSeconds |
+|---|---|---|
+| Spring Boot (embedded Tomcat) | `timeout-per-shutdown-phase` + 10s | See §46 formula |
+| Tomcat WAR (non-Boot) | `unloadDelay` (default 2s) + 10s buffer | 12 (minimum 30 per K8s floor) |
+| Tomcat WAR with custom shutdown | Custom connector `closeDelay` + 10s | closeDelay + 10 |
+
+**Rule:** For Tomcat WAR deployments, use a standardised `terminationGracePeriodSeconds: 30` (K8s minimum floor) unless a custom shutdown timeout is configured. The +10s buffer accounts for SIGTERM propagation and servlet context destroy hooks.
+
+## Javadoc Wildcard Escaping
+
+**Trigger:** Java Dockerfile or shell commands containing `*/` substring (e.g., `target/*/` glob, `src/main/*/`).
+
+**Problem:** `*/` inside a Javadoc comment (`/** ... */`) is interpreted as the comment-closing sequence. If a file contains wildcard paths in Javadoc, the comment terminates prematurely causing compilation errors.
+
+**Escape pattern:** Use `&#42;/` in Javadoc or avoid `*/` by using descriptive text:
+```java
+/**
+ * Files matching target/&#42;/.jar are included.
+ */
+```
+
+**Detection:** `grep -rn '\*/' src/ --include='*.java' | grep -v '^\s*\*/' | grep -v '^.*\*\*/'`
+
+**Rule:** When generating MIGRATION comments containing glob patterns with `*/`, use single-line `//` comments instead of `/** */` blocks to avoid Javadoc parse errors.
+
+## Multi-Module Test Shadow Rule for XML PPC
+
+**Trigger:** Multi-module Maven project with PropertyPlaceholderConfigurer loading a shared properties file that was migrated to use `${VAR}` placeholders.
+
+**Problem:** Test classes in dependent modules that load the XML context transitively pull in the PPC bean, which attempts to resolve `${VAR}` from the properties file. Without a test-specific properties file providing defaults, tests fail with `Could not resolve placeholder`.
+
+**Detection:**
+```bash
+# Find XML context files loaded in tests
+grep -rn 'ClassPathXmlApplicationContext\|@ContextConfiguration.*xml' src/test/ --include='*.java'
+# Cross-reference with PPC-loaded properties files
+grep -rn 'PropertyPlaceholderConfigurer' src/main/resources/*.xml | grep -oP 'location="[^"]*"'
+```
+
+**Rule:** After migrating any properties file loaded by XML PPC to use `${VAR}` placeholders, create a test shadow file at `src/test/resources/<same-path>` with safe defaults for ALL newly-introduced placeholders.
+
+## Latin-1 Properties File Detection
+
+**Trigger:** Java `.properties` files with non-ASCII characters that must be preserved during migration edits.
+
+**Problem:** Java `Properties.load(InputStream)` reads ISO-8859-1 (Latin-1). If a worker writes to the file using UTF-8 encoding, non-ASCII characters (accents, umlauts) become garbled at runtime.
+
+**Detection:**
+```bash
+file -i src/main/resources/*.properties 2>/dev/null | grep -v 'us-ascii'
+```
+
+**Rule:** When editing `.properties` files during migration, always preserve the original encoding. If the file is Latin-1, write replacements using Python with `encoding='latin-1'` or use only ASCII-safe characters (Unicode escapes for non-ASCII: `\u00e9` for é).
+
+## Classic PPC No-Relaxed-Binding
+
+**Trigger:** Legacy Spring XML `PropertyPlaceholderConfigurer` (not Spring Boot PSPC).
+
+**Problem:** Classic PPC does NOT support Spring Boot's relaxed binding. `${db.password}` in a properties file resolves ONLY from a property named exactly `db.password` — NOT from `DB_PASSWORD` env var. Spring Boot's PSPC bridges these automatically, but classic PPC does not.
+
+**Rule:** For applications using XML PPC without Spring Boot, env var injection requires explicit bridging in the properties file:
+```properties
+# Bridge env var to dotted property name for classic PPC:
+db.password=${DB_PASSWORD:default}
+```
+
+Without this bridge line, setting `DB_PASSWORD` as an env var has no effect on the `db.password` placeholder.
+
+**Detection:**
+```bash
+grep -rn 'PropertyPlaceholderConfigurer' . --include='*.xml' | grep -v 'test'
+grep -L 'spring-boot\|SpringApplication' src/main/java/**/*.java 2>/dev/null | head -1
+# Both present + no Boot = classic PPC project
+```
+
+## terminationGracePeriodSeconds Standard Buffer
+
+**Rule:** When no explicit graceful shutdown timeout is configured by the application, use `terminationGracePeriodSeconds: 30` as the standard minimum. When an explicit timeout IS configured, add exactly 10 seconds as the buffer (not 5s):
+
+| Scenario | Formula |
+|---|---|
+| No graceful shutdown config | 30 (K8s default floor) |
+| Spring Boot `timeout-per-shutdown-phase=Ns` | N + 10 |
+| PHP-FPM supervisord `stopwaitsecs=Ns` | N + 30 |
+| Custom app shutdown handler | handler_timeout + 10 |
+
+The 10s buffer (increased from 5s) accounts for SIGTERM delivery latency, container runtime overhead, and pre-stop hook execution.
+
+## PPC Detection and Migration (Phase 1 Blocker)
+
+**Trigger:** Legacy Spring XML application using `PropertyPlaceholderConfigurer` (PPC) without Spring Boot.
+
+**Problem:** PPC does NOT support env var resolution natively. Unlike Spring Boot's PSPC which bridges `${DB_PASSWORD}` to the `DB_PASSWORD` env var automatically, classic PPC only resolves from its configured `.properties` file locations. This is a **Phase 1 Blocker** — env var externalisation cannot work without bridging.
+
+**Detection:**
+```bash
+grep -rn 'PropertyPlaceholderConfigurer' . --include='*.xml' | grep -v test
+grep -L 'SpringApplication\|@SpringBootApplication' src/main/java/**/*.java 2>/dev/null | head -1
+# Both present + no Boot = classic PPC project needing migration
+```
+
+**Migration path (PPC → PSPC):**
+1. Add Spring Boot dependency OR `PropertySourcesPlaceholderConfigurer` bean
+2. For each `<property>` in PPC XML, add explicit bridge in properties file: `property.key=${ENV_VAR:default}`
+3. Ensure `ignoreUnresolvablePlaceholders=true` on legacy PPC if keeping both
+
+**Three injection paths for Classic Spring WAR (no-relaxed-binding):**
+Classic PPC does NOT support Spring Boot's relaxed binding. `${db.password}` resolves ONLY from a property named exactly `db.password`, NOT from `DB_PASSWORD` env var.
+
+| Injection Path | Mechanism | Env Var Works? |
+|---|---|---|
+| XML PPC `<property>` | Literal property file lookup | NO — needs explicit bridge line |
+| `@Value("${prop.name}")` with PSPC | Spring Boot relaxed binding | YES (if PSPC active) |
+| `Environment.getProperty()` | Spring Environment abstraction | YES (env vars are a PropertySource) |
+
+**Rule:** For every `${dotted.name}` placeholder in a classic PPC project, add a bridge line in the properties file: `dotted.name=${SCREAMING_SNAKE_NAME:default}`. Without this, setting env vars has no effect.
+
+## Spring Boot Flyway/Mail Job Autoconfigure Exclusion
+
+**Trigger:** Spring Boot application with Flyway AND background jobs (Kafka consumers, mail senders) that fail on missing DataSource or MailSender beans.
+
+**Problem:** Spring Boot auto-configures `FlywayAutoConfiguration` for ALL Spring contexts including standalone worker jobs that don't need database migration. Similarly, `MailSenderAutoConfiguration` fails if SMTP is not configured for workers that don't send mail.
+
+**Detection:**
+```bash
+grep -rn 'spring-boot-starter-mail\|FlywayAutoConfiguration\|spring.flyway' . --include='*.java' --include='*.properties' --include='*.gradle'
+```
+
+**Fix — exclude in worker/job application class:**
+```java
+@SpringBootApplication(exclude = {
+    FlywayAutoConfiguration.class,
+    MailSenderAutoConfiguration.class
+})
+public class KafkaWorkerApplication { ... }
+```
+
+**Rule:** When a Spring Boot project has multiple entry points (web app + Kafka consumer + CronJob), each non-web entry point MUST exclude auto-configurations it doesn't need. Common exclusions for workers:
+- `FlywayAutoConfiguration` — unless the worker runs migrations
+- `MailSenderAutoConfiguration` — unless the worker sends mail
+- `WebMvcAutoConfiguration` — always exclude for non-web (already in §18)
+
+## Post-T2 Test Classpath Shadow Sync
+
+**Trigger:** After Tier 2 (kubeconform) passes and before Final Review, verify test infrastructure still compiles.
+
+**Problem:** Properties externalised during Sub-Phase §3/§7 (e.g., `${DB_PASSWORD}` with no default) cause test failures with `Could not resolve placeholder` when test resource files lack corresponding defaults.
+
+**Procedure:**
+```bash
+# Find all ${VAR} references without defaults in main resources
+grep -rn '\${[A-Z_]*}' src/main/resources/*.properties src/main/resources/*.yml 2>/dev/null | grep -v ':-\|:[^}]'
+# For each match, diff against test resources
+for f in $(grep -rl '\${[A-Z_]*}' src/main/resources/ 2>/dev/null | grep -v ':'); do
+  BASENAME=$(basename "$f")
+  if [ ! -f "src/test/resources/$BASENAME" ]; then
+    echo "MISSING TEST SHADOW: src/test/resources/$BASENAME"
+  else
+    # Check if test shadow has defaults for the same keys
+    grep -c ':-\|:[^}]' "src/test/resources/$BASENAME" || echo "TEST SHADOW MAY LACK DEFAULTS: $BASENAME"
+  fi
+done
+```
+
+**Fix:** Create or update `src/test/resources/<filename>` with safe defaults for ALL newly-introduced `${VAR}` placeholders:
+```properties
+# src/test/resources/application.properties
+db.password=${DB_PASSWORD:test-password}
+api.secret=${API_SECRET:test-secret}
+```
+
+**Rule:** This check is part of the Post-Externalisation Test Sync Gate. Run within the same task that introduces `${VAR}` (no default) — do not defer.
+
+
+## PIPESTATUS for Maven Pipe Verification
+
+**Trigger:** Maven/Gradle build commands piped through `tee` or `grep` for log capture.
+
+**Problem:** When piping build output (`mvn package 2>&1 | tee build.log`), the exit code captured by `$?` is from the LAST command in the pipe (tee, which always exits 0). The build tool's actual exit code is lost.
+
+**Correct pattern:**
+```bash
+mvn package -DskipTests 2>&1 | tee /tmp/build.log
+BUILD_EXIT=${PIPESTATUS[0]}
+[ "$BUILD_EXIT" -eq 0 ] && echo "BUILD OK" || echo "BUILD FAILED (exit $BUILD_EXIT)"
+```
+
+**Rule:** ALWAYS use `${PIPESTATUS[0]}` after piped Maven/Gradle commands. `$?` captures only the rightmost command's exit code.
+
+## Mixed-Type Secret envFrom Prohibition
+
+**Trigger:** Spring applications using Secret with `envFrom` bulk injection where some keys contain dots.
+
+**Problem:** Kubernetes `envFrom.secretRef` injects ALL keys as environment variables. Keys containing dots (e.g., `spring.datasource.password`) are invalid as env var names on Linux — they are SILENTLY SKIPPED. The application never receives these values.
+
+**Detection:**
+```bash
+python3 -c "
+import yaml
+with open('kubernetes/secret.yaml') as f:
+    for doc in yaml.safe_load_all(f):
+        if doc and doc.get('kind') == 'Secret':
+            for k in list(doc.get('stringData', {}).keys()) + list(doc.get('data', {}).keys()):
+                if '.' in k:
+                    print(f'INCOMPATIBLE: {k} — dots prevent envFrom injection')
+"
+```
+
+**Rule:** Secret keys used with `envFrom` MUST NOT contain dots, slashes, or other characters invalid in env var names. For dotted keys, use explicit `env[].valueFrom.secretKeyRef` with SCREAMING_SNAKE_CASE env var name and let Spring relaxed binding bridge them.
+
+## S3 IAM Two-Statement Policy Template
+
+**Trigger:** ANY S3 IAM policy in INFRASTRUCTURE_REQUIREMENTS.md §4.
+
+**Rule:** S3 IAM policies MUST use two statements with different resource ARNs:
+- Statement 1: `s3:ListBucket` on bucket ARN (`arn:aws:s3:::BUCKET_NAME`)
+- Statement 2: `s3:GetObject/PutObject/DeleteObject` on object ARN (`arn:aws:s3:::BUCKET_NAME/*`)
+
+Include `s3:CopyObject` (source read) when the application moves files between paths. Missing `s3:ListBucket` causes misleading `AccessDenied` on non-existent keys.
+
+See §64 (IAM Policy Two-Statement Split) for the canonical template.
+
+## Hibernate Dual-Load Properties Guard
+
+**Trigger:** Hibernate properties file loaded by BOTH raw `Properties.load()` (Java IO) AND Spring `PropertySource`/`@PropertySource`.
+
+**Problem:** Raw `Properties.load(InputStream)` does NOT resolve `${VAR}` placeholders — it passes the literal string `${DB_PASSWORD}` as the JDBC credential. Spring `PropertySource` DOES resolve them. When the same file is read via both paths (common in legacy Hibernate + Spring hybrid apps), adding `${VAR}` syntax breaks the raw-load path.
+
+**Detection:**
+```bash
+# Find properties files loaded by raw Properties.load()
+grep -rn 'Properties.*load\|getResourceAsStream.*properties' . --include='*.java' | grep -v test
+# Cross-reference with Spring @PropertySource
+grep -rn '@PropertySource\|PropertyPlaceholderConfigurer' . --include='*.java' --include='*.xml'
+```
+
+**Rule:** When a properties file is loaded by BOTH raw `Properties.load()` AND Spring, NEVER add `${VAR}` placeholders for credentials. Instead: clear credentials to empty strings and rely on startup-script injection or environment variable override at the Spring PropertySource level. Add a MIGRATION comment explaining the dual-load constraint.
+
+**Before (WRONG — breaks raw Properties.load path):**
+```properties
+hibernate.connection.password=${DB_PASSWORD}
+```
+
+**After (CORRECT — empty string for raw path, Spring resolves from env separately):**
+```properties
+hibernate.connection.password=
+# MIGRATION: Dual-load file — raw Properties.load() cannot resolve ${VAR}. Credential injected via Spring Environment overlay.
+```
+
+## Log4j2 RollingFileAppender createOnDemand
+
+**Trigger:** Log4j2 configuration with `RollingFile` appenders being redirected to Console (§5 Logging Transformation).
+
+**Problem:** When `readOnlyRootFilesystem: true` is set, Log4j2 `RollingFile` appenders fail at startup because they create the log file eagerly during `appender.start()`. Adding `createOnDemand="true"` defers file creation until the first log event — but if the logger is never triggered (common for error-only file loggers), no write occurs and no crash happens.
+
+**Rule:** When converting logging to stdout/stderr, if a `RollingFile` appender cannot be removed (e.g., it's referenced by a named logger with `additivity="false"`), add `createOnDemand="true"` AND redirect the logger to Console as the primary fix:
+
+```xml
+<!-- Before: eager file creation (crashes with readOnlyRootFilesystem) -->
+<RollingFile name="ErrorLog" fileName="/var/log/app/error.log" ...>
+
+<!-- After: deferred creation + Console redirect -->
+<RollingFile name="ErrorLog" fileName="/tmp/error.log" createOnDemand="true" ...>
+```
+
+**Source:** Log4j2 `createOnDemand` parameter — "configure to create the log file only when a log event passed to the appender" (https://stackoverflow.com/questions/2719845/how-do-i-make-log4j-create-log-files-on-demand-only).
+
+## Tomcat setenv.sh Write Avoidance
+
+**Trigger:** Tomcat-based applications where `catalina.sh` sources `${CATALINA_BASE}/bin/setenv.sh` at startup.
+
+**Problem:** With `readOnlyRootFilesystem: true`, if the entrypoint attempts to write/generate `setenv.sh` at runtime (common pattern for injecting JVM opts from env vars), the write fails and Tomcat refuses to start.
+
+**Detection:**
+```bash
+grep -rn 'setenv\.sh\|CATALINA_OPTS\|JAVA_OPTS' entrypoint*.sh docker-entrypoint*.sh Dockerfile 2>/dev/null
+```
+
+**Rule:** Do NOT write `setenv.sh` at container runtime. Instead:
+1. Bake a static `setenv.sh` into the image at build time with env var references: `CATALINA_OPTS="${JAVA_OPTS:-} -Djava.io.tmpdir=/tmp"`
+2. OR pass JVM opts via the `JAVA_OPTS` env var and configure the entrypoint to use `exec java $JAVA_OPTS -jar ...` (Spring Boot) or ensure `catalina.sh` reads `CATALINA_OPTS` from environment (default Tomcat behaviour).
+
+## Infinispan Programmatic Injection Guard
+
+**Trigger:** Infinispan/JGroups configured programmatically (not via XML) with `GlobalConfigurationBuilder`.
+
+**Problem:** When Infinispan is configured programmatically and the cluster transport settings reference env vars at class-loading time (static initializers), the env vars must be available BEFORE Spring context starts. `@Value` injection is too late — the JGroups transport is initialized in a static block or constructor.
+
+**Detection:**
+```bash
+grep -rn 'GlobalConfigurationBuilder\|DefaultCacheManager\|JGroupsTransport' . --include='*.java' | grep -v test
+```
+
+**Rule:** For programmatic Infinispan configuration, use `System.getenv()` directly (not Spring `@Value`) for transport-related settings (bind address, namespace, cluster name). Add these env vars to ConfigMap and document in ENV_VARIABLES.md:
+- `JGROUPS_CLUSTER_NAME` — Infinispan cluster name
+- `KUBE_NAMESPACE` — Kubernetes namespace for KUBE_PING discovery
+- `JGROUPS_BIND_ADDRESS` — typically `SITE_LOCAL` or pod IP
+
+## @KafkaListener Annotation EL Placeholders
+
+**Trigger:** Spring Kafka applications using `@KafkaListener` annotations with Spring EL placeholders in `topics` or `groupId` attributes.
+
+**Problem:** `@KafkaListener(topics = "${kafka.topic.name}")` resolves the topic name from Spring properties/env vars at runtime. Pass 1 env var grep scanning only `.properties`/`.yml` files misses these — the placeholder appears in a `.java` file annotation attribute.
+
+**Detection:**
+```bash
+# Find @KafkaListener with EL placeholders
+grep -rn '@KafkaListener' . --include='*.java' | grep '\${'
+# Extract placeholder variable names
+grep -rhoP '@KafkaListener.*?\$\{([A-Za-z_.]+)' . --include='*.java' | grep -oP '\$\{\K[A-Za-z_.]+'
+```
+
+**Rule:** Extend Pass 1 env var scan for Java/Spring projects to include `@KafkaListener` annotation attributes alongside `@Value`. Every `${placeholder}` in a `@KafkaListener` annotation needs either a Spring properties bridge (`kafka.topic.name=${KAFKA_TOPIC_NAME:default}`) or a direct env var entry.
+
+**Common @KafkaListener placeholders requiring ConfigMap entries:**
+- `${kafka.topic.name}` → `KAFKA_TOPIC_NAME` (ConfigMap)
+- `${kafka.group.id}` → `KAFKA_GROUP_ID` (ConfigMap)
+- `${kafka.consumer.concurrency}` → `KAFKA_CONSUMER_CONCURRENCY` (ConfigMap)
+
+**ENV_VARIABLES.md entries:** All Kafka topic/group placeholders are ConfigMap-scoped (not Secret) — they are routing configuration, not credentials. Exception: `KAFKA_SASL_USERNAME` and `KAFKA_SASL_PASSWORD` are credentials → Secret.
+
+## Gradle Wrapper Stub Pattern
+
+**Trigger:** Gradle projects where `gradlew` exists but `gradle/wrapper/gradle-wrapper.jar` is missing (e.g., `.gitignore` excludes JAR files).
+
+**Problem:** `./gradlew build` fails immediately with "Could not find or load main class org.gradle.wrapper.GradleWrapperMain" when the wrapper JAR is absent from the repository.
+
+**Detection:**
+```bash
+[ -f gradlew ] && [ ! -f gradle/wrapper/gradle-wrapper.jar ] && echo "WRAPPER STUB — JAR MISSING"
+```
+
+**Resolution options:**
+1. Generate wrapper: `gradle wrapper` (requires system Gradle)
+2. Use system Gradle directly: `gradle build -x test`
+3. Use the Gradle Docker image in multi-stage build (bypass host-side gate): `FROM gradle:8-jdk21 AS builder`
+
+**Rule:** When `gradlew` exists but `gradle-wrapper.jar` is absent, do NOT fail the build silently. Attempt resolution option 1, then 2, then 3. Record the method used in TRANSFORMATION_SUMMARY.md. If all options fail, record CONDITIONAL PASS with root cause.
+
+## Spring Redis ENV Bridge (SPRING_REDIS_HOST vs REDIS_HOST)
+
+**Trigger:** Spring Boot applications using Spring Data Redis where the source code reads `spring.redis.host` / `spring.data.redis.host` via property binding.
+
+**Problem:** Workers create `REDIS_HOST` as the env var name, but Spring Data Redis expects `SPRING_REDIS_HOST` (or `SPRING_DATA_REDIS_HOST` in Spring Boot 3.x) for its auto-configuration. The application silently connects to `localhost` when the bridge is missing.
+
+**Detection:**
+```bash
+grep -rn 'spring\.redis\|spring\.data\.redis' src/main/resources/ --include='*.properties' --include='*.yml'
+```
+
+**Rule:** For Spring Data Redis, the ConfigMap env var MUST match the Spring property naming convention:
+```properties
+# application.properties — bridge to env var:
+spring.data.redis.host=${SPRING_DATA_REDIS_HOST:localhost}
+spring.data.redis.port=${SPRING_DATA_REDIS_PORT:6379}
+```
+
+**ConfigMap entry:**
+```yaml
+data:
+  SPRING_DATA_REDIS_HOST: "replace-with-redis-host"
+  SPRING_DATA_REDIS_PORT: "6379"
+```
+
+Do NOT use bare `REDIS_HOST` unless the application explicitly reads it via `System.getenv("REDIS_HOST")`.
+
+## Kafka Consumer HPA Sizing Formula
+
+**Trigger:** Spring Kafka applications with `@KafkaListener` and HPA configured.
+
+**Problem:** Kafka consumers are limited by partition count — more replicas than partitions means idle consumers that waste resources. The HPA `maxReplicas` must not exceed `floor(partition_count / concurrency)`.
+
+**Formula:** `safe_max_replicas = floor(partition_count / concurrency_per_consumer)`
+
+**Detection:**
+```bash
+grep -rn '@KafkaListener\|concurrency' . --include='*.java' --include='*.properties' --include='*.yml' | grep -i 'concurrency\|partitions'
+```
+
+**Rule:** When generating HPA for Kafka consumer Deployments:
+1. Extract `concurrency` from `@KafkaListener(concurrency = "N")` or `spring.kafka.listener.concurrency`
+2. Document `partition_count` as a prerequisite in INFRASTRUCTURE_REQUIREMENTS.md
+3. Set `maxReplicas = floor(partition_count / concurrency)` with a MIGRATION comment:
+```yaml
+# MIGRATION: maxReplicas = floor(TOPIC_PARTITIONS / CONSUMER_CONCURRENCY)
+# Update when partition count changes. Exceeding this wastes idle consumers.
+maxReplicas: 3  # Assumes 9 partitions / 3 concurrency
+```
+
+## Gradle bootJar archiveVersion
+
+**Trigger:** Spring Boot Gradle projects where the built JAR has a version suffix (e.g., `app-1.0.0.jar`).
+
+**Problem:** Dockerfile `COPY build/libs/*.jar /app/app.jar` works for single-JAR output, but if `bootJar` produces `app-1.0.0.jar` alongside `app-1.0.0-plain.jar` (from the `jar` task), the glob copies both — Docker COPY with multiple sources requires a directory destination.
+
+**Fix — disable plain jar and optionally strip version:**
+```groovy
+// build.gradle
+jar {
+    enabled = false  // Disable plain JAR — only bootJar output
+}
+bootJar {
+    archiveVersion.set('')  // Produces app.jar instead of app-1.0.0.jar
+}
+```
+
+**Detection:**
+```bash
+ls build/libs/*.jar 2>/dev/null | wc -l
+# If >1 JAR → plain jar is being produced alongside bootJar
+grep -n 'bootJar\|archiveVersion\|jar {' build.gradle build.gradle.kts 2>/dev/null
+```
+
+**Rule:** For Spring Boot Gradle projects, either set `archiveVersion.set('')` in `bootJar` OR disable the `jar` task. The Dockerfile COPY pattern must match exactly one JAR file.
+
+## Gradle Wrapper JAR Regeneration
+
+**Trigger:** Gradle project where `gradle/wrapper/gradle-wrapper.jar` is missing (common when `.gitignore` excludes `*.jar`).
+
+**Problem:** `./gradlew` fails immediately with "Could not find or load main class org.gradle.wrapper.GradleWrapperMain" when the wrapper JAR is absent.
+
+**Procedure:**
+```bash
+# Step 1: Check if wrapper JAR exists
+[ -f gradle/wrapper/gradle-wrapper.jar ] && echo "OK" || echo "MISSING"
+
+# Step 2: If missing, check if system Gradle is available
+command -v gradle && gradle wrapper --gradle-version=$(grep distributionUrl gradle/wrapper/gradle-wrapper.properties 2>/dev/null | grep -oP '\d+\.\d+(\.\d+)?' || echo "8.5")
+
+# Step 3: If no system Gradle, use Docker-based build (bypass host gate)
+# In Dockerfile:
+FROM gradle:8-jdk21 AS builder
+COPY . /build
+WORKDIR /build
+RUN gradle build -x test --no-daemon
+```
+
+**Rule:** When wrapper JAR is absent, attempt regeneration before falling back to system Gradle or Docker-based build. Record which method succeeded in TRANSFORMATION_SUMMARY.md.
+
+
+## Spring XML PPC Does Not Bridge SCREAMING_SNAKE_CASE
+
+**Trigger:** Legacy Spring XML application using `PropertyPlaceholderConfigurer` (PPC) without Spring Boot.
+
+**Problem:** Classic PPC does NOT perform the relaxed binding that Spring Boot's `PropertySourcesPlaceholderConfigurer` (PSPC) provides. Specifically:
+- `${db.password}` in a properties file resolves ONLY from a property named exactly `db.password`
+- Setting `DB_PASSWORD` as an environment variable has NO effect on `${db.password}` placeholders
+- Spring Boot PSPC automatically bridges `DB_PASSWORD` → `db.password` but classic PPC does not
+
+**Detection (is this a classic PPC project?):**
+```bash
+# Check for PPC in XML
+grep -rn 'PropertyPlaceholderConfigurer' . --include='*.xml' | grep -v test
+# Check for absence of Spring Boot
+grep -rL 'SpringApplication\|@SpringBootApplication' src/main/java/**/*.java 2>/dev/null | head -1
+# Both conditions true = classic PPC project needing explicit bridging
+```
+
+**Migration requirement — explicit bridge lines:**
+```properties
+# Add to application.properties for EACH dotted property that needs env var injection:
+db.host=${DB_HOST:localhost}
+db.port=${DB_PORT:3306}
+db.password=${DB_PASSWORD:}
+hibernate.connection.url=jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:appdb}
+```
+
+Without these bridge lines, setting environment variables in ConfigMap/Secret has zero effect on the application's resolved property values.
+
+**ENV_VARIABLES.md impact:** Document each bridged property with a note: "Requires explicit bridge in .properties file (classic PPC — no relaxed binding)."
+
+**Post-externalisation test sync:** After adding `${VAR}` bridge lines, verify test profiles also have corresponding defaults. Classic PPC projects often load `application-test.properties` which must mirror the bridge syntax with test-safe values.
+
+## spring-boot-starter-tomcat scope=provided + packaging=jar P0 Blocker
+
+**Trigger:** Spring Boot project with `<packaging>jar</packaging>` (or no packaging element, which defaults to JAR) AND `spring-boot-starter-tomcat` with `<scope>provided</scope>`.
+
+**Problem:** This combination causes a SILENT CrashLoopBackOff:
+1. `mvn package` succeeds (exit 0) — producing a JAR
+2. `docker build` succeeds (exit 0) — image builds correctly
+3. Container starts, Spring Boot prints banner, then IMMEDIATELY exits with code 0
+4. Kubernetes restarts → CrashLoopBackOff
+5. No error in logs — just "Completed initialization in X ms" followed by exit
+
+The root cause: `scope=provided` excludes the embedded Tomcat from the fat JAR. Spring Boot finds no `ServletWebServerFactory` bean, determines it's not a web application, and shuts down gracefully.
+
+**Detection:**
+```bash
+grep -B2 -A2 'provided' pom.xml | grep -i 'tomcat\|jetty\|undertow'
+grep '<packaging>' pom.xml  # If absent or 'jar', this is the P0 combination
+```
+
+**Fix — remove scope=provided:**
+```xml
+<!-- BEFORE (BROKEN for jar packaging): -->
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-tomcat</artifactId>
+    <scope>provided</scope>
+</dependency>
+
+<!-- AFTER (CORRECT for jar packaging): -->
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-tomcat</artifactId>
+</dependency>
+```
+
+**Rule:** For `<packaging>jar</packaging>`, ALWAYS remove `<scope>provided</scope>` from the embedded servlet container dependency. This fix is REQUIRED in Phase 2 §11 (Build/Release/Run) — do NOT assess as "non-blocking" or defer.
+
+## MIGRATION Comment Env Var Scanning Note
+
+**Trigger:** Java projects where `// MIGRATION:` comments describe removed credential values.
+
+**Problem:** `grep -rn 'getenv\|System.getenv'` misses env var NAMES that only appear inside MIGRATION comments. This is correct behaviour — MIGRATION comments document past state, not current env var reads. However, some workers see MIGRATION comments mentioning env var names and incorrectly add them to ENV_VARIABLES.md.
+
+**Rule:** MIGRATION comments are NOT sources of env var reads. Do NOT add entries to ENV_VARIABLES.md based solely on variable names found in MIGRATION comments. Only actual `System.getenv("VAR")`, `@Value("${VAR}")`, or `${VAR}` placeholder references in active (non-commented) code count as env var reads.
+
+## Latin-1 .properties File Encoding Detection
+
+**Trigger:** Java `.properties` files with non-ASCII content (accents, CJK characters).
+
+**Problem:** Java `Properties.load(InputStream)` reads ISO-8859-1 (Latin-1) by default. If a worker modifies a .properties file using UTF-8 encoding, non-ASCII characters become garbled at runtime.
+
+**Detection:**
+```bash
+file -i src/main/resources/*.properties 2>/dev/null | grep -v 'us-ascii'
+```
+
+**Rule:** When editing `.properties` files during migration:
+1. Run detection above to identify encoding
+2. If Latin-1: use `python3 -c "open('f','w',encoding='latin-1').write(content)"` for writes
+3. If UTF-8 non-ASCII is needed: use Unicode escapes (`\u00e9` for é)
+4. Never change a file's encoding without explicit intent
+
+## Post-Externalisation Test Sync for spring-session-data-redis
+
+**Trigger:** After adding `spring-session-data-redis` or `spring-boot-starter-data-redis` to `pom.xml` for session externalisation.
+
+**Problem:** Spring auto-configuration detects the Redis starter on the classpath and immediately attempts to connect to Redis during test context startup. Without a test-specific override, ALL `@SpringBootTest` classes fail with `RedisConnectionException`.
+
+**Fix — add to ALL test resource files:**
+```properties
+# src/test/resources/application-test.properties (or application.properties in test resources)
+spring.session.store-type=none
+spring.data.redis.repositories.enabled=false
+management.health.redis.enabled=false
+```
+
+**Detection (after adding redis starter):**
+```bash
+grep -rn 'spring-session-data-redis\|spring-boot-starter-data-redis' pom.xml build.gradle
+# If match found, verify test shadow exists:
+grep -rn 'store-type=none' src/test/resources/ || echo "MISSING: test shadow for Redis session"
+```
+
+**Rule:** Adding `spring-session-data-redis` to dependencies REQUIRES immediate test sync in the SAME task. Do NOT defer — tests will fail in all subsequent tasks.
+
+---
+
+## MIGRATION Comment Javadoc Wildcard Hazard
+
+**Trigger:** MIGRATION comments placed inside `/** ... */` Javadoc blocks that contain URL path globs (e.g., `*/path/*`, `/**/`).
+
+**Problem:** Path glob patterns inside Javadoc blocks are interpreted as closing the comment (`*/` terminates the block), which causes compilation errors in the surrounding class.
+
+**Rule:** Place all MIGRATION comments as `//` single-line comments immediately above or below the relevant code, never inside `/** ... */` Javadoc blocks. If a MIGRATION comment must appear near a method with Javadoc, insert it as a `//` comment after the closing `*/` of the Javadoc block.
+
+---
+
+## Dual-Namespace Elasticsearch/OpenSearch Coexistence
+
+**Trigger:** Project dependencies include both Elasticsearch and OpenSearch client libraries simultaneously (e.g., `spring-data-elasticsearch` + `opensearch-rest-client`).
+
+**Problem:** The two clients use separate Spring property namespaces (`spring.elasticsearch.*` vs `spring.opensearch.*`). Scanning for one namespace misses the other, causing incomplete externalisation.
+
+**Rule:** When both client types are detected in the dependency manifest, treat them as independent property sets. Discover and externalise both `spring.elasticsearch.*` and `spring.opensearch.*` property namespaces in the same credential/config externalisation task. Document both sets in ENV_VARIABLES.md with distinct rows and correct ConfigMap/Secret classifications for each.
+
+---
+
+## PropertyPlaceholderConfigurer Test Shadow Requirement
+
+**Trigger:** XML `PropertyPlaceholderConfigurer` (PPC) loading a `.properties` file that has credentials or required values with hardcoded defaults being removed as part of credential externalisation.
+
+**Problem:** When default values are removed from a PPC-loaded properties file, the corresponding test resource file (also loaded by PPC in test scope) no longer has those values. Tests fail with `IllegalArgumentException: Could not resolve placeholder` at startup.
+
+**Rule:** Whenever a default value is removed from a PPC-loaded properties file during credential externalisation, immediately add a test placeholder to the corresponding PPC-loaded test resource file (typically `src/test/resources/`). The test placeholder value should be a non-empty stub (e.g., `replace-with-test-value`) sufficient to satisfy the application's null/empty guard. This forward action prevents test compilation failures that would otherwise be discovered only at the build gate.
+
+## Dual-Use Directory Init-Container-Copy Pattern
+
+**Trigger:** Dockerfile `WORKDIR` or `COPY` target path that receives BOTH image-baked content (copied at build time) AND runtime writes (logged, cached, or generated at container start).
+
+**Detection:**
+```bash
+# Find directories that are both COPY targets and runtime-write targets
+grep '^COPY' Dockerfile | grep -v '\-\-from=' | awk '{print $NF}' | sort -u > /tmp/copy_targets.txt
+grep -nE 'mkdir|touch|cat >|tee|>>' entrypoint*.sh docker-entrypoint*.sh 2>/dev/null | grep -oP '[\w/.-]+' | sort -u > /tmp/write_targets.txt
+comm -12 /tmp/copy_targets.txt /tmp/write_targets.txt
+```
+
+**Problem:** Mounting an emptyDir at a Dual-Use path hides the image-baked content. The init-container-copy pattern solves this by copying image content into the emptyDir before the main container starts.
+
+**Pattern:**
+```yaml
+initContainers:
+- name: copy-content
+  image: same-as-main-container:tag
+  command: ['sh', '-c', 'cp -a /original/path/. /shared/']
+  volumeMounts:
+  - name: dual-use-vol
+    mountPath: /shared
+containers:
+- name: main
+  volumeMounts:
+  - name: dual-use-vol
+    mountPath: /original/path
+volumes:
+- name: dual-use-vol
+  emptyDir: {}
+```
+
+**fsGroup co-requirement:** When using init-container-copy with emptyDir, the pod-level `securityContext.fsGroup` MUST match `runAsUser` on both init and main containers. Otherwise the main container cannot write to files copied by the init container.
+
+**Rule:** When a path appears in BOTH COPY-target and runtime-write-target lists, apply the init-container-copy pattern. Never mount a bare emptyDir at a path containing image-baked content — it hides everything.
+
+## Spring XML PPC vs PropertiesFactoryBean Resolution Differences
+
+**Trigger:** Spring XML projects using BOTH `PropertyPlaceholderConfigurer` (PPC) and `PropertiesFactoryBean` (PFB).
+
+**Key difference:**
+| Bean | Resolves `${VAR}`? | Reads from Environment? | Use Case |
+|------|-------------------|------------------------|----------|
+| PropertyPlaceholderConfigurer | YES | YES (via systemEnvironmentVariablesMode) | Bean property injection |
+| PropertiesFactoryBean | NO | NO | Provides raw Properties map to consuming beans |
+
+**Source:** https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/beans/factory/config/PropertyPlaceholderConfigurer.html — "The default implementation delegates to resolvePlaceholder (placeholder, props) before/after the system properties check."
+
+**Detection:**
+```bash
+grep -rn 'PropertiesFactoryBean\|util:properties' . --include='*.xml' --include='*.java' | grep -v test
+```
+
+**Rule:** Properties loaded via PropertiesFactoryBean bypass placeholder resolution. Adding `${DB_HOST}` to a PFB-loaded file returns the literal string `${DB_HOST}`. For PFB-backed beans, inject `Environment` bean and call `env.getProperty()` instead of relying on placeholder syntax.
+
+## Multi-Profile Spring Property Scan
+
+**Trigger:** Spring applications with profile-specific configuration files under multiple subdirectories (e.g., `profiles/cloud/`, `profiles/mysql/`, `config/`).
+
+**Rule:** Pass 1 env var scanning MUST run against ALL profile subdirectories independently, not just the primary `src/main/resources/`. Discover all profile directories first:
+```bash
+find . -name 'application-*.properties' -o -name 'application-*.yml' | sed 's|/[^/]*$||' | sort -u
+```
+Then run Pass 1 grep against each discovered directory.
+
+## AcceptHeaderLocaleResolver + LocaleChangeInterceptor Incompatibility
+
+**Trigger:** Spring MVC applications using both `AcceptHeaderLocaleResolver` and `LocaleChangeInterceptor`.
+
+**Problem:** `AcceptHeaderLocaleResolver` is read-only — it derives the locale from the HTTP `Accept-Language` header. `LocaleChangeInterceptor` attempts to call `setLocale()` which throws `UnsupportedOperationException`.
+
+**Detection:**
+```bash
+grep -rn 'AcceptHeaderLocaleResolver\|LocaleChangeInterceptor' . --include='*.java' --include='*.xml' | grep -v test
+```
+
+**Rule:** If both are present: either replace `AcceptHeaderLocaleResolver` with `SessionLocaleResolver` (which supports `setLocale()`), or remove `LocaleChangeInterceptor`. Document as a Phase 2 finding — do not fix in-scope unless the task touches locale configuration.
+
+## JobRunr / ShedLock Distributed Scheduling
+
+**Trigger:** `net.javacrumbs.shedlock` or `org.jobrunr` in dependencies.
+
+**Detection:**
+```bash
+grep -rn 'shedlock\|jobrunr\|@SchedulerLock\|JobRunrAutoConfiguration' . --include='*.java' --include='*.xml' --include='*.gradle' --include='pom.xml' | grep -v test
+```
+
+**Rule:** When ShedLock or JobRunr is detected with JDBC-backed coordination:
+1. Do NOT generate a separate CronJob manifest — the scheduler coordinates across pods via database locks
+2. Document the existing coordination mechanism in INFRASTRUCTURE_REQUIREMENTS.md
+3. Add NetworkPolicy egress for the scheduler's DB connection
+4. The HPA can safely scale — lock coordination prevents duplicate execution
+
+**ShedLock minimum lock duration:** Ensure `@SchedulerLock(lockAtLeastFor = "PT5M")` or similar prevents same-job re-entry during horizontal scaling events (pod startup overlap).
+
+## Non-Boot Spring WAR Env-Var Lowercasing
+
+**Trigger:** Traditional Spring WAR (no Spring Boot) where entrypoint scripts lowercase environment variable names before passing to the application.
+
+**Detection heuristic:**
+```bash
+# Check for Spring Boot absence
+grep -L 'spring-boot-starter-parent\|SpringApplication' pom.xml 2>/dev/null
+# Check for lowercasing in entrypoint
+grep -rn 'tr.*upper.*lower\|sed.*y/A-Z/a-z/' entrypoint*.sh startup*.sh docker-entrypoint*.sh 2>/dev/null
+```
+
+**Problem:** Lowercasing transforms `camelCase` Spring `@Value` property names into all-lowercase, breaking resolution (e.g., `autoCreateUser` becomes `autocreateuser`).
+
+**Workaround:** Mount a `.properties` file via Secret for properties requiring mixed-case names. See §camelCase @Value Env-Lowercasing Conflict for full details.
+
+## Surefire forkCount=0 for Host-Side Test Execution
+
+**Trigger:** Running `mvn test` on the host for the Pre-Docker Local Validation gate in environments without Docker or with limited process capabilities.
+
+**Problem:** Surefire's default `forkCount=1` spawns a new JVM process per test class, which may fail in restricted containers (e.g., ECS tasks) or when JAVA_HOME is inconsistent.
+
+**Proactive step:** Add `-DforkCount=0` when running tests on the host:
+```bash
+mvn test -DforkCount=0 -Dtest='!*IntegrationTest,!*Integration' -B -q
+```
+
+**Trade-off:** `forkCount=0` runs all tests in the Maven process JVM. Tests with static state leakage may interfere with each other. Use only for the host-side validation gate — production CI should use default forkCount.
+
+**Detection:** If `mvn test` fails with JVM fork errors (e.g., `Error occurred in starting fork`), retry with `-DforkCount=0`.
+
+## SMTP Egress from pom.xml Dependencies
+
+**Trigger:** Spring Boot or Java project with mail sending capability detected from Maven dependencies.
+
+**Detection:**
+```bash
+grep -E 'javax\.mail|jakarta\.mail|spring-boot-starter-mail|commons-email' pom.xml
+```
+
+**Rule:** When ANY of the above dependencies are present in pom.xml, include SMTP egress ports (25, 465, 587) in the NetworkPolicy — even if no `SMTP_HOST` env var is found in source code. Java mail libraries may use DB-stored or properties-file SMTP configuration that bypasses env var detection.
+
+```yaml
+# NetworkPolicy egress for SMTP
+- ports:
+  - protocol: TCP
+    port: 25
+  - protocol: TCP
+    port: 465
+  - protocol: TCP
+    port: 587
+```
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/microservice-decomposition-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/microservice-decomposition-patterns.md
@@ -1,0 +1,577 @@
+# Microservice Decomposition Patterns
+
+Comprehensive guidance for decomposing monoliths into microservices during Kubernetes containerisation. This reference bridges Phase 1 analysis (identifying decomposition candidates) and Phase 2 execution (generating per-service manifests).
+
+## Table of Contents
+
+1. [Named Service Inventory Template](#named-service-inventory-template)
+2. [Decomposition Complexity Rubric](#decomposition-complexity-rubric)
+3. [Data Ownership Matrix](#data-ownership-matrix)
+4. [First-Extraction Candidate Heuristics](#first-extraction-candidate-heuristics)
+5. [AuthService Is Always Last](#authservice-is-always-last)
+6. [Worker Specialisation Pattern](#worker-specialisation-pattern)
+7. [Mode-Toggle Flag Detection](#mode-toggle-flag-detection)
+8. [Shared-DB Remediation Ladder](#shared-db-remediation-ladder)
+9. [Event Bus Migration Patterns](#event-bus-migration-patterns)
+10. [Strangler Fig Pattern](#strangler-fig-pattern)
+11. [HTTP+Consumer Co-Deployment Anti-Pattern](#httpconsumer-co-deployment-anti-pattern)
+12. [Per-Service Docker Image Guidance](#per-service-docker-image-guidance)
+13. [Technology-Specific Decomposition Triggers](#technology-specific-decomposition-triggers)
+14. [HIPAA/Healthcare Boundary Decomposition](#hipaahealthcare-boundary-decomposition)
+15. [Phase 2 Execution Rules](#phase-2-execution-rules)
+16. [Output Templates](#output-templates)
+
+---
+
+## Named Service Inventory Template
+
+Phase 1 MUST produce this table (not a generic visual diagram). Every row represents a named service candidate identified from source analysis.
+
+**Mandatory columns:**
+
+| ServiceName | DomainResponsibility | SourcePaths | OwnedTables | InboundAPIs | OutboundEvents | ScalingDriver | ExtractionOrder | Complexity | BlockingDependencies | DataOwnership |
+|---|---|---|---|---|---|---|---|---|---|---|
+| NotificationService | Email/SMS/push dispatch | `app/notifications/`, `app/mail/` | `notifications`, `email_log` | POST /notify | notification.sent | Queue depth | 1 | Low | None | exclusive-write |
+| UploadService | File upload/download/presign | `app/storage/`, `app/uploads/` | `attachments` | POST /upload, GET /files/:id | file.uploaded | Request count | 2 | Low | S3 bucket | exclusive-write |
+| SearchService | Full-text search indexing | `app/search/` | None (ES index) | GET /search | index.updated | Query volume | 3 | Low | Elasticsearch cluster | read-only |
+| AuthService | Identity, login, JWT issuance | `app/auth/`, `app/users/` | `users`, `sessions`, `roles` | POST /login, GET /me | user.created | Login rate | LAST | High | All services adopt JWT | shared-write-BLOCKER |
+
+**Enumeration algorithm** (how to discover candidates):
+1. **Route-group analysis**: Group HTTP routes by URL prefix (`/api/uploads/*`, `/api/auth/*`, `/api/search/*`). Each group with ≥3 endpoints is a candidate.
+2. **Package/namespace scan**: Each top-level package/namespace with its own models = candidate.
+3. **Queue channel scan**: Each distinct queue name or topic = worker candidate.
+4. **Scheduled task scan**: Each cron entry = CronJob candidate (already in spec).
+5. **Mode-toggle scan**: Each env flag that gates behaviour = per-mode image candidate.
+
+**DataOwnership column values:**
+- `exclusive-write` — only this service writes; others may read → Low complexity
+- `read-only` — this service only reads from tables another service owns → Low complexity
+- `shared-write-BLOCKER` — multiple services write same tables → extraction blocked until remediated
+
+---
+
+## Decomposition Complexity Rubric
+
+Apply to EVERY row in the Named Service Inventory:
+
+### Low Complexity
+- No shared-DB FK constraints with other service candidates
+- Single external dependency already externalised (e.g., S3, SMTP, Elasticsearch)
+- Independent scaling axis clear (queue depth, request count, connection count)
+- Examples: NotificationService, FileStorageService, SearchService, CronJob extraction
+- **Action in Phase 2**: Generate separate Deployment + Service + NetworkPolicy manifests immediately
+
+### Medium Complexity
+- Shared DB pool but no cross-service WRITES (reads from other domains acceptable via views)
+- Requires package refactoring or config split (shared `config.py`, `application.yml`)
+- 1–2 inter-service API dependencies to introduce
+- Examples: CartService (reads ProductService tables), ShippingService, ReportingService
+- **Action in Phase 2**: Document in INFRASTRUCTURE_REQUIREMENTS.md §0 with extraction prerequisites. Generate separate Dockerfile but shared DB connection for now.
+
+### High Complexity
+- Distributed transactions required across service boundaries
+- Multiple cross-cutting FK constraints (e.g., `orders.user_id`, `sessions.user_id`, `payments.order_id`)
+- Shared mutable state (in-process plugin coupling, shared static registries)
+- Service mesh or API gateway prerequisite for traffic routing
+- Examples: AuthService, OrderService (ecommerce), ObservationService (EHR)
+- **Action in Phase 2**: Document extraction roadmap only. Do NOT generate separate manifests. Mark as "Decomposition Deferred" with blocking reasons.
+
+---
+
+## Data Ownership Matrix
+
+Phase 1 MUST produce this for projects with ≥3 tables and ≥2 service candidates:
+
+| Table/Collection | WrittenBy | ReadBy | FK Constraints | DecompositionBlocker |
+|---|---|---|---|---|
+| `users` | AuthService | ALL | `orders.user_id`, `posts.author_id` | YES — shared identity |
+| `notifications` | NotificationService | ReportingService | None | No |
+| `attachments` | UploadService | ContentService | `posts.attachment_id` | No — read-only FK |
+| `orders` | OrderService | ShippingService, ReportingService | `order_items.order_id` | YES — distributed tx |
+
+**Rules:**
+- Any table with multiple services in WrittenBy = CRITICAL blocker
+- Tables with only read-only FKs from other services = not blocked (use API or DB view)
+- Apply table-to-bounded-context mapping: group tables that share FK relationships into same service
+
+---
+
+## First-Extraction Candidate Heuristics
+
+These service types are consistently the lowest-risk, highest-value first extractions. Evaluate in this priority order:
+
+### Priority 1: StorageService / UploadService / FileService
+**Detection triggers:**
+- `AWS_S3_BUCKET`, `STORAGE_PATH`, `UPLOAD_DIR` env vars
+- S3 SDK imports (`boto3`, `aws-sdk`, `Aws\S3`)
+- Existing module boundary (`app/storage/`, `services/upload/`)
+
+**Why Low complexity:** No PostgreSQL/MySQL dependency for core operation; env vars exclusively scoped to storage; immediate IRSA security win (S3 IAM role scoped to this service only).
+
+### Priority 2: NotificationService
+**Detection triggers:**
+- `SMTP_HOST`, `MAILGUN_SECRET`, `SENDGRID_API_KEY` env vars
+- Inline `Mail::send()`, `send_mail()`, SMTP calls in controllers
+- Queue job names containing "notification", "email", "sms"
+
+**Why Low complexity:** Pure event consumer; SMTP credentials already isolated; zero shared-state dependencies. Extraction pattern: replace inline email dispatch with event emission → NotificationService is standalone consumer.
+
+### Priority 3: SearchService / ElasticsearchService
+**Detection triggers:**
+- `ES_HOSTS`, `ELASTICSEARCH_URL`, `SEARCH_INDEX` env vars
+- SQL `FULLTEXT` or `LIKE '%query%'` for product/content search
+- `post_save` signals or observer hooks firing synchronously to update index
+
+**Why Low complexity:** Read-only index consumer. **Prerequisite:** replace sync signals with async queue/event before extraction (sync index updates on the web request path = latency coupling).
+
+### Priority 4: CronJob Extraction (already in core spec)
+Scheduled tasks with independent logic → Kubernetes CronJob with separate image.
+
+**Rule:** These candidates ALWAYS go before AuthService. Never attempt auth extraction first.
+
+---
+
+## AuthService Is Always Last
+
+Auth/Identity is ALWAYS High complexity. Never a first-extraction candidate.
+
+**Why:**
+- Shared `users` table with FK references from nearly every other table
+- In-process session validation coupled to every request middleware
+- Password hashing, role checking, token issuance deeply embedded
+
+**Prerequisites for full extraction:**
+1. All other services adopt JWT validation (verify token signature, no DB call)
+2. UserProjection sync pattern — downstream services maintain read-only user cache
+3. Shared identity tables dropped from downstream service schemas
+4. JWKS endpoint exposed by AuthService for public key rotation
+
+**Immediate mitigations (apply during Phase 2 even without full extraction):**
+- LDAP timeout cap: set `LDAP_TIMEOUT=5s` to prevent cascading failures
+- Circuit breaker around SSO/OAuth providers
+- Session TTL enforcement to prevent unbounded session table growth
+
+---
+
+## Worker Specialisation Pattern
+
+**When:** A single queue worker handles jobs from multiple domains (notifications, exports, search indexing, file cleanup) via a single queue.
+
+**Detection:**
+```bash
+# Celery
+grep -rn 'app.task\|@shared_task' . --include='*.py' | grep -oP 'name=["\047]([^"]+)' | sort
+# Laravel
+grep -rn 'class.*implements ShouldQueue' . --include='*.php'
+# BullMQ/Node
+grep -rn 'queue.add\|Queue(' . --include='*.js' --include='*.ts'
+```
+
+**Decomposition pattern:**
+1. Identify distinct job domains (notification jobs, export jobs, indexing jobs)
+2. Assign each domain a dedicated queue channel:
+   - Laravel: `--queue=notifications`, `--queue=exports`
+   - Celery: `CELERY_QUEUES` with separate routing keys per domain
+   - BullMQ: Separate `Queue('notifications')`, `Queue('exports')`
+3. Each specialised worker → own Deployment with independent resource limits
+4. Each worker gets its own Docker image OR shared image with different `command:`
+
+**Kubernetes manifests (per worker):**
+```yaml
+# deployment-worker-notifications.yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: worker-notifications
+        command: ["celery", "-A", "app", "worker", "--queues=notifications", "--concurrency=2"]
+        resources:
+          limits: { memory: "256Mi", cpu: "200m" }
+```
+
+**This is LOW-complexity decomposition** — does not require DB schema split.
+
+---
+
+## Mode-Toggle Flag Detection
+
+**Detection triggers** — these env vars indicate runtime mode selection:
+- `CONSUMER_ONLY`, `DISABLE_SCHEDULER`, `WORKER_ONLY`, `APP_MODE`
+- `ENABLE_WEB=false`, `ENABLE_WORKER=true`, `RUN_MODE=consumer`
+
+**Rule:** Each mode-toggle flag MUST become its own Docker image with a fixed entry point. Mode-toggle env flags are decomposition indicators, NOT solutions.
+
+**Before (anti-pattern):**
+```yaml
+# Single Deployment with mode flags
+env:
+- name: APP_MODE
+  value: "worker"
+- name: DISABLE_SCHEDULER
+  value: "true"
+```
+
+**After (correct):**
+```dockerfile
+# Dockerfile.worker
+FROM app-base AS worker
+CMD ["python", "-m", "celery", "-A", "app", "worker"]
+
+# Dockerfile.scheduler
+FROM app-base AS scheduler
+CMD ["python", "-m", "celery", "-A", "app", "beat"]
+
+# Dockerfile.web
+FROM app-base AS web
+CMD ["gunicorn", "app:create_app()"]
+```
+
+**Shared modules** (config, models, storage) → shared library package:
+- Python: `pip install -e ./common/` or `COPY common/ && pip install ./common/`
+- Node.js: `COPY packages/shared/ && npm install ./packages/shared`
+- Go: Shared module in go.work or internal/ package
+- PHP: Composer path repository
+- Java: Shared Maven module
+
+---
+
+## Shared-DB Remediation Ladder
+
+When multiple service candidates share a single database, apply remediation steps in order (each step enables the next):
+
+| Step | Pattern | Effort | Enables |
+|------|---------|--------|---------|
+| 1 | **Schema-per-domain prefixes** — `auth_users`, `notify_templates`, `order_items` | Low | Clear ownership visibility |
+| 2 | **Read-only DB views per context** — `CREATE VIEW order_summary AS SELECT ...` | Low | Service reads via view, not raw table |
+| 3 | **Per-service DB roles with table-level GRANT** — `GRANT SELECT ON auth_users TO order_svc` | Low | Enforce ownership at DB level |
+| 4 | **Replace cross-service reads with API calls** — OrderService calls AuthService `/users/:id` | Medium | Removes direct DB coupling |
+| 5 | **Event-driven CQRS projections** — AuthService publishes `user.updated`, OrderService maintains local projection | Medium-High | Removes synchronous coupling |
+| 6 | **Database-per-service** — each service owns its own DB instance | High | Full independence |
+
+**Phase 2 action:** Document current step and target step in INFRASTRUCTURE_REQUIREMENTS.md §0. Do NOT attempt step 6 during initial containerisation — steps 1–3 are achievable during Phase 2.
+
+---
+
+## Event Bus Migration Patterns
+
+When decomposing, in-process events must become inter-service events:
+
+| Source Pattern | Target Pattern | Broker |
+|---|---|---|
+| Django signals (`post_save`) | Celery task or Kafka message | Redis/RabbitMQ/Kafka |
+| Laravel events (`Event::dispatch`) | Queue job with `ShouldQueue` | Redis/SQS |
+| Spring `ApplicationEventPublisher` | Spring Cloud Stream or Kafka | Kafka/RabbitMQ |
+| Node.js `EventEmitter` | BullMQ job or SNS message | Redis/SQS/SNS |
+| Go channel sends | NATS or Kafka publish | NATS/Kafka |
+
+**Key rule:** Synchronous in-process events on the request path (e.g., `post_save` updating search index) MUST become asynchronous BEFORE the service producing the event can be extracted. Otherwise, latency coupling defeats the purpose of decomposition.
+
+---
+
+## Strangler Fig Pattern
+
+Incremental extraction via Kubernetes Ingress path-based routing:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+  - host: app.example.com
+    http:
+      paths:
+      # Extracted services (specific paths first — longest match wins)
+      - path: /api/uploads(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service: { name: upload-service, port: { number: 8080 } }
+      - path: /api/search(/|$)(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service: { name: search-service, port: { number: 8080 } }
+      # Monolith catches everything else
+      - path: /(.*)
+        pathType: ImplementationSpecific
+        backend:
+          service: { name: monolith, port: { number: 8080 } }
+```
+
+**Rule:** Route extracted service paths BEFORE the monolith catch-all. Add paths incrementally as services are extracted.
+
+---
+
+## HTTP+Consumer Co-Deployment Anti-Pattern
+
+**Detection:** A single Deployment runs both an HTTP API server AND a queue consumer (RabbitMQ, Celery, Kafka, SQS).
+
+**Why this fails:**
+- HTTP API needs CPU-based HPA (request latency sensitive)
+- Queue consumer needs queue-depth-based HPA (KEDA) — CPU is near-zero while IO-waiting
+- CPU HPA on combined deployment = queue consumer incorrectly scales with HTTP traffic
+
+**Mandatory split:**
+```yaml
+# deployment-api.yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        command: ["gunicorn", "app:create_app()"]
+  # HPA: cpu targetAverageUtilization: 70%
+
+# deployment-consumer.yaml
+spec:
+  template:
+    spec:
+      containers:
+      - name: consumer
+        command: ["celery", "-A", "app", "worker"]
+  # HPA: KEDA RabbitMQ queue-depth scaler
+```
+
+**Consumer Deployment specifics:**
+- NetworkPolicy: deny-all ingress (no inbound traffic)
+- readinessProbe: MAY omit with MIGRATION comment (pull-based worker)
+- HPA: queue-depth via KEDA (`ScaledObject` targeting queue length)
+
+**Validation failure:** CPU-based HPA on a combined HTTP+consumer Deployment is a decomposition failure that must be flagged.
+
+---
+
+## Per-Service Docker Image Guidance
+
+Each extracted service gets its own Dockerfile:
+
+| Service Type | Base Image | Size Target | Key Differences |
+|---|---|---|---|
+| Web API | language-slim | <200MB | Includes HTTP framework, no queue deps |
+| Queue Worker | language-slim | <200MB | Excludes HTTP framework, includes queue client |
+| CronJob | language-slim | <150MB | Minimal — only job logic + DB client |
+| Search Indexer | language-slim | <150MB | ES client only, no web framework |
+
+**Shared library pattern** (see Mode-Toggle Flag Detection §Shared modules):
+```dockerfile
+# Multi-stage shared base
+FROM python:3.12-slim AS base
+COPY common/ /build/common/
+RUN pip install /build/common/
+
+FROM base AS web
+COPY web/ /app/
+CMD ["gunicorn", "..."]
+
+FROM base AS worker
+COPY worker/ /app/
+CMD ["celery", "..."]
+```
+
+---
+
+## Technology-Specific Decomposition Triggers
+
+### GraphQL (Apollo Server in package.json)
+**Trigger:** `@apollo/server` or `apollo-server` in dependencies
+**Pattern:** Apollo Federation v2 subgraph decomposition:
+- Each resolver group (users, products, orders) → separate subgraph service
+- Apollo Router as federated gateway
+- `@key` directive identifies entity ownership across subgraphs
+
+**Before:** Single monolithic GraphQL schema serving all types
+**After:** Per-domain subgraph services behind Apollo Router
+
+### Next.js (next in package.json)
+**Trigger:** `next` in dependencies + API routes in `pages/api/` or `app/api/`
+**Pattern:** API routes → named backend services; Next.js remains as BFF (Backend-for-Frontend)
+- `NEXT_PUBLIC_*` vars = build-time (baked into client bundle)
+- Non-prefixed vars = runtime server-side only
+- Each `pages/api/<domain>/` directory = potential service extraction
+
+### Ecommerce (opencart/magento/woocommerce in composer.json)
+**Trigger:** `opencart`, `magento`, `woocommerce` in composer dependencies or directory structure
+**Named service catalog:**
+1. CatalogService (products, categories, attributes)
+2. CartService (basket, pricing rules)
+3. OrderService (checkout, order lifecycle)
+4. PaymentService (gateway integration)
+5. ShippingService (rates, tracking)
+6. CustomerService (accounts, addresses)
+7. NotificationService (email, SMS)
+8. SearchService (product search, filters)
+9. MediaService (product images, thumbnails)
+10. AdminService (backoffice CRUD)
+11. ReportingService (analytics, exports)
+12. InventoryService (stock levels, reservations)
+
+### WebSocket (socket.io in package.json)
+**Trigger:** `socket.io` or `ws` in dependencies
+**Pattern:** Extract RealtimeGatewayService:
+- Separate Deployment scaled on connection count (not CPU)
+- Redis adapter for cross-pod pub/sub (`@socket.io/redis-adapter`)
+- Sticky sessions via Ingress annotation OR Redis-backed state
+- HPA metric: WebSocket connection count
+
+### Flask/Django Bounded Contexts
+**Trigger:** `Flask` or `Django` in requirements.txt
+**Pattern:**
+- Flask: Each Blueprint with its own `models.py` = bounded context candidate
+- Django: Each app (`INSTALLED_APPS`) with its own `models.py` = candidate
+- SESSION_DRIVER=redis as decomposition BLOCKER (must migrate to JWT first)
+- Per-service Redis namespace pattern: `REDIS_KEY_PREFIX=svc_name:`
+
+---
+
+## HIPAA/Healthcare Boundary Decomposition
+
+**Trigger:** `openmrs`, `openemr`, medical/clinical domain keywords in source
+
+**Primary splitting criterion:** HIPAA compliance boundary. Protected Health Information (PHI) data MUST be isolated from non-PHI services.
+
+**Named clinical domain catalog:**
+1. PatientService (demographics, PHI — HIPAA boundary)
+2. ObservationService (vitals, lab results — HIPAA boundary)
+3. OrderService (clinical orders, prescriptions — HIPAA boundary)
+4. EncounterService (visits, notes — HIPAA boundary)
+5. SchedulingService (appointments — partial PHI)
+6. NotificationService (non-PHI alerts, reminders)
+7. ReportingService (de-identified analytics)
+8. AdminService (users, roles, configuration)
+9. AuditService (access logs — HIPAA requirement)
+
+**Rules:**
+- Services 1–4 (HIPAA boundary) share a HIPAA-compliant DB with encryption at rest
+- Non-PHI services (6–8) MUST NOT have direct DB access to PHI tables
+- AuditService receives events from ALL services for HIPAA access logging
+- PHI services = HIGH complexity extraction (shared patient FK everywhere)
+- Non-PHI services (Notification, Reporting, Admin) = LOW complexity — extract first
+
+---
+
+## Phase 2 Execution Rules
+
+### Execution Scope Constraint
+
+**Execution scope ≠ Reporting scope.** The `decomposition_scope` parameter (SKILL.md Entry Criteria §5) controls what gets implemented:
+
+- **`minimal` (default):** Only the Minimal Execution Set — the primary Deployment and required supporting resources. The full Named Service Inventory is documented in roadmaps but NOT generated as manifests.
+- **`full`:** ALL Low and Medium complexity candidates get manifests (Deployment, Service, NetworkPolicy). High-complexity candidates remain documented only.
+
+See `references/minimal-execution-set.md` for the resource classification table and how `full` mode changes it.
+
+**In-scope for `minimal`:**
+- ONE primary Deployment (web/API — owns the primary HTTP endpoint)
+- ONE required background worker (only if app CANNOT function without it)
+- ONE required migration Job (only if primary Deployment cannot start without it)
+- Supporting resources: Namespace, ConfigMap, Secret, ServiceAccount, NetworkPolicy, Ingress
+
+**Additional in-scope for `full`:**
+- ALL Low-complexity service Deployments + Services + NetworkPolicies
+- ALL Medium-complexity service Deployments + Services + NetworkPolicies (shared DB connection)
+- CronJobs for in-scope services
+- Per-service HPAs
+
+**Always deferred (both modes):**
+- High-complexity candidates (documented only)
+- Multi-container sidecars, additional PVCs beyond primary need
+
+### Sub-Phase §2: Decomposition Assessment
+
+After Phase 1 produces the Named Service Inventory, Phase 2 MUST execute:
+
+1. **Ingest** — Read the Named Service Inventory from the Phase 1 report
+2. **Classify** — Apply the Complexity Rubric to each candidate (if not already rated)
+3. **Identify primary Deployment** — Apply selection criteria: owns primary HTTP endpoint, fewest hard external dependencies, lowest ExtractionOrder
+4. **Execute per decomposition_scope:**
+   - **`minimal`**: Generate Dockerfile and manifests for primary Deployment only + required migration Job + required background worker. All other candidates → roadmap.
+   - **`full`**: Generate Dockerfile and manifests for primary Deployment AND all Low/Medium candidates. Each gets Deployment + Service + NetworkPolicy. High → roadmap only.
+5. **Document ALL candidates in roadmap:**
+   - Low-complexity: INFRASTRUCTURE_REQUIREMENTS.md §0 as "Ready for extraction" (minimal) or "Extracted" (full)
+   - Medium-complexity: INFRASTRUCTURE_REQUIREMENTS.md §0 with extraction prerequisites (minimal) or "Extracted with shared DB" (full)
+   - High-complexity: INFRASTRUCTURE_REQUIREMENTS.md §0 with full blocking dependency list, marked "Decomposition Deferred"
+6. **If NO candidates are Low-complexity:**
+   - Document ALL candidates as "Decomposition Deferred" in TRANSFORMATION_SUMMARY.md
+   - §Microservice Decomposition Roadmap section must explain WHY and list pre-requisites
+
+### Decision: "Decomposition Deferred"
+
+A service extraction is deferred when:
+- Complexity is High AND no immediate mitigations available
+- Shared-DB remediation ladder is at step 0 (no schema separation exists)
+- Auth extraction attempted before other services adopt JWT
+
+Document as:
+```markdown
+## Decomposition Deferred: AuthService
+- **Complexity:** High
+- **Blocking Dependencies:** All services use direct DB session lookup; JWT not adopted
+- **Prerequisites:** (1) Implement JWT issuance, (2) All services validate JWT locally, (3) Remove direct users table access from OrderService, ShippingService
+- **Target Extraction Phase:** Post-containerisation sprint 2
+```
+
+---
+
+## Output Templates
+
+### INFRASTRUCTURE_REQUIREMENTS.md §0 — Target Microservice Architecture
+
+```markdown
+## §0 Target Microservice Architecture
+
+### Named Service Inventory
+
+| Service | Responsibility | Complexity | ExtractionOrder | Status |
+|---------|---------------|-----------|----------------|--------|
+| NotificationService | Email/SMS dispatch | Low | 1 | Extracted (separate Deployment) |
+| UploadService | File upload/presign | Low | 2 | Extracted (separate Deployment) |
+| SearchService | Full-text search | Low | 3 | Deferred (async prerequisite) |
+| AuthService | Identity/JWT | High | LAST | Deferred (JWT migration required) |
+
+### Top-3 First-Extraction Candidates
+1. **NotificationService** — pure event consumer, zero shared-state, SMTP isolated
+2. **UploadService** — clean S3 module boundary, IRSA security win
+3. **SearchService** — requires async signal decoupling first (Medium after that)
+
+### Primary Blocking Anti-Patterns
+- Shared `users` table with FK from 6 other tables → AuthService extraction blocked
+- Single DATABASE_URL across all workloads → Step 1 remediation (schema prefixes) needed
+- Synchronous Elasticsearch indexing on web request path → must async before SearchService extraction
+```
+
+### TRANSFORMATION_SUMMARY.md §Microservice Decomposition Roadmap
+
+```markdown
+## Microservice Decomposition Roadmap
+
+### Scope Comparison: Minimal vs Full
+
+| Service | Complexity | Minimal Scope Status | Full Scope Status | Effort (Full) | Prerequisites |
+|---------|-----------|---------------------|-------------------|--------------|---------------|
+| Primary (MonolithService) | N/A | ✅ Deployed | ✅ Deployed | — | None |
+| NotificationService | Low | 📋 Documented only | ✅ Extracted | S | None |
+| UploadService | Low | 📋 Documented only | ✅ Extracted | S | S3 bucket |
+| SearchService | Medium | 📋 Documented only | ✅ Extracted (shared DB) | M | Async signal decoupling |
+| AuthService | High | 📋 Documented only | 📋 Documented only | XL | JWT adoption across all services |
+
+**Minimal scope total**: ~5-8 manifests (primary Deployment + supporting resources)
+**Full scope total**: ~15-25 manifests (all Low/Medium candidates extracted)
+
+### Extraction Status
+| Service | Phase 2 Status | Manifests Generated | Notes |
+|---------|---------------|--------------------|----|
+| NotificationService | Extracted | deployment-notifications.yaml, service-notifications.yaml | Separate queue worker |
+| UploadService | Extracted | deployment-uploads.yaml, service-uploads.yaml | IRSA-scoped S3 access |
+| AuthService | Deferred | None | Requires JWT migration across all consumers |
+
+### Blocking Anti-Patterns Addressed
+- Replaced mode-toggle APP_MODE flag with per-workload Docker images
+- Split HTTP+Consumer co-deployment into api + worker Deployments
+
+### Remaining Extraction Prerequisites (post-containerisation)
+- Adopt JWT validation in OrderService, ShippingService (currently direct DB session lookup)
+- Implement event-driven user projection sync for downstream services
+- Migrate from shared DATABASE_URL to per-service connection strings
+```

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/minimal-execution-set.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/minimal-execution-set.md
@@ -1,0 +1,122 @@
+# Minimal Execution Set
+
+## Purpose
+
+Defines the boundary between **execution scope** (resources actually generated, built, and validated in Phase 2) and **reporting scope** (resources documented in INFRASTRUCTURE_REQUIREMENTS.md and TRANSFORMATION_SUMMARY.md as a roadmap). The goal is to ensure the transformation succeeds by focusing on the minimum set of resources required to make the primary application build and run.
+
+**Core principle:** Execution scope ≠ Reporting scope. The Phase 1 report and INFRASTRUCTURE_REQUIREMENTS.md §0 catalog ALL decomposition candidates. Phase 2 execution implements only what is required unless `decomposition_scope=full` is specified.
+
+## Decomposition Scope Parameter
+
+The `decomposition_scope` parameter (set in Entry Criteria §5) controls how much of the Named Service Inventory is implemented:
+
+| Value | Behaviour |
+|-------|-----------|
+| `minimal` (default) | Generate manifests for the primary Deployment + required supporting resources only. All other candidates are documented in roadmap. |
+| `full` | Generate manifests for ALL Low and Medium complexity candidates from the Named Service Inventory, in addition to the primary Deployment and required support resources. High-complexity candidates remain documented only. |
+
+When `decomposition_scope` is absent or unset, apply `minimal`.
+
+### How `full` Mode Changes the Resource Classification
+
+When `decomposition_scope=full`:
+- All **Low-complexity** candidates move from Deferred to **In-Scope** — generate Deployment, Service, NetworkPolicy, and (if needed) separate Dockerfile.
+- All **Medium-complexity** candidates move from Deferred to **In-Scope** — generate Deployment, Service, NetworkPolicy with shared DB connection.
+- **High-complexity** candidates remain Deferred (documented only).
+- CronJobs for Low/Medium services move to In-Scope.
+- Per-service HPAs move to In-Scope.
+
+The `full` mode still requires each generated manifest to pass all validation (docker build, kubeconform, structural assertions).
+
+## When to Apply
+
+During Phase 2 Sub-Phase §2 (Decomposition Assessment) and §15 (Manifest Generation).
+
+- When `decomposition_scope=minimal` (or absent): apply the Minimal Execution Set constraint — this document's classification table governs scope.
+- When `decomposition_scope=full`: the classification table below shows the default; Low/Medium candidates are promoted to In-Scope per the rules above.
+
+## Resource Classification Table (Minimal Mode)
+
+| Resource Type | In Minimal Execution Set? | Condition |
+|---|---|---|
+| Namespace | ✅ Always | Required for all other resources |
+| Primary Deployment (web/API) | ✅ Always | The main HTTP service — owns the primary ingress endpoint |
+| Primary Service (ClusterIP) | ✅ Always | Exposes the primary Deployment |
+| ConfigMap | ✅ Always | Required by Deployment env/envFrom |
+| Secret | ✅ Always | Required by Deployment env/envFrom |
+| ServiceAccount | ✅ Always (when IRSA) | Required for cloud credential injection |
+| Required Background Worker | ✅ Conditional | Only if the primary Deployment CANNOT function without it (e.g., Sidekiq for Rails Action Mailer, Celery for async-mandatory workflows) |
+| Required Migration Job | ✅ Conditional | Only if the primary Deployment CANNOT start without schema/data init (Flyway, Liquibase, EF Core, Alembic, Rails db:migrate) |
+| Ingress | ✅ Conditional | Only if access pattern = browser-facing web app |
+| Primary NetworkPolicy | ✅ Always | Ingress + egress for the primary Deployment |
+| Nginx/Reverse Proxy Deployment | ✅ Conditional | Only if user confirmed reverse proxy is required |
+| CronJobs | ❌ Deferred | Document schedule + command in roadmap |
+| HPA | ❌ Deferred | Document scaling strategy in roadmap |
+| Additional worker Deployments | ❌ Deferred | Document in §0 Microservice Architecture |
+| NetworkPolicies for deferred workloads | ❌ Deferred | Generated only when workload is generated |
+| PVCs (beyond primary) | ❌ Deferred | Document storage requirements only |
+| Multi-container sidecars | ❌ Deferred | Document pattern in roadmap |
+
+## Selection Criteria for Primary Deployment
+
+When multiple Deployments are candidates, select the **primary** using this priority:
+
+1. Owns the primary HTTP ingress endpoint (the URL users access).
+2. Has the fewest hard external dependencies (can start independently).
+3. Has the lowest ExtractionOrder in the Named Service Inventory.
+4. If tied: prefer the monolith/main-app over extracted services.
+
+## What "Deferred" Means
+
+Deferred resources are:
+- **Documented** in TRANSFORMATION_SUMMARY.md §Microservice Decomposition Roadmap.
+- **Described** in INFRASTRUCTURE_REQUIREMENTS.md §0 with prerequisites.
+- **NOT generated** as YAML manifests in `kubernetes/`.
+- **NOT validated** by docker build, kubeconform, or cluster tests.
+
+Manifest stubs for deferred resources MAY exist as comments or roadmap notes but are NOT the tested/validated output.
+
+## Exceptions: When to Include More (Minimal Mode)
+
+Include additional resources in the Minimal Execution Set ONLY when:
+1. The primary Deployment literally cannot start without them (hard dependency at startup).
+2. The user explicitly requested them in interactive mode.
+3. A background worker is mandatory for the app to process its first request.
+
+## Verification
+
+After Phase 2 manifest generation, count resources:
+
+```bash
+# Count generated manifest files
+ls kubernetes/*.yaml | wc -l
+
+# Verify resource types present
+for f in kubernetes/*.yaml; do
+  grep '^kind:' "$f"
+done | sort | uniq -c
+```
+
+**Expected resource kinds** for a typical minimal set:
+- Namespace: 1
+- Deployment: 1–2 (primary + optional required worker)
+- Service: 1–2
+- ConfigMap: 1
+- Secret: 1
+- NetworkPolicy: 1–2
+- Job: 0–1 (migration only if required)
+- Ingress: 0–1
+- ServiceAccount: 0–1
+
+**Red flag (minimal mode):** If >8 manifest files are generated for a single-service application, review whether deferred resources leaked into execution scope.
+
+**Full mode:** Expect more manifests proportional to the number of Low/Medium candidates in the Named Service Inventory. Each additional service adds Deployment + Service + NetworkPolicy (minimum 3 files).
+
+## Relationship to Phase 1 Report
+
+| Document | Scope | Content |
+|----------|-------|---------|
+| Phase 1 Readiness Report | Full catalog | ALL service candidates, ALL findings, ALL decomposition recommendations |
+| INFRASTRUCTURE_REQUIREMENTS.md §0 | Full catalog | ALL services with extraction prerequisites and blocking dependencies |
+| TRANSFORMATION_SUMMARY.md §Roadmap | Full catalog | Extraction status of ALL candidates (Extracted / Deferred / N/A) |
+| `kubernetes/` directory | **Execution scope** | Only resources within scope per `decomposition_scope` setting |

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/nodejs-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/nodejs-patterns.md
@@ -1,0 +1,1442 @@
+# Node.js Patterns Reference
+
+Node.js-specific containerisation gotchas for Phase 2 transformation. Applies when `package.json` is present.
+
+## Table of Contents
+
+1. [Port Parsing — parseInt NaN Guard](#port-parsing)
+2. [ioredis Pub/Sub Two-Connection Pattern](#ioredis-pubsub)
+3. [process.env Timing — Module-Level Reads](#processenv-timing)
+4. [multer memoryStorage Filename Trap](#multer-memorystorage)
+5. [require.main Guard for CLI/Library Dual-Use](#requiremain-guard)
+6. [Winston Transport Stacking](#winston-transport-stacking)
+7. [connect-redis Version-Aware Import](#connect-redis-version-aware)
+8. [ioredis Middleware Configuration](#ioredis-middleware-config)
+9. [process.env Enumeration](#processenv-enumeration)
+10. [Node.js Binary Absent Fallback](#nodejs-binary-absent-fallback)
+11. [Non-Root USER on node:18-alpine](#non-root-user-on-node18-alpine)
+12. [Jest Test Environment Variables](#jest-test-environment-variables)
+13. [Socket.io Graceful Shutdown](#socketio-graceful-shutdown)
+14. [Cluster Module Removal](#cluster-module-removal)
+15. [CronJob Connection Bootstrap](#cronjob-connection-bootstrap)
+16. [Optional Dependency Guard](#optional-dependency-guard)
+17. [Bull/BullMQ Graceful Shutdown](#bull-bullmq-graceful-shutdown)
+18. [Apollo Federation Subgraph Decomposition](#apollo-federation-subgraph-decomposition)
+19. [WebSocket Gateway Extraction](#websocket-gateway-extraction)
+20. [Next.js Route-to-Service Mapping](#nextjs-route-to-service-mapping)
+21. [NestJS WebSocket Scaling](#nestjs-websocket-scaling)
+22. [amqplib Reconnect Pattern](#amqplib-reconnect-pattern)
+23. [IRSA Cross-Task Dependency](#irsa-cross-task-dependency)
+24. [Test File Co-Scoping Rule](#test-file-co-scoping-rule)
+25. [RABBITMQ_ROUTING_KEY False-Positive Exemption](#rabbitmq_routing_key-false-positive-exemption)
+26. [JSDoc Cron Comment Hazard (Tier 1 Escalation)](#jsdoc-cron-comment-hazard)
+27. [Template Literal Tier 1 Escalation](#template-literal-tier-1-escalation)
+28. [connect-redis Absent-from-package.json Default](#connect-redis-absent-default)
+29. [CronJob Lazy-Require for Connection-Eager Modules](#cronjob-lazy-require)
+30. [SIGTERM Handler Standalone Worker Exception](#sigterm-handler-standalone-worker-exception)
+31. [Express/Koa Health Probe Ordering](#expresskoa-health-probe-ordering)
+
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify Node.js source has no syntax errors, dependencies resolve, and TypeScript compiles — all BEFORE `docker build`.
+
+### Commands
+```bash
+# 1. Syntax check entry point(s)
+node --check src/index.js  # or main field from package.json
+# Expected: exit 0 (silent success)
+
+# 2. Dependency install
+npm ci 2>&1  # or: npm install --prefer-offline
+# Expected: exit 0
+
+# 3. TypeScript compilation (if tsconfig.json present)
+[ -f tsconfig.json ] && npx tsc --noEmit 2>&1
+# Expected: exit 0
+
+# 4. Unit tests (infrastructure-excluded)
+npx jest --testPathIgnorePatterns='integration|e2e' --passWithNoTests 2>&1 || true
+# Exit 0 = PASS; infrastructure failures = CONDITIONAL PASS; import errors = FAIL
+```
+
+### Expected Output
+- Step 1: No output (exit 0 = syntax OK)
+- Step 2: Exit 0 with packages installed
+- Step 3: Exit 0 (no type errors) — only if TypeScript
+- Step 4: Exit 0 or infrastructure-only failures
+
+### CONDITIONAL PASS Triggers
+- `node` not installed and `mise install node` fails → CONDITIONAL PASS
+- Node.js version mismatch (engines.node in package.json) → CONDITIONAL PASS
+- `npm ci` fails due to lock file desync → fix lock file first (see §Lock File Desync Pre-Check)
+- Network timeout on npm registry (after 1 retry) → CONDITIONAL PASS
+
+### Toolchain Bootstrap
+```bash
+# Check Node.js availability
+command -v node && node --version
+# If absent or wrong version, try mise
+if [ -f .tool-versions ] || [ -f .mise.toml ] || [ -f .nvmrc ]; then
+  command -v mise && mise install node 2>/dev/null
+  export PATH=$HOME/.local/share/mise/shims:$PATH
+fi
+node --version && npm --version
+```
+
+### Validated Example Repositories
+- NOT YET VALIDATED AGAINST REAL REPO — commands inferred from Node.js documentation. Mark as validated when a Node.js project passes through the pipeline.
+
+
+## Port Parsing
+
+```javascript
+// BAD: string concatenation instead of addition
+const port = process.env.PORT || 3000;  // "8080" (string)
+
+// GOOD: always parseInt with NaN guard
+const port = parseInt(process.env.PORT, 10) || 3000;
+```
+
+Rule: Every `process.env.*` read used as a number must use `parseInt(value, 10)` with `|| default`.
+
+## ioredis Pub/Sub
+
+A Redis connection in subscribe mode cannot issue other commands:
+
+```javascript
+const Redis = require('ioredis');
+const subscriber = new Redis(process.env.REDIS_URL);
+const publisher = new Redis(process.env.REDIS_URL);
+
+subscriber.subscribe('channel');
+subscriber.on('message', (ch, msg) => { /* handle */ });
+publisher.publish('channel', JSON.stringify(data));
+```
+
+**Trap**: Single connection for both → `ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT`.
+
+## process.env Timing
+
+Module-level reads execute at `require()` time — before runtime setup:
+
+```javascript
+// BAD: reads env before dotenv.config
+const DB_HOST = process.env.DB_HOST;  // undefined
+
+// GOOD: lazy getter
+module.exports = {
+  get DB_HOST() { return process.env.DB_HOST || 'localhost'; }
+};
+```
+
+Rule: Never assign `process.env.*` to a module-level constant.
+
+## multer memoryStorage
+
+With `multer({ storage: multer.memoryStorage() })`, `req.file.filename` is **undefined**:
+
+```javascript
+// BAD:
+const filename = req.file.filename;  // undefined!
+// GOOD:
+const key = `uploads/${Date.now()}-${req.file.originalname}`;
+await s3.putObject({ Key: key, Body: req.file.buffer });
+```
+
+## require.main Guard
+
+```javascript
+if (require.main === module) {
+  runTask().then(() => process.exit(0)).catch((e) => { console.error(e); process.exit(1); });
+}
+module.exports = { runTask };
+```
+
+Without this guard, `require('./worker')` executes the task at import time.
+
+## Winston Transport Stacking
+
+`logger.add(transport)` appends — does NOT replace:
+
+```javascript
+// GOOD: configure once
+const logger = winston.createLogger({
+  transports: [new winston.transports.Console({ format: winston.format.json() })]
+});
+```
+
+Migration: Remove all file transports; ensure exactly one Console transport outputting stdout.
+
+## connect-redis Version-Aware Import
+
+**CRITICAL: The CJS import pattern differs between connect-redis v7 and v9+.**
+
+**v7 (CJS — uses `exports.default`):**
+```javascript
+const RedisStore = require('connect-redis').default;
+const store = new RedisStore({ client: redisClient });
+```
+
+**v7 (ESM):**
+```javascript
+import RedisStore from 'connect-redis';
+const store = new RedisStore({ client: redisClient });
+```
+
+**v9+ (CJS — uses named export):**
+```javascript
+const { RedisStore } = require('connect-redis');
+const store = new RedisStore({ client: redisClient });
+```
+
+**v9+ (ESM):**
+```javascript
+import { RedisStore } from 'connect-redis';
+const store = new RedisStore({ client: redisClient });
+```
+
+**Version detection:**
+```bash
+grep '"connect-redis"' package.json package-lock.json | grep -oP '"[~^]?\K[0-9]+'
+# First digit: 7 → use .default; 9 → use { RedisStore }
+```
+
+**v6 (LEGACY — factory function, do NOT use in new code):**
+```javascript
+const RedisStore = require('connect-redis')(session);
+```
+
+**Jest mock shape warning**: Mock shape MUST mirror real CJS export structure. A mock matching the wrong import shape masks production bugs — all tests pass on broken code. For v7: `jest.mock('connect-redis', () => ({ default: MockRedisStore }))`. For v9+: `jest.mock('connect-redis', () => ({ RedisStore: MockRedisStore }))`.
+
+**Source**: connect-redis v9.x uses destructuring import `const { RedisStore } = require('connect-redis')` whereas v7.x uses `require('connect-redis').default` (https://stackoverflow.com/questions/79784688/trying-to-use-connect-redis-but-getting-an-error).
+
+## ioredis Middleware Config
+
+```javascript
+const redis = new Redis({
+  host: process.env.REDIS_HOST,
+  enableOfflineQueue: false,
+  maxRetriesPerRequest: 0
+});
+```
+
+## process.env Enumeration
+
+When extracting env var names for ENV_VARIABLES.md, use digit-inclusive regex:
+
+```bash
+# Correct: includes vars like S3_BUCKET_V2, PORT_8080 — excludes node_modules/__tests__/kubernetes/
+grep -rhoP 'process\.env\.([A-Za-z][A-Za-z0-9_]+)' . --include='*.js' --include='*.ts' --exclude-dir=node_modules --exclude-dir=__tests__ --exclude-dir=kubernetes | sort -u
+
+# Also check destructured patterns:
+grep -rn 'const.*=.*process\.env' src/ | grep -oP '[A-Z][A-Z0-9_]+'
+```
+
+**Note:** Do NOT use `grep -h` with pipe-based node_modules exclusion — `-h` suppresses filenames, breaking downstream path-based filtering. Use `--exclude-dir=node_modules` instead.
+
+## Node.js Binary Absent Fallback
+
+When `node` is not installed in the migration environment:
+
+**Decision list (numbered — follow in order):**
+
+1. **Is `node` available?** → Run `node --check file.js` directly. Done.
+2. **Is `node` absent but needed only for syntax check?** → Use Tier 1 (Python brace-balance).
+3. **Does Tier 1 report MISMATCH on a JS/TS file?** → Unconditionally escalate to Tier 2. Do NOT attempt manual inspection or check for template literals — any JS/TS Tier 1 MISMATCH is a known false-positive risk. When Tier 1 MISMATCH + Tier 2 PASS, document as false positive and proceed.
+4. **Is runtime execution needed (tests, linting)?** → Use Tier 2 (download node).
+5. **Does Tier 2 node_modules/.bin fail with "Permission denied"?** → Use Tier 2b (invoke via node binary).
+
+**Tier 1 — Python brace-balance + grep assertions** (immediate substitute):
+```bash
+python3 -c "
+import re, sys
+code = open(sys.argv[1]).read()
+# Strip strings and comments to avoid false matches
+code = re.sub(r'//[^\n]*', '', code)
+code = re.sub(r'/\*.*?\*/', '', code, flags=re.DOTALL)
+code = re.sub(r'\x60[^\x60]*\x60', '', code, flags=re.DOTALL)  # template literals
+code = re.sub(r'\"(?:[^\"\\\\]|\\\\.)*\"', '', code, flags=re.DOTALL)
+code = re.sub(r\"'(?:[^'\\\\\\\\]|\\\\\\\\.)*'\", '', code, flags=re.DOTALL)
+for o,c,name in [('{','}','curly'),('(',')', 'paren'),('[',']','bracket')]:
+    if code.count(o) != code.count(c):
+        print(f'MISMATCH {name}: {code.count(o)} open vs {code.count(c)} close')
+        sys.exit(1)
+print('OK')
+" path/to/file.js
+```
+
+**Known false-positive triggers in Tier 1**: Template literals with embedded braces (`\`${obj.key}\``), regex containing braces (`/\d{3}/`), URL strings with encoded braces. If Tier 1 reports MISMATCH on a file with template literals or regex, escalate to Tier 2.
+
+**Tier 2 — Download node v18 to /tmp** (for tasks requiring runtime):
+```bash
+if ! which node >/dev/null 2>&1; then
+  curl -sSL https://nodejs.org/dist/v18.20.2/node-v18.20.2-linux-x64.tar.xz | tar -xJ -C /tmp/
+  export PATH="/tmp/node-v18.20.2-linux-x64/bin:$PATH"
+fi
+```
+
+**Tier 2b — Permission denied on node_modules/.bin symlinks**:
+
+If `node_modules/.bin/<tool>` (jest, mocha, eslint) returns "Permission denied", invoke via the downloaded or system node binary directly:
+```bash
+# Instead of: npx jest (or node_modules/.bin/jest)
+node node_modules/.bin/jest --passWithNoTests
+# Or with downloaded node:
+/tmp/node-v18.20.2-linux-x64/bin/node node_modules/.bin/jest --passWithNoTests
+```
+
+**Rule**: Apply Tier 1 proactively. Escalate to Tier 2 if runtime execution is required. Use Tier 2b when symlink permissions block direct execution.
+
+## Non-Root USER on node:18-alpine
+
+`node:18-alpine` provides a built-in `node` user at UID 1000. Do NOT create a new user:
+
+```dockerfile
+USER 1000:1000
+WORKDIR /app
+COPY --chown=1000:1000 . .
+```
+
+**Kubernetes manifest alignment**:
+```yaml
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+```
+
+## Jest Test Environment Variables
+
+When running Jest tests that depend on env vars:
+
+```bash
+# Set required env vars inline
+DB_HOST=localhost REDIS_URL=redis://localhost:6379 node node_modules/.bin/jest --passWithNoTests
+```
+
+**jest.config.js environment setup** (if project uses `setupFiles`):
+```javascript
+// jest.setup.js
+process.env.NODE_ENV = 'test';
+process.env.DB_HOST = process.env.DB_HOST || 'localhost';
+process.env.PORT = process.env.PORT || '3000';
+```
+
+**Rule**: Tests requiring specific env vars must have them provided at invocation. Do NOT modify source `.env` files. Use `--passWithNoTests` flag to avoid failure when no test files match in a subset run.
+
+**Coverage + memory**: For large codebases, add `--maxWorkers=2` to prevent OOM in constrained environments.
+
+## Socket.io Graceful Shutdown
+
+```javascript
+const server = http.createServer(app);
+const io = new Server(server);
+
+process.on('SIGTERM', () => {
+  // 1. Stop accepting new connections
+  io.close(() => {
+    // 2. Close HTTP server
+    server.close(() => {
+      // 3. Clean up other resources
+      process.exit(0);
+    });
+  });
+  // 4. Force exit after grace period
+  setTimeout(() => process.exit(1), 25000);
+});
+```
+
+**Rule**: Socket.io server MUST be closed BEFORE the HTTP server. Set `terminationGracePeriodSeconds: 30` in pod spec to allow connection draining.
+
+## Cluster Module Removal
+
+Node.js `cluster` module (for multi-process scaling) is REDUNDANT in Kubernetes — HPA handles scaling:
+
+```javascript
+// BEFORE (remove this):
+const cluster = require('cluster');
+if (cluster.isMaster) {
+  for (let i = 0; i < numCPUs; i++) cluster.fork();
+} else {
+  startServer();
+}
+
+// AFTER (single-process, Kubernetes scales pods):
+startServer();
+```
+
+**Detection**:
+```bash
+grep -rn 'require.*cluster\|cluster\.fork\|cluster\.isMaster\|cluster\.isPrimary' . --include='*.js' --include='*.ts'
+```
+
+**Migration**: Remove cluster logic entirely. Set `WEB_CONCURRENCY=1` or remove it. Let Kubernetes HPA scale pod count.
+
+## CronJob Connection Bootstrap
+
+CronJob containers that connect to databases/Redis must handle connection lifecycle:
+
+```javascript
+// GOOD: Connect at start, disconnect at end
+async function runJob() {
+  const db = await connectDB();
+  try {
+    await doWork(db);
+  } finally {
+    await db.close();  // MUST close — CronJob pods don't receive SIGTERM reliably
+  }
+}
+
+runJob().then(() => process.exit(0)).catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+```
+
+**Rule**: CronJob entry points MUST explicitly close connections and call `process.exit()`. Without explicit exit, Node.js event loop keeps process alive indefinitely (Job never completes).
+
+## Optional Dependency Guard
+
+When a dependency is used only in certain code paths (e.g., `sharp` for image processing):
+
+```javascript
+// GOOD: graceful fallback when optional dep missing
+let sharp;
+try {
+  sharp = require('sharp');
+} catch (e) {
+  console.warn('sharp not available, image processing disabled');
+}
+
+function processImage(buffer) {
+  if (!sharp) throw new Error('Image processing requires sharp');
+  return sharp(buffer).resize(200).toBuffer();
+}
+```
+
+**package.json**: Move to `optionalDependencies` if not needed for core functionality.
+
+## Bull/BullMQ Graceful Shutdown
+
+Bull/BullMQ workers must handle SIGTERM to complete in-progress jobs:
+```javascript
+const worker = new Worker('queue', processor);
+process.on('SIGTERM', async () => {
+  await worker.close();  // Waits for active job to finish
+  process.exit(0);
+});
+```
+
+**Rule**: Set `terminationGracePeriodSeconds` ≥ max expected job duration. Without `worker.close()`, active jobs are aborted mid-execution.
+
+## Apollo Federation Subgraph Decomposition
+
+**Trigger:** `@apollo/server` or `apollo-server` in `package.json` dependencies.
+
+**Pattern:** Apollo Federation v2 decomposes a monolithic GraphQL schema into domain-specific subgraph services behind an Apollo Router gateway.
+
+**Decomposition mapping:**
+1. Each resolver file/module → potential subgraph service
+2. `@key` directive identifies entity ownership across subgraphs
+3. Apollo Router replaces monolithic Apollo Server as gateway
+4. Each subgraph = separate Deployment + Service in Kubernetes
+
+**Kubernetes architecture:**
+- `deployment-apollo-router.yaml` — gateway, CPU-based HPA
+- `deployment-users-subgraph.yaml` — users domain
+- `deployment-orders-subgraph.yaml` — orders domain
+- Ingress routes all `/graphql` traffic to Apollo Router only
+
+**Detection:**
+```bash
+grep -r '@apollo/federation\|@apollo/subgraph\|buildSubgraphSchema' package.json src/
+```
+
+## WebSocket Gateway Extraction
+
+**Trigger:** `socket.io` or `ws` in `package.json` dependencies.
+
+**Pattern:** Extract WebSocket handling into a RealtimeGatewayService.
+
+**Why separate:**
+- WebSocket connections are long-lived vs HTTP (milliseconds)
+- Scaling driver = connection count, not CPU
+- Pod restart kills all connections — needs separate lifecycle
+
+**Redis adapter requirement** (cross-pod message delivery):
+```javascript
+const { createAdapter } = require('@socket.io/redis-adapter');
+const pubClient = createClient({ url: process.env.REDIS_URL });
+const subClient = pubClient.duplicate();
+io.adapter(createAdapter(pubClient, subClient));
+```
+
+**Socket.io `getRoomUsers()` async replacement:**
+```javascript
+// BEFORE (in-memory, single-pod):
+const users = io.sockets.adapter.rooms.get(roomId);
+// AFTER (Redis-backed, multi-pod):
+const sockets = await io.in(roomId).fetchSockets();
+const users = sockets.map(s => s.data.userId);
+```
+
+**HPA:** Scale on custom metric (WebSocket connection count), NOT CPU.
+
+## Next.js Route-to-Service Mapping
+
+**Trigger:** `next` in `package.json` + API routes in `pages/api/` or `app/api/`.
+
+**Decomposition pattern:**
+- `pages/api/<domain>/` or `app/api/<domain>/route.ts` → potential backend service
+- Next.js remains as BFF serving SSR pages
+- Backend services exposed via internal ClusterIP Service
+
+**Build-time vs runtime env vars:**
+- `NEXT_PUBLIC_*` → baked into client bundle at build time
+- Non-prefixed → server-side only, runtime injectable
+
+**Detection:**
+```bash
+find pages/api app/api -type f -name '*.ts' -o -name '*.js' 2>/dev/null | \
+  sed 's|/[^/]*$||' | sort -u | wc -l
+# >3 distinct API route directories = strong decomposition signal
+```
+
+## NestJS WebSocket Scaling
+
+**Trigger:** `@nestjs/websockets` or `@nestjs/platform-socket.io` in `package.json` dependencies.
+
+**Problem:** NestJS WebSocket gateways maintain a `connectedClients` map that is pod-local. With HPA scaling, clients connected to pod A cannot receive events broadcast from pod B.
+
+**Solution — Redis adapter:**
+```typescript
+// main.ts or app.module.ts
+import { IoAdapter } from '@nestjs/platform-socket.io';
+import { createAdapter } from '@socket.io/redis-adapter';
+import { createClient } from 'redis';
+
+export class RedisIoAdapter extends IoAdapter {
+  createIOServer(port: number, options?: any) {
+    const server = super.createIOServer(port, options);
+    const pubClient = createClient({ url: process.env.REDIS_URL });
+    const subClient = pubClient.duplicate();
+    server.adapter(createAdapter(pubClient, subClient));
+    return server;
+  }
+}
+// In bootstrap: app.useWebSocketAdapter(new RedisIoAdapter(app));
+```
+
+**Detection:**
+```bash
+grep -rn 'WebSocketGateway\|@SubscribeMessage\|connectedClients' . --include='*.ts'
+```
+
+**NetworkPolicy:** WebSocket gateway Deployment needs Redis egress (TCP 6379) AND WebSocket-specific Ingress annotations (`proxy-read-timeout: 3600`, `proxy-send-timeout: 3600`).
+
+**Rule:** Any NestJS WebSocket gateway with HPA replicas > 1 MUST use Redis adapter. Pod-local `connectedClients` is a horizontal-scaling blocker.
+
+## amqplib Reconnect Pattern
+
+**Trigger:** `amqplib` in `package.json` dependencies (RabbitMQ client).
+
+**Problem:** `amqplib` does NOT auto-reconnect on connection loss. Without explicit reconnect logic, pod network blips cause permanent consumer death — the pod stays alive but processes no messages.
+
+**Solution:**
+```javascript
+const amqp = require('amqplib');
+
+let connection = null;
+let channel = null;
+
+async function connect() {
+  connection = await amqp.connect(process.env.RABBITMQ_URL);
+  connection.on('error', (err) => {
+    console.error('RabbitMQ connection error:', err.message);
+    setTimeout(connect, 5000);
+  });
+  connection.on('close', () => {
+    console.warn('RabbitMQ connection closed, reconnecting...');
+    setTimeout(connect, 5000);
+  });
+  channel = await connection.createChannel();
+  await channel.assertQueue(process.env.QUEUE_NAME, { durable: true });
+  channel.consume(process.env.QUEUE_NAME, handleMessage);
+}
+
+connect().catch(console.error);
+```
+
+**Detection:**
+```bash
+grep -rn 'amqplib\|amqp\.connect' . --include='*.js' --include='*.ts' | grep -v node_modules
+```
+
+**livenessProbe consideration:** Without reconnect logic, use exec livenessProbe that verifies the channel is open (e.g., check a health flag file written by the `connection.on('close')` handler).
+
+**Rule:** All amqplib consumers MUST implement reconnect-on-error. Default amqplib behaviour is to silently stop consuming on any connection interruption.
+
+## IRSA Cross-Task Dependency
+
+**Trigger:** Node.js projects using AWS SDK where Criterion 2 (config externalisation) applies `requireEnv()` or similar mandatory-env patterns to AWS credential variables.
+
+**Problem:** Criterion 6 IRSA guard needs AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY to be empty strings in IRSA mode. But `requireEnv()` (or any validation that treats empty string as falsy) crashes when the value is `""`.
+
+**WRONG — requireEnv rejects empty string:**
+```javascript
+// config.js
+const AWS_ACCESS_KEY_ID = requireEnv('AWS_ACCESS_KEY_ID'); // throws on ""
+```
+
+**CORRECT — use fallback to empty string:**
+```javascript
+// config.js
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || '';
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || '';
+
+// s3-client.js
+const clientConfig = { region: process.env.AWS_REGION || 'us-east-1' };
+if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY) {
+  clientConfig.credentials = { accessKeyId: AWS_ACCESS_KEY_ID, secretAccessKey: AWS_SECRET_ACCESS_KEY };
+}
+const s3 = new S3Client(clientConfig);
+```
+
+**Rule:** AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY MUST use `process.env.X || ""` pattern. NEVER use requireEnv(), assertEnv(), or any validation that rejects empty strings for these two specific variables.
+
+**Jest setup companion:** After applying IRSA pattern, update jest.setup.js in the SAME task:
+```javascript
+// jest.setup.js
+process.env.AWS_ACCESS_KEY_ID = 'test-key';
+process.env.AWS_SECRET_ACCESS_KEY = 'test-secret';
+process.env.AWS_REGION = 'us-east-1';
+```
+
+## Test File Co-Scoping Rule
+
+**Trigger:** ANY source file modification that removes functions, renames exports, or applies requireEnv().
+
+**Problem:** Removing a function from source or applying requireEnv() leaves dead references in test files (describe blocks, mocks, imports). These are discovered only in a later dedicated test task, causing downstream failures and expensive rework.
+
+**Rule:** When modifying a source file, scan the ENTIRE corresponding test file for ALL references to the modified construct in the SAME task scope:
+```bash
+# After modifying src/config.js:
+grep -n 'functionName\|removedExport\|oldPattern' tests/config.test.js __tests__/config.test.js
+```
+
+**Checklist for each source modification:**
+1. Removed function → remove/rewrite ALL test describe blocks, mocks, and imports referencing it.
+2. Renamed export → update ALL test imports and mock references.
+3. Applied requireEnv() → add the env var to jest.setup.js with a non-empty test value.
+4. Changed function signature → update ALL test call sites.
+
+**Detection — find orphaned test references after migration:**
+```bash
+# List all exported names from source
+grep -oP 'module\.exports\.\K\w+|exports\.\K\w+' src/*.js | sort -u > /tmp/exports.txt
+# List all referenced names in tests
+grep -oP "require\('.*?'\)\.\K\w+" tests/*.js __tests__/*.js | sort -u > /tmp/test_refs.txt
+# Find test refs not in exports
+comm -23 /tmp/test_refs.txt /tmp/exports.txt
+```
+
+## RABBITMQ_ROUTING_KEY False-Positive Exemption
+
+**Problem:** Credential scan (Criterion 6) flags variables ending in `_KEY` as secrets. `RABBITMQ_ROUTING_KEY` (and similar AMQP routing configuration) is NOT a credential — it's a message routing label.
+
+**Rule:** Variables ending in `_ROUTING_KEY` are ConfigMap values, not Secrets:
+- `RABBITMQ_ROUTING_KEY` → ConfigMap
+- `AMQP_ROUTING_KEY` → ConfigMap  
+- `EVENT_ROUTING_KEY` → ConfigMap
+
+**Detection of false positives:**
+```bash
+# Check if any routing key was incorrectly placed in Secret
+grep -i 'routing.key' kubernetes/secret.yaml && echo "FALSE POSITIVE: routing key in Secret"
+```
+
+**Rule applies to the general pattern**: Any env var whose name ends with `_ROUTING_KEY`, `_QUEUE_NAME`, `_EXCHANGE_NAME`, or `_TOPIC_NAME` is a non-credential ConfigMap value regardless of containing the substring "KEY".
+
+
+## npm ci --omit=dev Dockerfile Pattern
+
+**Trigger:** Node.js Dockerfile using `npm install --production` or `npm install --only=production`.
+
+**Problem:** The `--production` flag is deprecated in npm 8+ (ships with node:18+). Using it produces a deprecation warning and may behave unexpectedly in future npm versions.
+
+**Before (deprecated):**
+```dockerfile
+RUN npm ci --production
+```
+
+**After (correct):**
+```dockerfile
+RUN npm ci --omit=dev
+```
+
+**Rule:** All Node.js Dockerfiles MUST use `npm ci --omit=dev` instead of `npm install --production` or `npm ci --production`. The `--omit=dev` flag explicitly excludes devDependencies from the install.
+
+**Source:** https://github.com/npm/cli/issues/8025 — "I suggest using: --omit=dev instead of the deprecated flag --production"
+
+## require.main Guard Placement
+
+**Trigger:** Node.js module that both exports functions AND has a standalone execution path (CLI entry, CronJob worker).
+
+**Rule:** Place `require.main === module` guard AFTER `module.exports` — not before. Otherwise, imports of the module trigger the standalone execution path.
+
+**Before (incorrect — guard blocks exports):**
+```javascript
+if (require.main === module) {
+  runTask().then(() => process.exit(0));
+}
+module.exports = { runTask };  // Never reached when required!
+```
+
+**After (correct — exports available, guard at bottom):**
+```javascript
+async function runTask() { /* ... */ }
+
+module.exports = { runTask };
+
+if (require.main === module) {
+  runTask().then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); });
+}
+```
+
+## node-cron Multi-Schedule CronJob Generation
+
+**Trigger:** Application using `node-cron` or `cron` package with multiple `cron.schedule()` calls at different intervals.
+
+**Rule:** Generate ONE CronJob manifest per distinct schedule expression. A single Node.js CronJob manifest that runs all tasks defeats Kubernetes schedule granularity.
+
+**Detection:**
+```bash
+grep -rn 'cron\.schedule\|new CronJob\|new Cron' src/ --include='*.js' --include='*.ts' | grep -oP "'[0-9*/,\s]+'|\"[0-9*/,\s]+\"" | sort -u
+```
+
+**Pattern:** If the grep produces >1 unique schedule expression:
+- Create separate CronJob manifests per schedule: `cronjob-<task-name>.yaml`
+- Each CronJob uses a command flag or env var to select its task: `node worker.js --task=cleanup`
+- Apply `app.kubernetes.io/role: cronjob` label to all CronJob pod templates
+
+## node-cron CronJob One-Shot Exit Pattern
+
+**Trigger:** Node.js CronJob containers using `node-cron` or `cron` package that register a scheduled callback.
+
+**Problem:** `node-cron` keeps the Node.js event loop alive indefinitely after the scheduled callback fires — the Job never completes, eventually hitting `activeDeadlineSeconds` and being force-killed.
+
+**WRONG — event loop stays alive:**
+```javascript
+const cron = require('node-cron');
+cron.schedule('* * * * *', () => {
+  doWork();
+  // node-cron keeps process alive — Job never terminates!
+});
+```
+
+**CORRECT — one-shot execution with explicit exit:**
+```javascript
+async function main() {
+  await doWork();
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });
+```
+
+**Rule:** In Kubernetes CronJob containers, do NOT use `node-cron`/`cron` scheduling. The Kubernetes CronJob `schedule:` field handles timing. The container entry point MUST execute the task once and call `process.exit(0)`. The in-process scheduler pattern is for long-running Deployments only.
+
+**Detection:**
+```bash
+grep -rn 'cron\.schedule\|new CronJob\|new Cron' . --include='*.js' --include='*.ts' | grep -v node_modules
+```
+
+## Next.js Standalone Output Scope
+
+**Trigger:** Next.js project using `output: 'standalone'` in `next.config.js`.
+
+**Problem:** `next build` with standalone output copies only the files needed for production serving into `.next/standalone/`. Scripts in `scripts/`, custom `lib/` utilities not imported by pages/API routes, and dev tools are EXCLUDED from the standalone output.
+
+**Rule:** Audit the standalone output before finalising the Dockerfile:
+```bash
+# After build, check what's included
+ls .next/standalone/
+# Compare with expected runtime dependencies
+```
+
+**Dockerfile pattern for Next.js standalone:**
+```dockerfile
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_MANUAL_SIG_HANDLE=1
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+USER 1000
+EXPOSE 3000
+CMD ["node", "server.js"]
+```
+
+**NEXT_MANUAL_SIG_HANDLE=1**: Required as Dockerfile ENV for graceful shutdown in Kubernetes. Without it, Next.js does not handle SIGTERM, causing abrupt termination during rolling updates.
+
+## NEXT_PUBLIC_* Build-Time Exclusion
+
+**Trigger:** Next.js project with `NEXT_PUBLIC_*` environment variables.
+
+**Problem:** `NEXT_PUBLIC_*` variables are baked into the JavaScript bundle at BUILD time (inlined by webpack). They are NOT read at runtime from `process.env`. Placing them in ConfigMap has no runtime effect.
+
+**Rule:**
+- `NEXT_PUBLIC_*` vars MUST be available as build args in the Dockerfile (ARG/ENV before `npm run build`)
+- Do NOT include `NEXT_PUBLIC_*` vars in the Kubernetes ConfigMap — they have no runtime effect
+- Document in ENV_VARIABLES.md with annotation: "Build-time only — baked into client bundle"
+
+**Dockerfile pattern:**
+```dockerfile
+ARG NEXT_PUBLIC_API_URL=https://api.example.com
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+RUN npm run build
+```
+
+## pg.Pool Connection Limit ConfigMap
+
+**Trigger:** Node.js project using `pg` (node-postgres) with `new Pool()`.
+
+**Rule:** Externalise `max` (pool size) to a ConfigMap variable with replica-aware formula:
+
+```javascript
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: parseInt(process.env.DB_POOL_MAX, 10) || 10,
+});
+```
+
+**ConfigMap entry:**
+```yaml
+data:
+  DB_POOL_MAX: "10"  # Formula: max_connections / expected_replicas (e.g., 100/10=10)
+```
+
+**ENV_VARIABLES.md entry:** `DB_POOL_MAX` — Maximum connections per pool instance. Production formula: `max_connections / replica_count`. K8s Scope: ConfigMap.
+
+## BullMQ Graceful Shutdown
+
+**Trigger:** Node.js project using BullMQ (`@bull-board`, `bullmq`, `bull`).
+
+**Rule:** BullMQ workers MUST close gracefully on SIGTERM to avoid lost jobs:
+
+```javascript
+const { Worker } = require('bullmq');
+const worker = new Worker('queue', processor, { connection: redisOpts });
+
+async function shutdown() {
+  await worker.close();       // Finishes current job, stops polling
+  await worker.connection.ping(); // Verify connection still alive (bootstrap check)
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+```
+
+**Multiple workers pattern:**
+```javascript
+const workers = [worker1, worker2, worker3];
+process.on('SIGTERM', async () => {
+  await Promise.all(workers.map(w => w.close()));
+  process.exit(0);
+});
+```
+
+**Connection bootstrap verification:** After creating the BullMQ connection, verify it's alive before starting the worker:
+```javascript
+const connection = new IORedis(process.env.REDIS_URL);
+await connection.ping(); // Throws if Redis unreachable — fail fast
+const worker = new Worker('queue', processor, { connection });
+```
+
+## ws vs socket.io — WebSocket Scaling Differences
+
+**Trigger:** `ws` or `socket.io` in `package.json` dependencies with HPA replicas > 1.
+
+**Problem:** `ws` (raw WebSocket) and `socket.io` handle horizontal scaling differently:
+
+| Library | Multi-Pod Support | Required Adapter |
+|---------|------------------|-----------------|
+| `socket.io` | Built-in adapter mechanism | `@socket.io/redis-adapter` — broadcasts to all pods |
+| `ws` (raw) | No built-in multi-pod | Sticky sessions (nginx `ip_hash`) OR external pub/sub |
+
+**socket.io with Redis adapter (preferred):**
+```javascript
+const { createAdapter } = require('@socket.io/redis-adapter');
+io.adapter(createAdapter(pubClient, subClient));
+```
+
+**ws with sticky sessions** (when Redis adapter unavailable):
+```yaml
+# Ingress annotation for sticky sessions
+nginx.ingress.kubernetes.io/affinity: "cookie"
+nginx.ingress.kubernetes.io/session-cookie-name: "ws-route"
+nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+```
+
+**Rule:** For `socket.io` projects, always add Redis adapter when HPA > 1. For `ws` projects, document sticky-session requirement in INFRASTRUCTURE_REQUIREMENTS.md and add Ingress annotations.
+
+**Detection:**
+```bash
+grep -rn '"ws"\|"socket.io"' package.json | grep -v devDependencies
+```
+
+## SIGTERM Handler Ownership Rule
+
+**Trigger:** Node.js projects with multiple entry points or shared modules that register `process.on('SIGTERM', ...)`.
+
+**Problem:** When a shared module registers `process.on('SIGTERM', handler)`, AND the main entry point also registers its own SIGTERM handler, behaviour is unpredictable — Node.js calls ALL registered handlers but only the last-registered `process.exit()` determines the exit code. Worse, if the shared module calls `process.exit(0)` before the entry point's graceful shutdown completes, in-flight requests are dropped.
+
+**Rule:** Only the application entry point (the file that starts the HTTP server or worker) registers `process.on('SIGTERM', ...)`. Shared modules expose `shutdown()` methods that the entry point calls within its own SIGTERM handler.
+
+**WRONG — shared module registers SIGTERM:**
+```javascript
+// lib/cache.js
+process.on('SIGTERM', () => { cache.disconnect(); process.exit(0); }); // BUG
+```
+
+**CORRECT — entry point owns SIGTERM, calls module shutdown:**
+```javascript
+// lib/cache.js
+module.exports.shutdown = () => cache.disconnect();
+
+// server.js (entry point)
+const cache = require('./lib/cache');
+process.on('SIGTERM', async () => {
+  server.close();
+  await cache.shutdown();
+  process.exit(0);
+});
+```
+
+**Detection:**
+```bash
+grep -rn "process\.on.*SIGTERM\|process\.on.*SIGINT" . --include='*.js' --include='*.ts' | grep -v node_modules | grep -v test
+# Multiple matches in different files = ownership violation
+```
+
+**Rule:** If grep returns SIGTERM handlers in more than one non-test source file, consolidate to the entry point only.
+
+## JSDoc Cron Comment Hazard (Tier 1 Escalation)
+
+**Trigger:** Tier 1 brace-balance check reports MISMATCH on files containing JSDoc blocks with cron expressions.
+
+**Problem:** JSDoc comments containing `*/step` cron syntax (e.g., `* */5 * * *`) prematurely close the JSDoc comment block. The `*/` inside the cron expression is interpreted as the comment terminator, leaving subsequent code syntactically broken from the parser's perspective. The Tier 1 Python brace-balance checker sees unbalanced braces in the resulting malformed code.
+
+**Detection:**
+```bash
+grep -n '\*/[0-9]' path/to/file.js | grep -c '^\s*\*'
+# If matches found inside JSDoc, this is a known Tier 1 false positive
+```
+
+**Rule:** When Tier 1 reports MISMATCH and the file contains JSDoc blocks with `*/N` cron expressions, escalate directly to Tier 2 without per-line analysis. This is a known limitation of comment stripping in the Tier 1 checker.
+
+## Template Literal Tier 1 Escalation
+
+**Trigger:** Tier 1 brace-balance check reports MISMATCH on files containing template literals with `${expression}` syntax.
+
+**Problem:** The Tier 1 Python checker's template-literal stripping regex (`\x60[^\x60]*\x60`) fails on nested template literals, tagged templates, or template literals spanning multiple lines with embedded expressions containing braces. The remaining `${...}` content produces false brace-count mismatches.
+
+**Rule:** When Tier 1 reports MISMATCH and the file contains template literals (backtick strings with `${}`), escalate directly to Tier 2. Do NOT attempt manual brace counting or per-line inspection — template literals with complex expressions are beyond Tier 1's capability.
+
+**Detection of template literals:**
+```bash
+grep -c '`.*\${' path/to/file.js
+# Any count > 0 = template literals present → Tier 1 false-positive likely
+```
+
+## connect-redis Absent-from-package.json Default
+
+**Trigger:** Session externalisation (Sub-Phase §4) requires `connect-redis`, but it is NOT listed in `package.json` dependencies.
+
+**Problem:** When `connect-redis` is absent from both `package.json` and `package-lock.json`, the worker cannot determine which version to use. Installing without a pinned version may pull v9+ (latest), but the project's existing `express-session` setup may expect v7 patterns.
+
+**Rule:** When `connect-redis` is absent from `package.json`:
+1. Check `express-session` version: `grep '"express-session"' package.json`
+2. Default to v7 import pattern (`.default`) — it has broader compatibility with older express-session setups
+3. Add `"connect-redis": "^7.1.0"` to dependencies
+4. Document the version choice in TRANSFORMATION_SUMMARY.md
+
+## CronJob Lazy-Require for Connection-Eager Modules
+
+**Trigger:** CronJob entry points that import shared scheduler/utility modules which transitively require connection-eager libraries (Bull, BullMQ, ioredis, mongoose, pg).
+
+**Problem:** Top-level `require()` of shared modules creates database/Redis connections at import time — even if the CronJob only needs a small subset of functionality. This wastes connections in short-lived CronJob pods and may cause connection timeouts if backing services are slow to respond.
+
+**WRONG — top-level require creates connections immediately:**
+```javascript
+const scheduler = require('../lib/scheduler'); // internally does: new Redis(), new Pool()
+async function main() {
+  await scheduler.runCleanup(); // only needs one function
+  process.exit(0);
+}
+```
+
+**CORRECT — lazy require inside the function:**
+```javascript
+async function main() {
+  const { runCleanup } = require('../lib/scheduler');
+  await runCleanup();
+  process.exit(0);
+}
+main().catch(e => { console.error(e); process.exit(1); });
+```
+
+**Detection:**
+```bash
+# Find CronJob entry points (files with process.exit pattern)
+grep -rln 'process\.exit(0)' src/ --include='*.js' | while read f; do
+  # Check if they import connection-eager modules at top level
+  head -20 "$f" | grep -q 'require.*redis\|require.*mongoose\|require.*bull\|require.*pg' && echo "EAGER: $f"
+done
+```
+
+**Rule:** CronJob entry points should lazy-require connection-eager modules inside the main function body, not at module top-level.
+
+## SIGTERM Handler Standalone Worker Exception
+
+**Trigger:** Standalone worker pods (Deployments running background job processors like Bull/BullMQ workers, queue consumers) that are NOT shared modules.
+
+**Problem:** The SIGTERM Handler Ownership Rule (§25 above) states that only the entry point should register SIGTERM. However, standalone worker Deployment entry points ARE their own entry point — they legitimately register SIGTERM handlers for graceful job completion.
+
+**Rule:** The SIGTERM ownership rule applies to SHARED MODULES (libraries imported by multiple entry points). Standalone worker entry points (files that ARE the container's CMD) are exempt — they own their process lifecycle and MUST register SIGTERM/SIGINT for graceful shutdown. Cross-reference: SKILL.md §9 CronJob framework exception list — worker Deployments with Bull/BullMQ MUST have SIGTERM handler for `worker.close()`.
+
+**Detection (is this file a standalone entry point?):**
+```bash
+# Check if the file is referenced as CMD in Dockerfile or in a Deployment manifest
+grep -rn "$(basename file.js)" Dockerfile kubernetes/*.yaml
+# If referenced as container command → standalone entry point → SIGTERM is correct
+```
+
+## Express/Koa Health Probe Ordering
+
+**Problem:** In Express/Koa applications, middleware registered with `app.use()` applies to ALL subsequent routes. Health/readiness probe endpoints registered AFTER global auth middleware receive 401/403 from K8s liveness/readiness checks, blocking pod readiness.
+
+**Rule:** Health probe routes MUST be registered BEFORE any global auth middleware.
+
+**Express — CORRECT ordering:**
+```javascript
+const app = express();
+
+// 1. Register health probes FIRST (no auth required)
+app.get('/healthz', (req, res) => res.status(200).json({ status: 'ok' }));
+app.get('/readyz', (req, res) => res.status(200).json({ status: 'ok' }));
+
+// 2. THEN apply auth middleware
+app.use(passport.authenticate('jwt', { session: false }));
+
+// 3. Register protected routes
+app.use('/api', apiRouter);
+```
+
+**Express — WRONG (probes receive 401):**
+```javascript
+const app = express();
+app.use(passport.authenticate('jwt', { session: false })); // Auth first
+app.get('/healthz', (req, res) => res.status(200).json({ status: 'ok' })); // Gets 401!
+```
+
+**Koa:**
+```javascript
+const app = new Koa();
+// Health route BEFORE auth middleware
+router.get('/healthz', (ctx) => { ctx.body = { status: 'ok' }; });
+app.use(router.routes());
+app.use(authMiddleware);
+app.use(protectedRouter.routes());
+```
+
+**Detection:**
+```bash
+# Find where health routes are registered relative to auth middleware
+grep -n 'app\.use\|app\.get.*health\|app\.get.*ready\|passport\|authenticate' src/ --include='*.js' --include='*.ts' -r | sort -t: -k2 -n
+# If auth middleware line number < health route line number → issue
+```
+
+**Rule:** After migration, verify probe path returns HTTP 2xx without credentials: `curl -s -o /dev/null -w '%{http_code}' http://localhost:PORT/healthz` — expected: 200.
+
+## Config Module Audit — Post-Patch Call-Site Sweep
+
+**Trigger:** After patching a central config module (e.g., `src/config.js`, `config/index.ts`) to use env var reads.
+
+**Problem:** Fixing the config module does NOT neutralise call-site `||` fallback expressions in application files or multi-consumer workers that read `process.env` directly, bypassing the config module entirely.
+
+**Two mandatory steps:**
+
+**Step 1 — Pre-patch discovery** (run BEFORE patching config module):
+```bash
+# Find ALL direct process.env reads across entire src/ (not just config/)
+grep -rn 'process\.env\.' src/ --include='*.js' --include='*.ts' --exclude-dir=node_modules | grep -v 'config\|Config' | sort
+```
+This identifies files that bypass the config module.
+
+**Step 2 — Post-patch sweep** (run AFTER config module is patched):
+```bash
+# Find surviving call-site fallback expressions
+grep -rnE 'process\.env\.[A-Z_]+\s*\|\|\s*["\x27]' src/ --include='*.js' --include='*.ts' --exclude-dir=node_modules | grep -v 'config/'
+# Find hardcoded localhost/redis fallbacks
+grep -rn '|| "redis://\||| "localhost"\||| "127.0.0.1"\||| "mongodb://' src/ --include='*.js' --include='*.ts' --exclude-dir=node_modules
+```
+
+**Rule:** Every match in the post-patch sweep is a credential/config bypass that must be fixed in the same task scope. Common patterns:
+- Worker files with `process.env.REDIS_URL || "redis://localhost:6379"`
+- Route handlers with `process.env.DB_HOST || "localhost"`
+- Middleware with `process.env.SECRET || "default-secret"`
+
+Replace each with a reference to the centralised config module OR remove the fallback (use bare `process.env.VAR` when the var is required).
+
+## Multi-Consumer Scope Detection
+
+**Trigger:** Node.js applications with multiple worker/consumer entry points (e.g., `worker.js`, `consumer.js`, `processor.js`) alongside the main HTTP server.
+
+**Problem:** Config externalisation tasks often patch only the primary entry point's config reads, leaving secondary workers with hardcoded values or direct `process.env` reads that bypass the config module.
+
+**Detection:**
+```bash
+# Find potential worker entry points
+grep -rln 'process\.exit\|worker\|consumer\|processor' src/ --include='*.js' --include='*.ts' | grep -v node_modules | grep -v test
+# Cross-reference with package.json scripts
+grep -A20 '"scripts"' package.json | grep -E 'worker|consumer|processor|queue'
+```
+
+**Rule:** After patching the main config module, run the config audit on EVERY entry point file identified above. Each worker that reads env vars directly must either (a) import from the centralised config module, or (b) have its fallback expressions removed.
+
+## Mise/asdf Toolchain Bootstrap (Node.js)
+
+**Trigger:** Node.js project with `.tool-versions` or `.mise.toml` specifying node version.
+
+**Bootstrap procedure:**
+```bash
+if [ -f .tool-versions ] || [ -f .mise.toml ]; then
+  mise install node 2>/dev/null
+  export PATH=$HOME/.local/share/mise/shims:$PATH
+fi
+node --version  # Verify
+```
+
+### Toolchain Bootstrap Fallback (Tier 2)
+
+When `npm` is absent from PATH (mise shim not activated or node not installed):
+```bash
+# Read version from .tool-versions or .nvmrc
+NODE_VER=$(grep 'nodejs' .tool-versions 2>/dev/null | awk '{print $2}')
+[ -z "$NODE_VER" ] && NODE_VER=$(cat .nvmrc 2>/dev/null | tr -d 'v')
+[ -z "$NODE_VER" ] && NODE_VER="18.20.2"  # fallback
+
+# Download and activate
+curl -sSL "https://nodejs.org/dist/v${NODE_VER}/node-v${NODE_VER}-linux-x64.tar.xz" | tar -xJ -C /tmp
+export PATH="/tmp/node-v${NODE_VER}-linux-x64/bin:$PATH"
+node --version && npm --version
+```
+
+**Rule:** Before ANY `npm install`, `npm test`, or `node` command, check for mise/asdf config and activate. If activation fails, use the Tier 2 curl+tar download fallback.
+
+## multer-s3 v3 Requires @aws-sdk/client-s3 v3
+
+**Trigger:** Node.js file upload applications using `multer-s3` package.
+
+**Problem:** `multer-s3` v3+ requires `@aws-sdk/client-s3` (AWS SDK v3). If the project currently uses `aws-sdk` (v2), upgrading multer-s3 without also migrating to SDK v3 causes runtime errors.
+
+**Detection:**
+```bash
+grep -E 'multer-s3|@aws-sdk/client-s3|aws-sdk' package.json
+```
+
+**Compatibility matrix:**
+| multer-s3 | AWS SDK Required | Import Pattern |
+|---|---|---|
+| v2.x | `aws-sdk` (v2) | `const AWS = require('aws-sdk')` |
+| v3.x | `@aws-sdk/client-s3` (v3) | `const { S3Client } = require('@aws-sdk/client-s3')` |
+
+**Rule:** When migrating file uploads to S3, verify multer-s3 version matches the AWS SDK version in package.json. If upgrading to SDK v3, add `@aws-sdk/client-s3` to dependencies.
+
+## jest.mock Virtual for Migration-Added Packages
+
+**Trigger:** Adding new packages during migration (e.g., `@aws-sdk/client-s3`, `ioredis`, `connect-redis`) that don't exist in the test environment.
+
+**Problem:** Tests importing modules that reference newly-added packages fail with "Cannot find module" if the test runner doesn't have the package installed (e.g., in CI with `--no-optional`).
+
+**Fix — jest.mock with virtual module:**
+```javascript
+// In test file or jest.setup.js (see decision tree below)
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: jest.fn() })),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+}), { virtual: true });
+```
+
+**Rule:** For every package added during migration that is referenced in testable code paths, add a `jest.mock(..., { virtual: true })` in `jest.setup.js` or the relevant test file. The `virtual: true` flag allows mocking modules that aren't installed.
+
+### jest.mock Placement Decision Tree
+
+Determine WHERE to place the jest.mock call:
+
+1. **Package used in ≤3 test files** → mock in EACH test file (top of file, before imports).
+2. **Package used in 4+ test files** → add to `jest.setup.js` via `setupFilesAfterEnv` in jest config (NOT `setupFilesAfterFramework` — that key is invalid and silently ignored).
+3. **Module-scope instantiation** (e.g., `const client = new S3Client()` at top of a source module) → `jest.mock` MUST be at the top of the test file, BEFORE any `require()`/`import`. Babel-jest hoists `jest.mock()` calls to the top of the file, but ONLY when they appear in the test file itself — not from setup files.
+
+**jest.config.js setupFilesAfterEnv** (correct configuration):
+```javascript
+// jest.config.js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],  // ← correct key
+  // NOT: setupFilesAfterFramework (invalid, silently ignored)
+};
+```
+
+**Module-scope instantiation example** (requires test-file placement):
+```javascript
+// src/storage.js — module-level instantiation
+const { S3Client } = require('@aws-sdk/client-s3');
+const client = new S3Client({ region: process.env.AWS_REGION }); // runs at require() time
+
+// test/storage.test.js — mock MUST be here, not in jest.setup.js
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: jest.fn() })),
+}), { virtual: true });
+const { uploadFile } = require('../src/storage');
+```
+
+## BullMQ Worker SIGTERM Capture
+
+**Trigger:** Node.js applications using BullMQ workers that must gracefully shut down.
+
+**Problem:** BullMQ workers processing long-running jobs need explicit SIGTERM handling to finish the current job before pod termination. Without it, Kubernetes kills the worker mid-job after `terminationGracePeriodSeconds`.
+
+**Pattern:**
+```javascript
+const worker = new Worker('queue-name', async (job) => {
+  // ... process job
+}, { connection: redis });
+
+// Graceful shutdown
+process.on('SIGTERM', async () => {
+  console.log('SIGTERM received, closing worker...');
+  await worker.close();
+  process.exit(0);
+});
+```
+
+**Kubernetes manifest:**
+```yaml
+terminationGracePeriodSeconds: 60  # Must exceed longest expected job duration
+```
+
+**Detection:**
+```bash
+grep -rn 'new Worker\|BullMQ\|bullmq' src/ --include='*.js' --include='*.ts' | grep -v node_modules
+```
+
+**Rule:** ALL BullMQ/Bull worker Deployments MUST have SIGTERM handling that calls `worker.close()`. Set `terminationGracePeriodSeconds` to exceed the longest expected job processing time.
+
+
+## Singleton Import-Graph Check
+
+**Trigger:** Node.js projects where a shared module creates a connection at import time (e.g., `const redis = new Redis(...)` at module level) and multiple entry points import it.
+
+**Problem:** If multiple workers/services import the same singleton connection module, each import in a different container creates its own connection. But within a single process, `require()` caches modules — subsequent imports return the SAME instance. This is safe for single-process Deployments but breaks when the same module is imported in a CronJob one-shot script (the connection may never close because `require()` caching keeps the event loop alive).
+
+**Detection:**
+```bash
+# Find module-level connection singletons
+grep -rn 'module\.exports.*=.*new Redis\|module\.exports.*=.*new Pool\|module\.exports.*=.*createClient' src/ --include='*.js' --include='*.ts' | grep -v test | grep -v node_modules
+```
+
+**Rule:** For CronJob entry points that import singleton connection modules, verify the one-shot script calls `.disconnect()` or `.end()` after completing work. Without explicit close, Node.js event loop stays alive indefinitely due to the cached singleton keeping an active socket. Cross-reference with §CronJob Connection Bootstrap and §CronJob Lazy-Require patterns.
+
+## §6 Filesystem-to-Object-Store Migration Cascade Checklist
+
+**Trigger:** Node.js project with file upload handling being migrated to S3/object store (Sub-Phase §6).
+
+**Problem:** S3 migration touches multiple layers that must all be updated in the SAME task to avoid deferred-fix cascades:
+
+### Mandatory In-Task Steps (do NOT defer any):
+
+1. **Sweep ALL route handlers for `req.file.path`** and replace with `req.file.key` (or `req.file.location` for multer-s3):
+```bash
+grep -rn 'req\.file\.path\|req\.files\[.*\]\.path' src/ routes/ --include='*.js' --include='*.ts' | grep -v node_modules
+```
+Every match must be updated in the same task.
+
+2. **Update ENV_VARIABLES.md immediately** when new env vars are introduced (S3_BUCKET, AWS_REGION, S3_ENDPOINT). Do NOT defer to Final Review.
+
+3. **IRSA credential guard trigger**: The presence of ANY AWS SDK client instantiation (`new S3Client(...)`, `new S3({...})`) is the trigger for IRSA credential env reads — even if the source code has zero pre-existing AWS credential reads.
+
+4. **Adapter wiring in same task as package.json addition**: When adding `multer-s3` or `@aws-sdk/client-s3` to package.json, complete the storage adapter wiring in the same task:
+```javascript
+// Complete in same task — not deferred:
+const multerS3 = require('multer-s3');
+const { S3Client } = require('@aws-sdk/client-s3');
+const upload = multer({
+  storage: multerS3({
+    s3: new S3Client({ region: process.env.AWS_REGION }),
+    bucket: process.env.S3_BUCKET,
+    key: (req, file, cb) => cb(null, `uploads/${Date.now()}-${file.originalname}`)
+  })
+});
+```
+
+5. **Delete-path migration**: If the app has file-deletion logic using `fs.unlink(path)`, grep and migrate to `DeleteObjectCommand`:
+```bash
+grep -rn 'fs\.unlink\|fs\.rmSync\|fs\.unlinkSync' src/ --include='*.js' --include='*.ts' | grep -v node_modules
+```
+
+### Verification:
+```bash
+# After migration — zero local-path file operations on upload paths:
+grep -rn 'req\.file\.path\|req\.file\.destination\|fs\.unlink.*upload' src/ --include='*.js' --include='*.ts' | grep -v node_modules
+# Expected: 0 matches
+```
+
+## Test Migration — jest.mock Requirements
+
+**Trigger:** ANY package added during migration (§4 session, §6 S3, §7 credentials) that is referenced in testable code paths.
+
+### Pre-Test Checklist (run BEFORE any test command):
+
+1. **Identify all migration-added packages:**
+```bash
+# Compare current package.json against original
+diff <(git show HEAD:package.json 2>/dev/null | grep -oP '"[^"]+":' | sort) <(grep -oP '"[^"]+":' package.json | sort) | grep '>'
+```
+
+2. **For each added package referenced in source code**, add jest.mock with `{ virtual: true }`:
+```javascript
+// jest.setup.js or individual test files
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({ send: jest.fn() })),
+  PutObjectCommand: jest.fn(),
+  GetObjectCommand: jest.fn(),
+  DeleteObjectCommand: jest.fn(),
+}), { virtual: true });
+
+jest.mock('ioredis', () => jest.fn(() => ({
+  get: jest.fn(), set: jest.fn(), del: jest.fn(),
+  on: jest.fn(), connect: jest.fn(),
+  disconnect: jest.fn(),
+})), { virtual: true });
+
+jest.mock('connect-redis', () => ({
+  default: jest.fn(() => ({}))  // v7 shape; adjust for v9+
+}), { virtual: true });
+```
+
+3. **Test-update task timing**: The test-update task MUST run immediately after the last migration task and BEFORE any validation task. Tests failing due to missing mocks block all downstream validation.
+
+### Common Migration-Added Packages Requiring Virtual Mocks:
+
+| Package | Mock Shape |
+|---------|-----------|
+| `@aws-sdk/client-s3` | `{ S3Client, PutObjectCommand, GetObjectCommand }` |
+| `ioredis` | Constructor returning `{ get, set, del, on, connect, disconnect }` |
+| `connect-redis` | v7: `{ default: MockRedisStore }`, v9+: `{ RedisStore: MockRedisStore }` |
+| `multer-s3` | `jest.fn(() => ({}))` |
+| `@socket.io/redis-adapter` | `{ createAdapter: jest.fn() }` |
+
+
+## NestJS Probe Path Verification
+
+**Trigger:** NestJS applications with health check endpoints configured for Kubernetes probes.
+
+**Problem:** NestJS `@Controller()` route paths are NOT the same as Express-level route registrations. Probe paths must match `expressApp.get()` registrations in `main.ts`/`bootstrap()`, not `@Controller()` decorator paths. The Express adapter registers routes at a different level than NestJS controllers — controller routes go through guards/interceptors (which may require auth), but `expressApp.get()` routes bypass them.
+
+**Detection:**
+```bash
+# Find probe path registration (Express-level, pre-auth):
+grep -rn 'app\.get\|expressApp\.get\|getHttpAdapter.*get' src/main.ts src/bootstrap* 2>/dev/null
+
+# Find controller-level health route (may require auth — NOT suitable for probes):
+grep -rn '@Get.*health\|@Controller.*health' src/ --include='*.ts'
+```
+
+**Rule:** For NestJS, probe paths MUST match the `expressApp.get()` registration in `main.ts`:
+```typescript
+// main.ts — probe route registered BEFORE global guards
+const app = await NestFactory.create(AppModule);
+const expressApp = app.getHttpAdapter().getInstance();
+expressApp.get('/healthz', (req, res) => res.status(200).send('ok'));
+// ... then apply guards, interceptors, etc.
+```
+
+The probe path in the manifest is `/healthz` (matching the Express registration), NOT `/api/health` (which might be a controller route behind auth).
+
+**Tier 2 version matching (Node.js):** When generating manifests, use the Node.js version from `package.json` `engines.node` field or `.nvmrc` for the Dockerfile FROM tag. Mismatch causes `node --check` failures in Tier 2.
+
+```bash
+# Detect expected Node version
+grep -oP '"node":\s*"[>=<^~]*\K[0-9]+' package.json 2>/dev/null || cat .nvmrc 2>/dev/null
+```
+
+
+## Lock File Desync Pre-Check
+
+**Trigger:** Node.js project with `package-lock.json` or `yarn.lock` present.
+
+**Problem:** When `package.json` has been modified (dependency added/removed/updated) but the lock file was not regenerated, `npm ci` (used in Dockerfiles for deterministic installs) fails with "npm ERR! `npm ci` can only install packages when your package.json and package-lock.json are in sync."
+
+**Detection (pre-Docker-build gate):**
+```bash
+# Check for desync indicators
+npm ci --dry-run 2>&1 | grep -q 'in sync' && echo "SYNC OK" || echo "LOCK DESYNC DETECTED"
+# Fallback when npm unavailable:
+node -e "
+const pkg = require('./package.json');
+const lock = require('./package-lock.json');
+const pkgDeps = {...(pkg.dependencies||{}), ...(pkg.devDependencies||{})};
+const lockPkgs = Object.keys(lock.packages || lock.dependencies || {}).filter(k => k && !k.startsWith('node_modules/'));
+const missing = Object.keys(pkgDeps).filter(d => !JSON.stringify(lock).includes(d));
+if (missing.length) { console.log('DESYNC:', missing.join(', ')); process.exit(1); }
+"
+```
+
+**Rule:** Before `docker build`, verify lock file is in sync with `package.json`. If desync detected, run `npm install` (or `yarn install`) to regenerate the lock file before building. Record in TRANSFORMATION_SUMMARY.md if lock file was regenerated during migration.
+
+## Package Removal Ordering Constraint
+
+**Trigger:** Removing multiple npm packages during migration (e.g., removing `express-session` memory store, `connect-mongo` when switching to Redis).
+
+**Problem:** Removing a package that other packages depend on causes `npm install` to fail with peer dependency errors. The removal order matters — remove dependents first, then dependencies.
+
+**Detection:**
+```bash
+# Check if package B depends on package A before removing A:
+npm ls <package-to-remove> 2>/dev/null | grep -v 'empty\|UNMET'
+```
+
+**Rule:** When removing multiple packages:
+1. Use `npm ls` to check for dependents of each package
+2. Remove packages in reverse-dependency order (dependents first)
+3. After all removals, run `npm install` once (not after each removal)
+4. Verify with `npm ls --all 2>&1 | grep -c 'UNMET PEER'` — should be 0
+
+## S3 URL Region-Sensitive Assertions
+
+**Trigger:** Node.js applications using AWS S3 SDK where URL format varies by region.
+
+**Problem:** S3 URL format differs between regions — `https://s3.amazonaws.com/bucket/key` (us-east-1 path-style) vs `https://bucket.s3.us-west-2.amazonaws.com/key` (virtual-hosted). Tests or assertions that hardcode one URL format fail when the region changes.
+
+**Detection:**
+```bash
+grep -rn 's3\.amazonaws\.com\|s3\.[a-z]\{2\}-[a-z]*-[0-9]' . --include='*.js' --include='*.ts' | grep -v 'node_modules'
+```
+
+**Rule:** When externalising S3 configuration:
+1. `S3_REGION` (or `AWS_REGION`) MUST be a ConfigMap entry — URL format depends on it
+2. Do NOT hardcode S3 URL patterns in application code or tests
+3. Use SDK-provided URL construction (`getSignedUrl()`, `endpoint` config) rather than string concatenation
+4. For `S3_ENDPOINT` (custom endpoints like MinIO), classify as ConfigMap (not Secret — it's a hostname, not a credential)
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/php-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/php-patterns.md
@@ -1,0 +1,1626 @@
+# PHP Patterns Reference
+
+PHP-specific containerisation gotchas for Phase 2 transformation. Applies when `composer.json` is present or PHP source files are detected.
+
+## Table of Contents
+
+1. [Three-Tier Config Fallback Pattern](#three-tier-config-fallback)
+2. [filter_var Boolean Trap](#filter_var-boolean-trap)
+3. [Logging — php://stdout vs error_log](#logging-streams)
+4. [realpath() Failure in S3/emptyDir Mode](#realpath-failure)
+5. [Undefined Constant Guards](#undefined-constant-guards)
+6. [APP_KEY Generation (Laravel)](#app-key-generation)
+7. [nginx Non-Root with PHP-FPM](#nginx-non-root)
+8. [PHP-FPM Non-Root PID Directory](#php-fpm-non-root-pid-directory)
+9. [Laravel Writable Paths](#laravel-writable-paths)
+10. [env() Default Argument and IRSA](#env-default-argument-and-irsa)
+11. [Laravel Queue Channel Routing](#laravel-queue-channel-routing)
+12. [Storage/Fonts/DomPDF emptyDir](#storagefontsdompdff-emptydir)
+13. [PHPStan Memory Limit](#phpstan-memory-limit)
+14. [Tab-Indented str_replace Workaround](#tab-indented-str_replace-workaround)
+15. [GD/S3 Temp-File Pattern](#gd-s3-temp-file-pattern)
+16. [Logging Config Key Mismatch](#logging-config-key-mismatch)
+17. [Laravel Framework-Consumed Env Vars](#laravel-framework-consumed-env-vars)
+18. [Ecommerce Decomposition Triggers](#ecommerce-decomposition-triggers)
+19. [PHP Env Var Grep Pattern (Mixed-Case)](#php-env-var-grep-pattern)
+20. [Bespoke Installer Config Overwrite](#bespoke-installer-config-overwrite)
+21. [Laravel IRSA Null vs Empty-String](#laravel-irsa-null-vs-empty-string)
+22. [Supervisord readOnlyRootFilesystem](#supervisord-readonlyrootfilesystem)
+23. [Supervisord PHP-FPM Graceful Shutdown](#supervisord-php-fpm-graceful-shutdown)
+24. [Nginx PID Override for readOnlyRootFilesystem](#nginx-pid-override)
+25. [S3 ACL Modern AWS Accounts](#s3-acl-modern-aws)
+26. [Config Load-Order Override Trap](#config-load-order-trap)
+27. [Apache Non-Root Port Binding](#apache-non-root-port-binding)
+28. [Apache /var/log/apache2 emptyDir Conditional](#apache-log-emptydir-conditional)
+29. [www-data UID 33 Coverage (FPM and Apache)](#www-data-uid-33-coverage)
+30. [Bespoke-Installer Lock-File Pattern](#bespoke-installer-lock-file-pattern)
+31. [php:*-apache CMD Inheritance Trap](#php-apache-cmd-inheritance-trap)
+32. [Pre-Dockerfile configPath() Override Detection](#pre-dockerfile-configpath-override-detection)
+33. [terminationGracePeriodSeconds — Direct Apache PID 1](#terminationgraceperiodseconds-direct-apache-pid-1)
+34. [5-Pass Grep Exclusions — tools/ and scripts/](#5-pass-grep-exclusions-tools-and-scripts)
+35. [Undefined Constants Detection Before Three-Tier Fallback](#undefined-constants-detection-before-three-tier-fallback)
+
+## Classification Authority Banner
+
+> **Classification examples in this file are illustrative. SKILL.md Criterion 6 Secret classification guards are authoritative when in conflict.** In particular: DB_USERNAME, DB_HOST, DB_PORT, DB_DATABASE → always ConfigMap; only DB_PASSWORD, DB_CONNECTION_STRING → Secret.
+
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify PHP source compiles without syntax errors, dependencies resolve, and the application can bootstrap — all BEFORE `docker build`.
+
+### Commands
+```bash
+# 1. Syntax check all PHP files (excluding vendor/ and Blade templates)
+find . -name '*.php' -not -path '*/vendor/*' -not -path '*/resources/views/*' | xargs -P4 php -l 2>&1 | grep -v 'No syntax errors' | grep -i 'error'
+# Expected: empty output. Any output = FAIL.
+# IMPORTANT: Do NOT use bare 'grep syntax error' — the success message
+# 'No syntax errors detected' contains that substring, causing false positives.
+
+# 2. Composer validate (checks composer.json structure)
+composer validate --no-check-publish
+# Expected: exit 0
+
+# 3. Dependency install (dry-run if possible, otherwise full)
+composer install --no-interaction --no-scripts --prefer-dist 2>&1
+# Expected: exit 0
+```
+
+### Expected Output
+- Step 1: Zero lines of output (all files pass `php -l`)
+- Step 2: "./composer.json is valid"
+- Step 3: Exit 0 with packages resolved
+
+### CONDITIONAL PASS Triggers
+- `php` not installed and `mise install php` fails → CONDITIONAL PASS
+- PHP version mismatch (e.g., project requires 8.2, host has 7.4) and mise fails → CONDITIONAL PASS
+- Network timeout on Composer dependency download (after 1 retry) → CONDITIONAL PASS
+
+### Toolchain Bootstrap
+
+⚠ **Composer is NOT available via mise.** Do NOT attempt `mise install composer` — it fails with "not found in mise tool registry".
+
+**Install Composer directly:**
+```bash
+# Check PHP availability first
+command -v php && php --version
+# If PHP absent, try mise for PHP only
+command -v mise && mise install php 2>/dev/null
+
+# Install Composer via official installer (requires PHP + curl)
+curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Verify
+composer --version
+```
+
+**If `/usr/local/bin` is not writable:**
+```bash
+curl -sSL https://getcomposer.org/installer | php -- --install-dir=/tmp --filename=composer
+export PATH="/tmp:$PATH"
+composer --version
+```
+
+**Custom vendor-dir detection** — run BEFORE §3 env var grep passes:
+```bash
+# Check for non-standard vendor directory in composer.json
+grep -oP '"vendor-dir"\s*:\s*"\K[^"]+' composer.json 2>/dev/null
+# Discover all vendor directories (add to --exclude-dir flags)
+find . -type d -name vendor -not -path './.git/*' 2>/dev/null
+```
+Add ALL discovered vendor directories to grep `--exclude-dir` alongside standard `vendor`.
+
+### Validated Example Repositories
+- **BookStack** (github.com/BookStackApp/BookStack): `php -l` passes on all 400+ files; `composer validate` passes. Validated 2026-06.
+- **OpenCart** (github.com/opencart/opencart): `php -l` passes on 11 modified files; vendor exclusion critical (nested vendor dirs at `upload/system/storage/vendor/`). Validated 2026-06.
+
+
+## Three-Tier Config Fallback
+
+```php
+// GOOD: env var → constant → hardcoded default
+define('DB_HOSTNAME', getenv('DB_HOST') ?: 'localhost');
+```
+
+Rule: Always use ternary-with-fallback. `getenv()` returns `false` on missing vars.
+
+## filter_var Boolean Trap
+
+`getenv('FLAG')` returns string `'false'` which is **truthy**:
+
+```php
+// BAD: string 'false' is truthy!
+$debug = getenv('APP_DEBUG') ?: false;
+
+// GOOD:
+$debug = filter_var(getenv('APP_DEBUG') ?: 'false', FILTER_VALIDATE_BOOLEAN);
+```
+
+Integer: `$port = (int)(getenv('DB_PORT') ?: '3306');`
+
+## Logging Streams
+
+```php
+ini_set('error_log', 'php://stderr');
+fwrite(STDOUT, json_encode($logEntry) . "\n");
+// Or Monolog:
+$handler = new \Monolog\Handler\StreamHandler('php://stdout', Logger::INFO);
+```
+
+## realpath() Failure
+
+`realpath()` returns `false` for non-existent paths:
+
+```php
+// BAD: crashes when path doesn't exist
+$path = realpath($uploadDir . '/' . $filename);  // false!
+
+// GOOD:
+$path = $uploadDir . '/' . $filename;
+if (file_exists($path)) { $resolved = realpath($path); }
+```
+
+## Undefined Constant Guards
+
+```php
+$prefix = (defined('CACHE_PREFIX') ? CACHE_PREFIX : 'app') . '_' . $key;
+```
+
+## APP_KEY Generation
+
+Runtime: Set `APP_KEY` in Kubernetes Secret. Laravel reads from env automatically.
+
+## nginx Non-Root
+
+```nginx
+server {
+    listen 8080;  # not 80
+    fastcgi_pass 127.0.0.1:9000;
+}
+```
+
+Update Service: `port: 80, targetPort: 8080`. Mount emptyDir at `/var/cache/nginx` and `/var/run`.
+
+## PHP-FPM Non-Root PID Directory
+
+When running as non-root with `readOnlyRootFilesystem: true`:
+
+```ini
+[global]
+pid = /tmp/php-fpm.pid
+```
+
+**Alternative — build-time directory creation:**
+```dockerfile
+RUN mkdir -p /usr/local/var/run && chown www-data:www-data /usr/local/var/run
+USER www-data
+```
+
+## Laravel Writable Paths
+
+| Mount Path | Purpose |
+|-----------|---------|
+| `/tmp` | PHP temp files |
+| `storage/framework/sessions` | Session files |
+| `storage/framework/cache` | File cache |
+| `storage/framework/views` | Compiled Blade templates |
+| `storage/logs` | Log fallback |
+| `bootstrap/cache` | Compiled config, routes, services |
+| `/var/cache/nginx` | nginx proxy temp (if sidecar) |
+| `/var/run` | nginx PID file (if sidecar) |
+| `/usr/local/var/run` | PHP-FPM PID file |
+| `storage/fonts` | DomPDF font cache (if used) |
+
+**www-data UID**: PHP-FPM runs as UID 82 (Alpine) or 33 (Debian). Match `runAsUser` in manifest.
+
+## env() Default Argument and IRSA
+
+```php
+// For IRSA, the correct default is null (not empty string).
+// See §21 (Laravel IRSA Null vs Empty-String) for the authoritative pattern.
+$key = env('AWS_ACCESS_KEY_ID');        // null if unset → SDK uses IRSA
+$secret = env('AWS_SECRET_ACCESS_KEY'); // null if unset → SDK uses IRSA
+if ($key && $secret) {
+    $config['credentials'] = ['key' => $key, 'secret' => $secret];
+}
+```
+
+**Rule**: For IRSA credential guards, use `null` default (omit second argument to `env()`). See §21 for the full explanation.
+
+## Laravel Queue Channel Routing
+
+**Detection:**
+```bash
+grep -rn 'class.*implements ShouldQueue' app/ --include='*.php' | grep -oP 'class \K\w+' | sort
+```
+
+**Per-queue Deployment:**
+```yaml
+containers:
+- name: worker-notifications
+  command: ["php", "artisan", "queue:work", "--queue=notifications", "--tries=3"]
+```
+
+**Rule:** Each `--queue=<name>` gets its own Deployment with independently sized resources.
+
+## Storage/Fonts/DomPDF emptyDir
+
+PHP apps using DomPDF write font cache to `storage/fonts/`:
+
+```yaml
+volumeMounts:
+- name: font-cache
+  mountPath: /app/storage/fonts
+```
+
+**Detection:** `grep -rn 'dompdf\|barryvdh/laravel-dompdf' composer.json composer.lock`
+
+## PHPStan Memory Limit
+
+```bash
+php -d memory_limit=512M vendor/bin/phpstan analyse src/ --level=5
+```
+
+**Rule**: Always pass `--memory-limit=512M` when running PHPStan.
+
+## Tab-Indented str_replace Workaround
+
+PHP files (WordPress/OpenCart) use tab indentation. The `editor str_replace` tool may fail when search string contains tabs.
+
+**Workaround:**
+```bash
+sed -i 's/old_pattern/new_pattern/' path/to/file.php
+# Or Python:
+python3 -c "
+content = open('path/to/file.php').read()
+content = content.replace('old_text', 'new_text')
+open('path/to/file.php', 'w').write(content)
+"
+```
+
+## GD/S3 Temp-File Pattern
+
+```php
+// GOOD: use /tmp (emptyDir) for GD processing before S3 upload
+$tmpPath = tempnam('/tmp', 'img_');
+imagepng($gdImage, $tmpPath);
+$s3->putObject(['Bucket' => env('S3_BUCKET'), 'Key' => $key, 'SourceFile' => $tmpPath]);
+unlink($tmpPath);
+```
+
+**Rule**: All GD/Imagick temp files MUST go to `/tmp` (emptyDir-backed).
+
+## Logging Config Key Mismatch
+
+Laravel `config/logging.php` channel names must match the env var value:
+
+```php
+'channels' => [
+    'stack' => ['driver' => 'stack', 'channels' => ['stdout']],
+    'stdout' => ['driver' => 'monolog', 'handler' => StreamHandler::class, 'with' => ['stream' => 'php://stdout']],
+]
+```
+
+**ConfigMap:** `LOG_CHANNEL: "stack"` — must match a key in `channels` array.
+
+## Laravel Framework-Consumed Env Vars
+
+Laravel reads these env vars internally without explicit `getenv()` in application code:
+
+| Env Var | Purpose | K8s Scope |
+|---------|---------|-----------|
+| `APP_KEY` | Encryption key | Secret |
+| `APP_ENV` | Environment name | ConfigMap |
+| `APP_DEBUG` | Debug mode | ConfigMap |
+| `APP_URL` | Application URL | ConfigMap |
+| `LOG_CHANNEL` | Logging channel | ConfigMap |
+| `DB_CONNECTION` | Database driver | ConfigMap |
+| `DB_HOST` | Database host | ConfigMap |
+| `DB_PORT` | Database port | ConfigMap |
+| `DB_DATABASE` | Database name | ConfigMap |
+| `DB_USERNAME` | Database user | ConfigMap |
+| `DB_PASSWORD` | Database password | Secret |
+| `CACHE_DRIVER` | Cache backend | ConfigMap |
+| `SESSION_DRIVER` | Session backend | ConfigMap |
+| `QUEUE_CONNECTION` | Queue backend | ConfigMap |
+
+**Detection**: `grep -rn "env(" config/ --include='*.php' | grep -oP "env\(['\"]([A-Za-z][A-Za-z0-9_]+)" | sort -u`
+
+## Ecommerce Decomposition Triggers
+
+**Detection triggers:**
+```bash
+grep -l 'opencart' composer.json system/config/default.php 2>/dev/null
+grep -l 'woocommerce' composer.json wp-content/plugins/ 2>/dev/null
+grep -l 'magento' composer.json 2>/dev/null
+```
+
+**Named service catalog for ecommerce monoliths:**
+
+| Service | Responsibility | Complexity | ExtractionOrder |
+|---------|---------------|-----------|----------------|
+| CatalogService | Products, categories, attributes | Medium | 3 |
+| CartService | Basket, pricing rules, coupons | Medium | 4 |
+| OrderService | Checkout, order lifecycle | High | 7 |
+| PaymentService | Gateway integration | High | 8 |
+| ShippingService | Rates, tracking | Medium | 5 |
+| CustomerService | Accounts, addresses | High (shared users) | LAST |
+| NotificationService | Order emails, SMS | Low | 1 |
+| SearchService | Product search, filters | Low | 2 |
+| MediaService | Product images, thumbnails | Low | 2 |
+| AdminService | Backoffice CRUD | Medium | 6 |
+| ReportingService | Analytics, CSV exports | Low | 3 |
+| InventoryService | Stock levels, reservations | Medium | 5 |
+
+**First extractions** (always Low): NotificationService, SearchService, MediaService.
+
+## PHP Env Var Grep Pattern (Mixed-Case)
+
+**Vendor directory exclusion** — ALWAYS add `--exclude-dir=vendor` to ALL PHP env var grep passes. The `vendor/` directory contains third-party Composer packages whose `getenv()`/`env()` calls are internal to those packages, not operator-configurable env vars for the application. Without exclusion, vendor code produces 10-20+ false positives per project.
+
+```bash
+# GOOD: catches mixed-case vars, excludes vendor
+grep -rhoP "getenv\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.php' --exclude-dir=vendor | \
+  grep -oP "[A-Za-z][A-Za-z0-9_]+" | sort -u
+
+# Also catch env() helper:
+grep -rhoP "env\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.php' --exclude-dir=vendor | \
+  grep -oP "[A-Za-z][A-Za-z0-9_]+" | sort -u
+```
+
+**Nested vendor directories**: Some PHP frameworks bundle vendor inside subdirectories (e.g., `upload/system/storage/vendor/`, `system/vendor/`). Add additional `--exclude-dir` flags for nested vendor paths found via `find . -type d -name vendor -not -path './.git/*'`.
+
+## Bespoke Installer Config Overwrite
+
+**Trigger:** PHP frameworks with CLI installers (OpenCart `cli_install.php`, WordPress `wp-cli`) that overwrite config files.
+
+**Detection:**
+```bash
+grep -rn 'file_put_contents.*config\|fwrite.*config' . --include='*.php' | grep -v vendor
+```
+
+**Rule:** Patch the installer to generate env-var-backed config, OR document that installer must NOT be run post-migration.
+
+## Laravel IRSA Null vs Empty-String
+
+**Problem:** `env('AWS_ACCESS_KEY_ID', null)` is correct for IRSA. Using `env('AWS_ACCESS_KEY_ID', '')` (empty string) prevents IRSA fallback because `''` is falsy but non-null — SDK interprets it as "credentials provided but empty" rather than "use default provider chain".
+
+**Disambiguation — framework adapter vs raw SDK constructor:**
+- **Use empty-string in Secret manifest** (`""`) — envFrom requires the key to exist for the `if ($key && $secret)` guard to work at runtime.
+- **Use null default in application code** when `env()` feeds a framework S3 adapter (Laravel Flysystem, which internally uses the SDK kwargs guard pattern).
+- **Use null/omit in application code** when passed directly to raw SDK constructor (`new S3Client`), because any non-null value (including `''`) passed as credential parameter blocks the provider chain.
+- **Resolution:** The Secret manifest always has `""`. The application code always uses `env('AWS_ACCESS_KEY_ID')` (no second argument = null default). The `if ($key && $secret)` guard in the adapter config ensures credentials are only passed when non-empty.
+
+```php
+// GOOD — null default allows IRSA fallback:
+'key' => env('AWS_ACCESS_KEY_ID'),        // returns null if unset
+'secret' => env('AWS_SECRET_ACCESS_KEY'), // returns null if unset
+
+// BAD — empty string blocks IRSA:
+'key' => env('AWS_ACCESS_KEY_ID', ''),
+```
+
+**Guard pattern with null check:**
+```php
+$config = ['region' => env('AWS_DEFAULT_REGION', 'us-east-1')];
+if (env('AWS_ACCESS_KEY_ID') && env('AWS_SECRET_ACCESS_KEY')) {
+    $config['credentials'] = [
+        'key' => env('AWS_ACCESS_KEY_ID'),
+        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+    ];
+}
+// When credentials key is absent, SDK uses IRSA/instance profile
+```
+
+**Detection:** `grep -rn "env.*AWS_ACCESS_KEY_ID\|env.*AWS_SECRET" config/ --include='*.php'`
+
+**Secret YAML for IRSA:** Keys must be present but empty (envFrom requires the key to exist):
+```yaml
+stringData:
+  AWS_ACCESS_KEY_ID: ""
+  AWS_SECRET_ACCESS_KEY: ""
+```
+
+## Supervisord readOnlyRootFilesystem
+
+**Trigger:** PHP applications using supervisord to manage PHP-FPM + nginx (or other multi-process setups) with `readOnlyRootFilesystem: true`.
+
+**Problem:** Supervisord requires BOTH a PID file AND a Unix socket for process control. Default paths (`/var/run/supervisor.sock`, `/var/run/supervisord.pid`) are not writable.
+
+**Solution — move BOTH to /tmp:**
+```ini
+; /etc/supervisor/supervisord.conf
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisord]
+pidfile=/tmp/supervisord.pid
+logfile=/dev/stdout
+logfile_maxbytes=0
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+```
+
+**emptyDir mount:** `/tmp` covers both files. No additional mount needed if `/tmp` is already an emptyDir.
+
+**Detection:** `grep -rn 'supervisord\|supervisor' Dockerfile docker-compose* | grep -v '#'`
+
+## Supervisord PHP-FPM Graceful Shutdown
+
+**Trigger:** PHP-FPM managed by supervisord in a Kubernetes pod. Without explicit configuration, supervisord sends SIGTERM to PHP-FPM which causes immediate hard-kill of worker processes — in-flight requests are dropped.
+
+**Problem:** Kubernetes sends SIGTERM to PID 1 (supervisord) during pod termination. Supervisord then forwards SIGTERM to child processes. PHP-FPM requires SIGQUIT for graceful shutdown — SIGTERM causes immediate worker termination without finishing active requests. `terminationGracePeriodSeconds` is ineffective without the correct stop signal.
+
+**Solution — supervisord config:**
+```ini
+[program:php-fpm]
+command=php-fpm --nodaemonize
+stopsignal=QUIT
+stopwaitsecs=30
+```
+
+**Kubernetes manifest:**
+```yaml
+spec:
+  terminationGracePeriodSeconds: 60  # must be >= stopwaitsecs + 30s overhead
+  containers:
+  - name: app
+    # ...
+```
+
+**Rules:**
+1. `stopsignal=QUIT` in the `[program:php-fpm]` supervisord block — sends SIGQUIT instead of SIGTERM
+2. `stopwaitsecs=30` — time supervisord waits for PHP-FPM to finish active requests
+3. `terminationGracePeriodSeconds` in K8s manifest ≥ `stopwaitsecs + 30s` overhead (60s recommended)
+4. Both settings must be present — `terminationGracePeriodSeconds` alone is ineffective if supervisord sends SIGTERM
+
+**Detection:**
+```bash
+grep -rn 'supervisord\|supervisor' Dockerfile docker-compose* | grep -v '#'
+```
+
+**Verification:**
+```bash
+# Confirm stopsignal is set in supervisord conf
+grep -rn 'stopsignal' /etc/supervisor/ supervisord.conf conf.d/ 2>/dev/null
+# Expected: stopsignal=QUIT in php-fpm program block
+```
+
+**Source:** supervisord forwards SIGTERM by default; PHP-FPM requires SIGQUIT for graceful shutdown (https://stackoverflow.com/questions/66010871/supervisord-graceful-shutdown-issue-in-kubernetes).
+
+## Nginx PID Override for readOnlyRootFilesystem
+
+**Trigger:** nginx as a sidecar or standalone with `readOnlyRootFilesystem: true`.
+
+**Problem:** nginx writes its PID to `/run/nginx.pid` (or `/var/run/nginx.pid`) by default, which fails on read-only filesystem.
+
+**Solution — CMD flag override (no config file change needed):**
+```dockerfile
+CMD ["nginx", "-g", "pid /tmp/nginx.pid; daemon off;"]
+```
+
+**Alternative — nginx.conf directive:**
+```nginx
+pid /tmp/nginx.pid;
+```
+
+**Required emptyDir mounts for nginx:**
+| Path | Purpose |
+|------|---------|
+| `/tmp` | PID file, fastcgi temp |
+| `/var/cache/nginx` | Proxy/fastcgi cache |
+| `/var/run` | Legacy PID location (if not overridden) |
+
+**Detection:** `grep -rn 'nginx' Dockerfile | grep -v '#'`
+
+## S3 ACL Modern AWS Accounts
+
+**Problem:** S3 `'ACL' => 'public-read'` is blocked by default on AWS accounts created after April 2023. The `PutObject` call fails with `AccessControlListNotSupported`.
+
+**Solution — omit ACL parameter entirely:**
+```php
+// BAD (fails on modern AWS accounts):
+$s3->putObject([
+    'Bucket' => env('S3_BUCKET'),
+    'Key' => $key,
+    'SourceFile' => $tmpPath,
+    'ACL' => 'public-read',  // BLOCKED
+]);
+
+// GOOD (use bucket policy for public access instead):
+$s3->putObject([
+    'Bucket' => env('S3_BUCKET'),
+    'Key' => $key,
+    'SourceFile' => $tmpPath,
+]);
+```
+
+**Detection:** `grep -rn "ACL.*public\|'ACL'" . --include='*.php' | grep -v vendor`
+
+**Infrastructure note:** Document in INFRASTRUCTURE_REQUIREMENTS.md that bucket policy (not object ACL) controls public access on modern AWS accounts.
+
+## Config Load-Order Override Trap
+
+**Trigger:** PHP applications with multi-file config loading where per-app config files silently overwrite values from `default.php` or base config.
+
+**Problem:** Some frameworks load config files in sequence (e.g., `default.php` → `app.php` → `local.php`). A per-app config file with hardcoded values silently overwrites env-var-backed defaults established in the base config.
+
+**Before (overwritten):**
+```php
+// config/default.php (migrated to use env vars):
+'db_host' => getenv('DB_HOST') ?: 'localhost',
+
+// config/app.php (loaded AFTER default.php — OVERWRITES):
+'db_host' => 'production-db.internal',  // Hardcoded, wins over env var!
+```
+
+**After (fixed):**
+```php
+// config/app.php (use env var too, or remove the override):
+'db_host' => getenv('DB_HOST') ?: 'localhost',
+```
+
+**Detection:**
+```bash
+# Find all config files that might override base config
+find . -path '*/config/*.php' -not -path '*/vendor/*' | sort
+# Check for hardcoded values in override files
+grep -n "=>\s*['\"][a-zA-Z0-9]" config/*.php | grep -v 'getenv\|env(\|true\|false\|null'
+```
+
+**Rule:** After migrating base config to env vars, scan ALL override config files for the same keys with hardcoded values. Fix or remove overrides that would negate the env-var migration.
+
+## Entrypoint-Script Env Var Grep
+
+**Trigger:** PHP applications with shell entrypoint scripts (`docker-entrypoint.sh`, `startup.sh`) that read env vars via bash parameter expansion.
+
+**Problem:** Standard PHP env grep (`getenv`/`env()`) misses env vars consumed by entrypoint scripts. These vars are equally important for ENV_VARIABLES.md and ConfigMap/Secret generation.
+
+**Additional grep pass for entrypoint scripts:**
+```bash
+# Extract env vars from bash parameter expansion in entrypoint scripts
+grep -oP '\$\{\K[A-Z][A-Z0-9_]+(?=:-)' entrypoint*.sh startup*.sh docker-entrypoint.sh 2>/dev/null | sort -u
+# Also catch direct $VAR references
+grep -oP '\$[A-Z][A-Z0-9_]+' entrypoint*.sh startup*.sh docker-entrypoint.sh 2>/dev/null | tr -d '$' | sort -u
+```
+
+**Vendor directory exclusion** — ALWAYS exclude vendor/ from PHP env grep:
+```bash
+grep -rhoP "(?:getenv|env)\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.php' --exclude-dir=vendor | sort -u
+```
+
+**Rule:** When enumerating env vars for PHP projects, run THREE passes: (1) `getenv()`/`env()` in PHP source (excluding vendor/), (2) entrypoint shell scripts, (3) framework-consumed vars (see §17 Laravel Framework-Consumed Env Vars).
+
+## Apache + readOnlyRootFilesystem emptyDir Paths
+
+**Trigger:** PHP applications using Apache (`php:*-apache` image) with `readOnlyRootFilesystem: true`.
+
+**Problem:** Apache requires multiple runtime-writable paths for PID files, lock files, and logs. With `readOnlyRootFilesystem: true`, Apache fails to start with "Permission denied" or "unable to open logs".
+
+**Mandatory emptyDir mounts for Apache:**
+
+| Path | Purpose |
+|------|---------|
+| `/var/run/apache2` | PID file, graceful restart socket |
+| `/var/log/apache2` | Access/error logs (or redirect to /dev/stdout, /dev/stderr) |
+| `/var/lock/apache2` | Lock file for accept mutex |
+| `/tmp` | PHP temp files, session files |
+
+**Distinction from app-level paths**: These are Apache infrastructure paths. App-level paths (e.g., `storage/`, `bootstrap/cache/`) are listed separately in §9 Laravel Writable Paths.
+
+**Log redirect alternative** — eliminate `/var/log/apache2` emptyDir:
+```apache
+# In apache2.conf or via sed in Dockerfile:
+ErrorLog /dev/stderr
+CustomLog /dev/stdout combined
+```
+
+**Detection:**
+```bash
+grep -rn 'apache\|httpd' Dockerfile | grep -iv 'test\|#'
+grep -rn 'FROM.*php.*apache' Dockerfile
+```
+
+**Dockerfile fix (build-time directory ownership):**
+```dockerfile
+RUN mkdir -p /var/run/apache2 /var/lock/apache2 && \
+    chown -R www-data:www-data /var/run/apache2 /var/lock/apache2
+```
+
+**UID note:** Apache on Debian (`php:*-apache`) runs as www-data UID 33. Match with `runAsUser: 33`, `runAsGroup: 33` in security context.
+
+**Total emptyDir count for Laravel/Apache K8s**: A typical Laravel + Apache deployment with `readOnlyRootFilesystem: true` requires 7-9 emptyDir mounts total: 4 Apache infrastructure paths (above) + 3-5 Laravel app paths (`storage/framework/sessions`, `storage/framework/views`, `storage/framework/cache`, `storage/logs`, `bootstrap/cache`). Count ALL before generating the manifest.
+
+## getenv() !== false Guard for Non-IRSA Credentials
+
+**Trigger:** PHP applications using direct AWS credential injection (non-IRSA) where `getenv()` returns `false` for missing vars.
+
+**Problem:** PHP `getenv()` returns `false` (not null or empty string) when a variable is not set. Code using `if ($key)` treats `false` as falsy but `''` (empty string from Secret) as falsy too — both prevent SDK provider chain activation identically.
+
+**Correct guard pattern:**
+```php
+// GOOD: explicit false check preserves IRSA fallback
+$key = getenv('AWS_ACCESS_KEY_ID');
+$secret = getenv('AWS_SECRET_ACCESS_KEY');
+if ($key !== false && $secret !== false && $key !== '' && $secret !== '') {
+    $config['credentials'] = ['key' => $key, 'secret' => $secret];
+}
+// When both are false OR empty string, SDK uses IRSA
+```
+
+**Detection:** `grep -rn "getenv.*AWS" . --include='*.php' | grep -v vendor`
+
+## Apache Non-Root Port Binding
+
+**Trigger:** PHP applications using `php:*-apache` image with `runAsNonRoot: true`.
+
+**Problem:** Apache default config listens on port 80, which requires root to bind. Non-root containers must use port 8080+.
+
+**Fix — sed in Dockerfile to change port binding:**
+```dockerfile
+# Change Apache to listen on 8080
+RUN sed -i 's/Listen 80/Listen 8080/' /etc/apache2/ports.conf && \
+    sed -i 's/<VirtualHost \*:80>/<VirtualHost *:8080>/' /etc/apache2/sites-available/000-default.conf
+
+USER www-data
+EXPOSE 8080
+```
+
+**Kubernetes Service alignment:**
+```yaml
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+```
+
+**Detection:**
+```bash
+grep -rn 'FROM.*php.*apache' Dockerfile
+grep -n 'Listen 80' /etc/apache2/ports.conf 2>/dev/null
+```
+
+**Rule:** ALL `php:*-apache` images with `runAsNonRoot: true` MUST have ports.conf and VirtualHost changed to 8080. The Kubernetes Service maps external port 80 → container port 8080.
+
+## Apache /var/log/apache2 emptyDir Conditional
+
+**Trigger:** PHP-Apache containers with `readOnlyRootFilesystem: true`.
+
+**Problem:** Apache writes access/error logs to `/var/log/apache2/` by default. Two approaches:
+
+**Option A — Redirect logs to stdout/stderr (preferred, eliminates emptyDir):**
+```dockerfile
+RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
+    ln -sf /dev/stderr /var/log/apache2/error.log
+```
+Or in apache2.conf:
+```apache
+ErrorLog /dev/stderr
+CustomLog /dev/stdout combined
+```
+
+**Option B — emptyDir mount (when log redirection is not feasible):**
+```yaml
+volumeMounts:
+- name: apache-logs
+  mountPath: /var/log/apache2
+```
+
+**Rule:** If the Dockerfile already redirects Apache logs to /dev/stdout and /dev/stderr (via symlinks or config directives), `/var/log/apache2` emptyDir is NOT required. Check with: `grep -n '/dev/std\|/proc/self/fd' Dockerfile` — any match means log redirect is in place.
+
+## www-data UID 33 Coverage (FPM and Apache)
+
+**Trigger:** ANY Debian-based PHP image (`php:*-fpm`, `php:*-apache`, `php:*-cli` on Debian).
+
+**Problem:** The www-data user is UID 33 on ALL Debian-based PHP images (not just FPM). The Security Context Edge Case (8) in SKILL.md applies equally to `php:*-apache` variants.
+
+**Coverage table:**
+
+| Image Pattern | UID | runAsUser | runAsGroup |
+|---|---|---|---|
+| `php:*-fpm` (Debian) | 33 | 33 | 33 |
+| `php:*-apache` (Debian) | 33 | 33 | 33 |
+| `php:*-fpm-alpine` | 82 | 82 | 82 |
+| `php:*-cli` (when USER www-data) | 33 | 33 | 33 |
+
+**Detection:**
+```bash
+grep -n 'FROM.*php:' Dockerfile | grep -iv alpine
+# If match: UID = 33
+grep -n 'FROM.*php:' Dockerfile | grep -i alpine
+# If match: UID = 82
+```
+
+**Rule:** Always check the base image variant to determine the correct UID. Do NOT assume UID 1000 for PHP containers.
+
+## Bespoke-Installer Lock-File Pattern
+
+**Trigger:** PHP frameworks with installer scripts (OpenCart `cli_install.php`, custom setup wizards) that write a lock file to indicate installation is complete.
+
+**Problem:** Installers typically write a lock file (e.g., `config/install.lock`, `.installed`) to prevent re-running. With `readOnlyRootFilesystem: true`, this write fails — causing the app to enter install mode on every pod restart.
+
+**Solution A — Pre-seed lock file in Dockerfile:**
+```dockerfile
+# Create the lock file at build time
+RUN touch /app/config/install.lock
+```
+
+**Solution B — emptyDir + init container:**
+```yaml
+initContainers:
+- name: create-lock
+  image: busybox
+  command: ['sh', '-c', 'touch /app-config/install.lock']
+  volumeMounts:
+  - name: app-config
+    mountPath: /app-config
+```
+
+**Solution C — RWM PVC (when installer writes config AND lock together):**
+If the installer writes both a config file and a lock file to the same directory, use an RWM PVC mounted at that directory path.
+
+**Detection:**
+```bash
+grep -rn 'install.*lock\|\.installed\|setup_complete' . --include='*.php' | grep -v vendor
+grep -rn 'file_exists.*lock\|is_file.*install' . --include='*.php' | grep -v vendor
+```
+
+**Rule:** Identify the lock-file path and mechanism before migration. The chosen solution depends on whether the lock is the ONLY file written (Solution A/B) or part of a larger config-write operation (Solution C).
+
+## Cross-Task PHP-FPM error_log Handoff
+
+**Trigger:** PHP-FPM applications where logging transformation (§5) and PHP-FPM non-root configuration (§13) are handled in separate tasks.
+
+**Problem:** PHP-FPM has two separate logging paths: (1) `error_log` in `php.ini` (PHP runtime errors), and (2) FPM worker `access.log`/`error_log` in `www.conf` (pool-level). When §5 redirects application logging to stdout but a later task configures PHP-FPM non-root, the FPM `error_log` path may still point to a non-writable location.
+
+**Checklist — pair these together in same task scope:**
+1. `php.ini`: `error_log = /proc/self/fd/2` (stderr)
+2. `www.conf`: `php_admin_value[error_log] = /proc/self/fd/2`
+3. `www.conf`: `access.log = /proc/self/fd/2` (or `/dev/stderr`)
+4. FPM master: `error_log = /proc/self/fd/2` (in `[global]` section)
+
+**Detection:**
+```bash
+grep -rn 'error_log\|access.log' . --include='*.ini' --include='*.conf' --include='php-fpm*' | grep -v vendor
+```
+
+**Rule:** When transforming PHP-FPM logging to stdout/stderr, configure ALL four logging paths in the same pass. A partial handoff (app logging fixed, FPM logging deferred) causes runtime errors when `readOnlyRootFilesystem: true` is applied in a later security hardening task.
+
+## DB-Stored Runtime Configuration
+
+**Trigger:** PHP frameworks that persist settings in database tables (OpenCart `oc_setting`, WordPress `wp_options`, Magento `core_config_data`).
+
+**Problem:** Workers may attempt to add ConfigMap/Secret keys for settings stored in database tables. These values are configured via the admin UI at runtime, not injected via environment variables.
+
+**Rule:** Do NOT add ConfigMap/Secret keys for DB-stored configuration values. Document them in INFRASTRUCTURE_REQUIREMENTS.md §2 or §5b as "post-install admin configuration":
+```
+## Post-Install Admin Configuration
+The following settings are managed via the application's admin interface and stored
+in the database. They do NOT require ConfigMap/Secret entries:
+- SMTP relay settings (oc_setting table, group: mail)
+- Store URL and name (oc_setting table, group: config)
+```
+
+**Still required:** NetworkPolicy egress rules for services referenced by DB-stored config (e.g., SMTP relay host requires TCP 25/465/587 egress even though the host value is in the database, not an env var).
+
+**Detection:**
+```bash
+grep -rn 'oc_setting\|wp_options\|core_config_data\|GlobalProperty' . --include='*.php' --include='*.java' --include='*.sql' | grep -v vendor | grep -v test
+```
+
+## Python Bulk Replacement for Log::channel Patterns
+
+**Trigger:** Laravel logging transformation (§5) replacing `Log::channel('...')` calls across ≥3 files.
+
+**Problem:** `editor str_replace` is unreliable for bulk multi-file PHP replacements — partial edits get lost, requiring repair tasks. For ≥3 files with the same pattern, use Python regex in-place substitution from the start.
+
+**Procedure:**
+```bash
+# Step 1: Preview matches
+grep -rln "Log::channel(" app/ --include='*.php' | wc -l
+# If count ≥ 3, use Python bulk replacement:
+
+# Step 2: Dry-run (preview changes without writing)
+python3 -c "
+import re, glob
+pattern = re.compile(r'Log::channel\(['\''\"]\w+['\''\"\])\s*->')
+for f in glob.glob('app/**/*.php', recursive=True):
+    content = open(f).read()
+    if pattern.search(content):
+        print(f'MATCH: {f}')
+        # Show first match context
+        for m in pattern.finditer(content):
+            print(f'  {m.group(0)} → Log::')
+"
+
+# Step 3: Apply replacement
+python3 -c "
+import re, glob
+pattern = re.compile(r'Log::channel\(['\''\"]\w+['\''\"]\)\s*->')
+for f in glob.glob('app/**/*.php', recursive=True):
+    content = open(f).read()
+    new_content = pattern.sub('Log::', content)
+    if new_content != content:
+        open(f, 'w').write(new_content)
+        print(f'UPDATED: {f}')
+"
+```
+
+**Rule:** When replacing `Log::channel('X')->` patterns across ≥3 files, use Python regex in-place substitution — do NOT use `editor str_replace` for each file individually.
+
+## composer.lock Glob Wildcard Dockerfile COPY
+
+**Trigger:** PHP Dockerfile with `COPY composer.json composer.lock ./` but `composer.lock` is absent from the repository.
+
+**Problem:** `COPY composer.json composer.lock ./` fails with "file not found" when `composer.lock` doesn't exist in the build context (common in some Laravel/Symfony projects that .gitignore the lock file).
+
+**Detection:**
+```bash
+test -f composer.lock && echo "EXISTS" || echo "MISSING"
+grep -n 'COPY.*composer.lock' Dockerfile
+```
+
+**WRONG (fails if lock missing):**
+```dockerfile
+COPY composer.json composer.lock ./
+```
+
+**CORRECT (glob wildcard tolerates missing lock):**
+```dockerfile
+COPY composer.json composer.lock* ./
+```
+
+**Rule:** Before writing the Stage 1 COPY in a PHP Dockerfile, check `test -f composer.lock`. If missing, use `COPY composer.json composer.lock* ./` with the glob wildcard so the COPY succeeds regardless.
+
+## Multi-Line env() Grep for config/session.php
+
+**Trigger:** Verifying session driver configuration in Laravel's `config/session.php`.
+
+**Problem:** Laravel's `config/session.php` often splits the `env()` call across multiple lines, causing single-line grep to miss the pattern:
+```php
+'driver' => env(
+    'SESSION_DRIVER',
+    'file'
+),
+```
+
+**Detection (multi-line aware):**
+```bash
+# Single-line check (catches inline form):
+grep -n "env.*SESSION_DRIVER" config/session.php
+
+# Multi-line check (catches split form):
+python3 -c "
+content = open('config/session.php').read()
+import re
+m = re.search(r\"'driver'\s*=>\s*env\(\s*['\\\"]SESSION_DRIVER['\\\"]\", content, re.DOTALL)
+if m:
+    print(f'FOUND at offset {m.start()}')
+    print(content[m.start():m.start()+80])
+else:
+    print('NOT FOUND — session driver may be hardcoded')
+"
+```
+
+**Rule:** When auditing Laravel config files for `env()` usage, always use the multi-line Python check as a fallback when single-line grep returns no results. PHP config files commonly split function calls across lines.
+
+## Dev-Only Dockerfile Detection
+
+**Trigger:** PHP projects with multiple Dockerfiles where one is intended for development only.
+
+**Detection markers (any one = dev-only):**
+- `RUN pecl install xdebug`
+- `RUN composer install` (without `--no-dev`)
+- `VOLUME` directives for code mounts
+- `FROM php:*-fpm` with no multi-stage production build
+
+```bash
+grep -lE 'xdebug|composer install[^-]|VOLUME.*\/app' Dockerfile* 2>/dev/null
+```
+
+**Rule:** Dev-only Dockerfiles MUST NOT be used for production image builds in Tier 1 validation. If found, generate a separate production Dockerfile (multi-stage, `--no-dev`, no xdebug).
+
+## Multi-Stage ARG Global Scope
+
+**Trigger:** PHP multi-stage Dockerfiles using `ARG` for version pinning.
+
+**Problem:** `ARG` declarations are scoped to the build stage they appear in. An `ARG` before the first `FROM` is available only in `FROM` lines. To use it inside a stage, re-declare it (without default):
+
+```dockerfile
+# Global scope — available in FROM lines only:
+ARG PHP_VERSION=8.2
+
+FROM php:${PHP_VERSION}-fpm AS builder
+# Re-declare to use inside this stage:
+ARG PHP_VERSION
+RUN echo "Building with PHP ${PHP_VERSION}"
+```
+
+**Detection:** `grep -n '^ARG' Dockerfile | head -5` — check if any ARG appears before first FROM.
+
+## Stage 0 — PHP Extension Builder
+
+**Trigger:** PHP applications requiring compiled extensions (gd, intl, zip, bcmath, opcache, etc.) that need `-dev` packages for compilation.
+
+**Problem:** Installing both `-dev` packages and compiling extensions in the runtime stage bloats the final image. Using a separate builder stage compiles extensions against the same ABI as runtime.
+
+**CRITICAL:** The extension builder stage MUST use the SAME `php:<version>-<variant>` tag as the runtime stage for binary ABI compatibility. Mixing tags (e.g., building on php:8.2-fpm then running on php:8.2-apache) causes "undefined symbol" crashes.
+
+**Pattern (3-4 stage build):**
+```dockerfile
+# Stage 0: Extension builder (same base as runtime for ABI)
+ARG PHP_VERSION=8.2
+FROM php:${PHP_VERSION}-apache AS php-ext-builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpng-dev libjpeg62-turbo-dev libfreetype6-dev \
+    libzip-dev libicu-dev libonig-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd zip intl mbstring opcache bcmath
+
+# Stage 1: Composer dependencies
+FROM composer:2 AS composer
+COPY composer.json composer.lock* ./
+RUN composer install --no-dev --no-scripts --ignore-platform-reqs --prefer-dist
+
+# Stage 2: Runtime (copy compiled extensions + vendor)
+FROM php:${PHP_VERSION}-apache
+# Copy compiled .so files and .ini configs from builder
+COPY --from=php-ext-builder /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
+COPY --from=php-ext-builder /usr/local/etc/php/conf.d/ /usr/local/etc/php/conf.d/
+# Install ONLY runtime shared libraries (not -dev)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpng16-16 libjpeg62-turbo libfreetype6 \
+    libzip4 libicu72 libonig5 \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=composer /app/vendor vendor/
+COPY . /var/www/html/
+```
+
+**Detection:** `grep -rn 'docker-php-ext-install\|pecl install' Dockerfile`
+
+**Rules:**
+1. Extension builder and runtime MUST share the exact same `php:<version>-<variant>` tag
+2. `--ignore-platform-reqs` on composer install in the composer stage (avoids needing extensions there)
+3. Install only runtime shared libs (no `-dev` suffix) in the final stage
+4. Update guidance: PHP Dockerfiles use "3-4 stages depending on compiled extensions"
+
+## Apache AllowOverride None After sed
+
+**Trigger:** PHP-Apache containers where the Dockerfile uses `sed` to modify Apache config for non-root operation.
+
+**Problem:** After `sed -i` operations on Apache config files, `.htaccess` processing may be disabled if `AllowOverride` was set to `None` in the modified VirtualHost. Many PHP frameworks (Laravel, WordPress, OpenCart) rely on `.htaccess` for routing.
+
+**Detection:**
+```bash
+grep -rn 'AllowOverride' /etc/apache2/ 2>/dev/null
+# If 'AllowOverride None' appears in the document root directory block, .htaccess is disabled
+```
+
+**Fix — ensure AllowOverride All for document root:**
+```dockerfile
+RUN sed -i '/<Directory \/var\/www\/html>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' \
+    /etc/apache2/apache2.conf
+```
+
+**Rule:** After ANY `sed` modification to Apache config, verify `AllowOverride All` is set for the document root directory. Without it, framework routing breaks silently (all routes return 404 except index).
+
+## CAP_DAC_OVERRIDE Entrypoint Audit
+
+**Trigger:** PHP containers with entrypoint scripts that perform file operations on volumes.
+
+**Problem:** Entrypoint scripts that `chown`, `chmod`, or create directories at startup may need `CAP_DAC_OVERRIDE` capability if running as non-root but writing to volume paths owned by different UIDs (e.g., shared emptyDir between init container and main container).
+
+**Detection:**
+```bash
+grep -nE 'chown|chmod|mkdir -p' entrypoint*.sh docker-entrypoint*.sh 2>/dev/null
+```
+
+**Decision:**
+1. If the chown/chmod targets build-time paths → move to Dockerfile (preferred, no capability needed)
+2. If the chown/chmod targets volume paths at runtime → either:
+   - Use init container with matching UID (preferred), OR
+   - Add `CAP_DAC_OVERRIDE` to capabilities (last resort)
+
+**Rule:** Audit ALL entrypoint scripts for file-ownership operations before setting `capabilities: { drop: ["ALL"] }`. Operations that can be moved to build time MUST be moved. Only add capabilities as a documented last resort with explanation.
+
+## Inline Hash Comments in RUN Blocks
+
+**Trigger:** PHP Dockerfiles with multi-line `RUN` instructions containing inline `#` comments.
+
+**Problem:** Inline `#` comments in shell commands within Docker `RUN` instructions can cause unexpected behavior when the comment follows a `\` line continuation:
+
+```dockerfile
+# WRONG — comment breaks continuation:
+RUN apt-get install -y \
+    libpng-dev \  # for GD
+    libzip-dev    # for zip
+
+# CORRECT — comments on separate lines or removed:
+RUN apt-get install -y \
+    libpng-dev \
+    libzip-dev
+```
+
+**Rule:** Never place `#` comments on the same line as a package in a multi-line `RUN apt-get install`. The shell interprets everything after `#` as a comment, potentially swallowing the line continuation or subsequent packages.
+
+## CMD Omission for php:*-apache Images
+
+**Trigger:** Dockerfiles using `php:*-apache` base image.
+
+**Problem:** The `php:*-apache` base image already has a correct `CMD` (`apache2-foreground`) defined in its parent layers. Adding an explicit `CMD` or `ENTRYPOINT` without understanding the base image's entrypoint chain can break the Apache startup sequence.
+
+**Rule:** For `php:*-apache` images, omit `CMD` unless you need a custom entrypoint. The base image's built-in CMD is sufficient:
+```dockerfile
+FROM php:8.2-apache
+# ... extensions, config, COPY ...
+# NO CMD needed — base image provides apache2-foreground
+EXPOSE 8080
+USER www-data
+```
+
+**Exception:** If you need a custom entrypoint for config generation:
+```dockerfile
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["apache2-foreground"]  # Must explicitly restore base CMD when overriding ENTRYPOINT
+```
+
+## PHP Multi-Stage Runtime System Libraries
+
+**Trigger:** PHP multi-stage builds where the runtime stage needs shared libraries installed during build.
+
+**Common runtime libraries needed (Debian):**
+```dockerfile
+# Runtime stage — install ONLY what's needed at runtime:
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpng16-16 libjpeg62-turbo libfreetype6 \
+    libzip4 libicu72 libonig5 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+**Rule:** Never install `-dev` packages in the runtime stage. Use the library package (e.g., `libpng16-16` not `libpng-dev`). The build stage compiles extensions against `-dev` packages; the runtime stage only needs the shared libraries.
+
+**Detection:** `grep -n 'apt-get install' Dockerfile | grep -v 'AS builder' | grep -i dev`
+
+## Nginx Sidecar Init-Copy-Code Pattern
+
+**Trigger:** PHP-FPM + nginx sidecar pattern where nginx needs access to static files from the PHP application.
+
+**Problem:** With `readOnlyRootFilesystem: true`, nginx cannot serve static files from the PHP image unless they are shared via a volume.
+
+**Solution — init container copies static assets:**
+```yaml
+initContainers:
+- name: copy-static
+  image: app-image:latest
+  command: ['sh', '-c', 'cp -r /app/public/* /static/']
+  volumeMounts:
+  - name: static-files
+    mountPath: /static
+containers:
+- name: nginx
+  image: nginx:alpine
+  volumeMounts:
+  - name: static-files
+    mountPath: /app/public
+    readOnly: true
+- name: php-fpm
+  image: app-image:latest
+  # PHP-FPM serves dynamic requests; nginx proxies to 127.0.0.1:9000
+```
+
+**Detection:** `grep -rn 'fastcgi_pass\|php-fpm' nginx.conf Dockerfile docker-compose* 2>/dev/null`
+
+## Common Package Writable Paths (DomPDF Expanded)
+
+**Trigger:** PHP applications using DomPDF that write font cache files to a subdirectory of storage/fonts.
+
+**Problem:** DomPDF writes generated font metrics to `storage/fonts/dompdf/` at runtime. With `readOnlyRootFilesystem: true`, this fails silently (PDFs render without custom fonts).
+
+**Solution — emptyDir at the dompdf font cache path:**
+```yaml
+volumeMounts:
+- name: dompdf-fonts
+  mountPath: /app/storage/fonts/dompdf
+volumes:
+- name: dompdf-fonts
+  emptyDir: {}
+```
+
+**Detection:** `grep -rn 'dompdf\|DOMPDF_FONT_DIR' . --include='*.php' | grep -v vendor`
+
+## Supervisord readOnlyRootFilesystem — All Three Paths
+
+When using supervisord with `readOnlyRootFilesystem: true`, ALL three paths must be writable:
+
+| Path | File | supervisord.conf Directive |
+|------|------|---------------------------|
+| `/tmp/supervisor.sock` | Unix socket | `[unix_http_server] file=` |
+| `/tmp/supervisord.pid` | PID file | `[supervisord] pidfile=` |
+| `/tmp/supervisor.sock` | Client socket | `[supervisorctl] serverurl=unix:///tmp/supervisor.sock` |
+
+All three are covered by a single `/tmp` emptyDir mount. Ensure the supervisord.conf points all three to `/tmp`. See §22 (Supervisord readOnlyRootFilesystem) for the full config snippet.
+
+
+## Production-Safe ConfigMap Defaults (Laravel/PHP)
+
+**Trigger:** Laravel or PHP applications generating ConfigMap manifests with default values from `.env`.
+
+**Problem:** Generated ConfigMaps often mirror the application's `.env` development defaults (SESSION_DRIVER=file, CACHE_DRIVER=file, LOG_CHANNEL=stack). These file-based drivers are incompatible with Kubernetes (ephemeral filesystem, horizontal scaling). Workers deploy manifests with dev defaults, requiring repair cycles.
+
+**Mandatory overrides for ANY Laravel/PHP ConfigMap:**
+
+| Key | Required Value | Why |
+|-----|---------------|-----|
+| `SESSION_DRIVER` | `redis` (or `database`) | File sessions lost on pod restart/scale |
+| `CACHE_DRIVER` | `redis` | File cache not shared across pods |
+| `LOG_CHANNEL` | `stderr` | File logs invisible to `kubectl logs` |
+| `QUEUE_CONNECTION` | `redis` (or `database`) | Sync/file queues block and don't survive restarts |
+| `FILESYSTEM_DISK` | `s3` | Local disk is ephemeral |
+
+**Rule:** File-based drivers (`file`, `single`, `daily`, `local`) are explicitly PROHIBITED in generated ConfigMap manifests for production Kubernetes workloads. Always override with distributed alternatives regardless of what `.env` contains.
+
+**Detection (post-manifest check):**
+```bash
+grep -E 'SESSION_DRIVER.*file|CACHE_DRIVER.*file|LOG_CHANNEL.*(daily|single|stack)|QUEUE_CONNECTION.*sync' kubernetes/configmap.yaml
+# Any match = violation — fix immediately
+```
+
+## Config Directory Discovery Pre-Step
+
+**Trigger:** Any PHP/Laravel project before running env var grep passes.
+
+**Problem:** PHP frameworks store config in various locations (`config/`, `app/config/`, `includes/configure.php`, `admin/includes/configure.php`). Missing a config directory during the grep pass causes env var omissions requiring later repair.
+
+**Procedure (run BEFORE §3 grep passes):**
+```bash
+# Discover all config directories/files
+find . -type f \( -name '*.php' -o -name '*.env*' \) -path '*/config*' | head -20
+find . -name 'configure.php' -o -name '.env*' -o -name 'config.php' | grep -v vendor
+```
+
+**Rule:** Use the discovery output to scope grep passes. Include ALL found config paths in the grep scope — not just the framework-standard `config/` directory.
+
+## APP_KEY Null-Default Enforcement (Laravel)
+
+**Trigger:** Laravel applications with `APP_KEY` in the ConfigMap or `.env`.
+
+**Problem:** Laravel's `APP_KEY` is used for encryption (passwords, cookies, sessions). A non-null placeholder in ConfigMap (e.g., `base64:placeholder...`) would be used verbatim — producing predictable encryption keys across environments.
+
+**Rule:** `APP_KEY` MUST be classified as Secret with an empty-string default. The deployment procedure must generate a unique key per environment (`php artisan key:generate`). Document as a post-deployment action in INFRASTRUCTURE_REQUIREMENTS.md.
+
+```yaml
+# kubernetes/secret.yaml
+stringData:
+  APP_KEY: ""  # MUST be generated per-environment via: php artisan key:generate --show
+```
+
+**Detection:**
+```bash
+grep -n 'APP_KEY' kubernetes/configmap.yaml 2>/dev/null
+# Any match = misclassification — move to Secret with empty default
+```
+
+
+## NetworkPolicy SMTP Egress for PHP Mail-Sending Workloads
+
+**Trigger:** PHP application using mail-sending libraries (PHPMailer, SwiftMailer, Symfony Mailer, Laravel Mail) in code paths extracted to CronJobs or scheduled tasks.
+
+**Problem:** When PHP scheduled tasks (e.g., Laravel `schedule:run`, custom cron scripts) send mail synchronously, the CronJob pod needs SMTP egress in its NetworkPolicy. This is commonly missed because SMTP config is often database-stored (admin UI settings) rather than appearing in env vars.
+
+**Detection:**
+```bash
+# Find mail-sending patterns in PHP code
+grep -rn 'PHPMailer\|SwiftMailer\|Transport::fromDsn\|Mail::send\|Mail::to\|mail(' . --include='*.php' | grep -v 'vendor/' | grep -v 'test'
+```
+
+**Rule:** If mail-sending code is found in any code path that runs as a CronJob or scheduled task, the CronJob's NetworkPolicy MUST include SMTP egress:
+
+```yaml
+egress:
+- ports:
+  - port: 587
+    protocol: TCP
+  # ports-only: no 'to:' field — allows egress to any SMTP relay
+```
+
+**Additional trigger:** Even when no SMTP env var is present in the codebase, platforms with admin-UI-configurable SMTP (OpenCart, WordPress, BookStack) still need SMTP egress if the scheduled task code path calls mail functions. Grep for the function call, not the env var.
+
+
+## Non-Standard Vendor Directory Discovery
+
+**Trigger:** PHP projects where `composer.json` specifies a custom `vendor-dir` (e.g., OpenCart uses `upload/system/storage/vendor/`).
+
+**Problem:** Standard `--exclude-dir=vendor` in grep passes misses the custom vendor directory, producing 10-20+ false positives from third-party code.
+
+**Pre-flight discovery step (run BEFORE §3 grep passes):**
+```bash
+# Check for custom vendor-dir in composer.json
+grep -oP '"vendor-dir"\s*:\s*"\K[^"]+' composer.json 2>/dev/null
+# Discover all vendor directories
+find . -type d -name vendor -not -path './.git/*' 2>/dev/null
+```
+
+**Rule:** Add ALL discovered vendor directories to grep `--exclude-dir` flags alongside standard `vendor`. Example:
+```bash
+grep -rhoP "getenv\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.php' \
+  --exclude-dir=vendor --exclude-dir=upload/system/storage/vendor
+```
+
+## Nginx Non-Root user Directive Removal
+
+**Trigger:** PHP-FPM + nginx sidecar where nginx runs as non-root.
+
+**Problem:** The default `/etc/nginx/nginx.conf` contains `user nginx;` directive. When the container runs as non-root (UID 101 for nginx:alpine), the `user` directive causes: "nginx: [emerg] getpwnam('nginx') failed" because the process can't change users.
+
+**Fix — remove the user directive:**
+```dockerfile
+RUN sed -i '/^user /d' /etc/nginx/nginx.conf
+```
+
+**Detection:**
+```bash
+grep -n '^user ' /etc/nginx/nginx.conf 2>/dev/null
+```
+
+**Rule:** When deploying nginx as non-root (runAsUser: 101), remove the `user` directive from nginx.conf. The process runs as whatever UID the container is started with.
+
+## httpd:2.4-alpine www-data User Creation
+
+**Trigger:** PHP applications using `httpd:2.4-alpine` (Apache) base image.
+
+**Problem:** `httpd:2.4-alpine` does NOT include a `www-data` user by default (unlike Debian-based Apache images). PHP-FPM configuration that references `www-data` fails.
+
+**Fix — create user in Dockerfile:**
+```dockerfile
+FROM httpd:2.4-alpine
+RUN addgroup -S www-data && adduser -S -G www-data -u 33 www-data
+```
+
+**Rule:** When using `httpd:2.4-alpine` with PHP-FPM (where FPM runs as www-data), explicitly create the www-data user in the Dockerfile.
+
+## Composer getcomposer.org Fallback Installation
+
+**Trigger:** Docker build environment where `composer` binary is not available.
+
+**Problem:** Some base images (e.g., `php:8.x-apache`) don't include Composer. The multi-stage pattern uses `FROM composer:2 AS composer` but for single-stage builds, Composer must be installed.
+
+**Canonical installation (single-stage):**
+```dockerfile
+RUN curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+```
+
+**Alternative — COPY from composer image:**
+```dockerfile
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+```
+
+**Rule:** Prefer `COPY --from=composer:2` for reproducibility. Use curl fallback only when multi-stage is not feasible.
+
+## False-Sentinel Exception for Credential Audit
+
+**Trigger:** PHP applications using sentinel values (e.g., `'changeme'`, `'null'`, `'disabled'`) as explicit "not configured" markers.
+
+**Problem:** Credential scan Forms A-C flag these as hardcoded credentials. However, some frameworks use sentinel string values to detect unconfigured state — removing them breaks the detection logic.
+
+**Example:**
+```php
+// OpenCart pattern — sentinel marks "unconfigured"
+define('DB_PASSWORD', 'changeme');
+// Application checks:
+if (DB_PASSWORD === 'changeme') {
+    redirect('/install');
+}
+```
+
+**Rule:** When a hardcoded value serves as a feature-detection sentinel (code explicitly compares against it), it is NOT a credential exposure. Document as "false-sentinel — application uses value as unconfigured marker" in task report. Replace with `env('VAR', '')` where the empty-string default serves the same detection purpose:
+```php
+define('DB_PASSWORD', getenv('DB_PASSWORD') ?: '');
+if (empty(DB_PASSWORD)) {
+    redirect('/install');
+}
+```
+
+---
+
+## getenv() Credential Presence Guard
+
+**Trigger:** PHP credential fields read via `getenv()` where the application must distinguish between a variable being absent vs intentionally set to empty string.
+
+**Problem:** The common PHP idiom `getenv('VAR') ?: 'default'` treats both `getenv()` returning `false` (variable absent) and returning `""` (variable set to empty) as falsy, and substitutes the default for both cases. For credential fields, an intentionally empty string (activating a fallback auth mechanism like IRSA) would incorrectly receive the hardcoded default.
+
+**Rule:** For credential fields, use `getenv('VAR') !== false ? getenv('VAR') : null` (or equivalent) rather than the `?:` operator. This preserves intentionally empty string values and only substitutes when the variable is truly absent.
+
+**Applies to:** AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and any credential field where empty string has semantic meaning (e.g., activating provider chain).
+
+---
+
+## PHP CLI Entry Point: $_GET/$_SERVER Routing in CronJobs
+
+**Trigger:** PHP scripts extracted to CronJob manifests that use `$_GET` or `$_SERVER['REQUEST_URI']` for execution-path routing, originally designed for both web and CLI invocation.
+
+**Problem:** `$_GET` is empty and `$_SERVER['REQUEST_URI']` is unset in CLI context. Scripts relying on these for routing silently take a default/no-op path when run as a CronJob, producing no work and no error.
+
+**Rule:** Before extracting a PHP script to a CronJob, check for `$_GET`/`$_SERVER['REQUEST_URI']` routing logic. If present, introduce a `APP_MODE` environment variable (or equivalent CLI argument) to explicitly select the execution path, and update the CronJob container `env:` section accordingly. Document the routing mechanism in the task report.
+
+---
+
+## exec() Orphan Process in Containerised CronJobs
+
+**Trigger:** PHP CronJob scripts that use `exec()`, `shell_exec()`, or `popen()` to spawn background sub-processes.
+
+**Problem:** Background processes spawned via `exec()` in a container run as orphans — they are not managed by the container runtime. When the PHP process exits, the container exits, potentially before the background process completes. The orphan process may also prevent clean container shutdown.
+
+**Rule:** Audit all PHP CronJob entry points for `exec()`/`shell_exec()`/`popen()` calls. Convert background work to direct PHP function calls within the same process, or use a supervisor-managed process (e.g., supervisord) if background execution is genuinely required. Document any retained `exec()` calls and their rationale in the task report.
+
+---
+
+## www-data UID by Base Image Variant
+
+**Trigger:** PHP application container setting `runAsUser` in the Kubernetes security context.
+
+**Problem:** The `www-data` user has different UIDs depending on the base image:
+- `php:*-apache` — UID 33
+- `php:*-fpm` — UID 82  
+- `ubuntu`/`debian`-based custom images — UID 33
+
+**Rule:** Do not assume a fixed UID for `www-data`. Determine the actual UID from the base image by inspecting the image's `/etc/passwd` or the upstream Dockerfile before setting `runAsUser`. Set `runAsUser` to the detected value, and document the base image variant and its UID in the task report.
+
+## Alpine httpd Missing www-data User
+
+**Trigger:** PHP applications using `httpd:2.4-alpine` (Alpine-based Apache) as the base image.
+
+**Problem:** `httpd:2.4-alpine` does NOT include a `www-data` user by default — unlike Debian-based images where www-data (UID 33) exists. PHP-FPM configuration referencing `www-data` fails at startup with "user not found".
+
+**Fix — create user in Dockerfile with correct flags:**
+```dockerfile
+FROM httpd:2.4-alpine
+# -S = system user, -G = group, -u = explicit UID, -H = no home dir
+RUN addgroup -S www-data && adduser -S -H -G www-data -u 33 www-data
+```
+
+**Detection:**
+```bash
+grep -n 'FROM.*httpd.*alpine' Dockerfile
+grep -rn 'www-data' Dockerfile | grep -v '#'
+# Both present without adduser/addgroup = startup failure
+```
+
+**Rule:** When using `httpd:2.4-alpine`, ALWAYS create www-data user explicitly. The `-H` flag prevents creation of a home directory (not needed for service users). Use UID 33 for consistency with Debian-based PHP images.
+
+## DB-Driven HTTP Cron Dispatcher Pattern
+
+**Trigger:** Ecommerce applications (OpenCart, Magento, WooCommerce) where scheduled tasks are dispatched by an HTTP-triggered cron controller that reads task definitions from the database.
+
+**Problem:** Unlike simple cron scripts that can be extracted to individual CronJob manifests, HTTP-dispatched cron uses a single URL endpoint (e.g., `/admin/cron/run`) that iterates over DB-registered tasks. Each task is not a standalone script — it's a class invoked by the dispatcher framework.
+
+**Solution — single CronJob for the HTTP dispatcher:**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cron-dispatcher
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cron
+            image: app-image:tag
+            command: ["php", "cli_cron.php"]
+            # OR for HTTP-gated dispatchers:
+            # command: ["curl", "-s", "http://localhost:8080/cron/run?token=${CRON_TOKEN}"]
+```
+
+**Rule:** For DB-driven cron dispatchers, generate ONE CronJob manifest that invokes the dispatcher endpoint/CLI — do NOT attempt to extract individual tasks into separate CronJobs. The task registry lives in the database and cannot be enumerated statically.
+
+**Auth-gated dispatcher note:** If the cron endpoint requires authentication, add a `CRON_TOKEN` or `CRON_SECRET` to the Secret manifest and pass it in the CronJob env.
+
+## exec() Background Process Anti-Pattern
+
+**Trigger:** PHP code using `exec()`, `shell_exec()`, or `popen()` to spawn background processes (often with `&` or `nohup`).
+
+**Problem:** Background processes spawned via `exec()` in a container:
+1. Are not managed by the container runtime — they become orphans when PHP exits
+2. May prevent clean container shutdown (SIGTERM not forwarded)
+3. In CronJobs, the container exits (job completes) while the background process is still running
+
+**Detection:**
+```bash
+grep -rn 'exec(\|shell_exec(\|popen(' . --include='*.php' | grep -v vendor | grep -v test | grep -E '&|nohup|background'
+```
+
+**Rule:** Convert `exec()`-based background work to:
+1. **Dedicated worker Deployment** — for long-running processes (e.g., video encoding, report generation)
+2. **Queue job** — push to Redis/database queue, process in a worker pod
+3. **Direct function call** — if the work is short, call it synchronously within the same process
+
+## Supervisord/Cron OS-Level emptyDir Paths
+
+**Trigger:** PHP applications using supervisord or cron daemon with `readOnlyRootFilesystem: true`.
+
+**Required emptyDir mounts for supervisord + cron:**
+
+| Path | Purpose |
+|------|---------|
+| `/tmp` | supervisor.sock, supervisord.pid |
+| `/etc/cron.d` | Crontab files (if using cron daemon) |
+| `/var/log` | Cron/supervisor log fallback |
+| `/var/run` | PID files, sockets |
+| `/var/run/supervisor` | Alternative supervisor socket path |
+| `/var/spool/cron` | Alternative crontab location |
+
+**Detection:**
+```bash
+grep -rn 'supervisord\|cron' Dockerfile docker-compose* | grep -v '#'
+grep -rn '/etc/cron\|/var/spool/cron\|/var/log' entrypoint*.sh docker-entrypoint*.sh 2>/dev/null
+```
+
+**Rule:** When supervisord OR cron daemon is used, enumerate ALL paths written by scanning entrypoint scripts and supervisor config. Each writable path needs an emptyDir mount.
+
+## DomPDF storage/fonts Mapping Confirmation
+
+**Trigger:** PHP applications with `barryvdh/laravel-dompdf` or `dompdf/dompdf` in dependencies.
+
+**Detection:**
+```bash
+grep -rn 'dompdf\|barryvdh/laravel-dompdf' composer.json composer.lock 2>/dev/null
+grep -rn 'DOMPDF_FONT\|font_dir\|fontDir' . --include='*.php' | grep -v vendor
+```
+
+**Confirm writable path:** DomPDF caches generated font metrics at runtime. The default path is `storage/fonts/` (Laravel) or configured via `DOMPDF_FONT_DIR`. Mount as emptyDir:
+```yaml
+volumeMounts:
+- name: dompdf-fonts
+  mountPath: /app/storage/fonts
+```
+
+**Rule:** When DomPDF is in dependencies, confirm the font cache directory exists as an emptyDir mount. Without it, PDF generation with custom fonts fails silently (renders with default font).
+
+## Large-Codebase Syntax Check Fallback
+
+**Trigger:** PHP projects with >2000 `.php` files where `find . -name '*.php' | xargs php -l` takes excessive time (>5 minutes).
+
+**Problem:** The Pre-Docker Local Validation gate requires syntax checking all PHP files, but in large codebases this can exceed task time budgets.
+
+**Fallback procedure** (use ONLY when full-tree check exceeds 5 minutes):
+```bash
+# Count PHP files (excluding vendor)
+PHP_COUNT=$(find . -name '*.php' -not -path '*/vendor/*' | wc -l)
+
+if [ "$PHP_COUNT" -gt 2000 ]; then
+  echo "Large codebase ($PHP_COUNT files) — using sampled syntax check"
+  # Check all modified/new files first
+  find . -name '*.php' -not -path '*/vendor/*' -newer composer.json | xargs -P4 php -l 2>&1 | grep -v 'No syntax errors'
+  # Then random sample of 500 files
+  find . -name '*.php' -not -path '*/vendor/*' | shuf -n 500 | xargs -P4 php -l 2>&1 | grep -v 'No syntax errors'
+else
+  find . -name '*.php' -not -path '*/vendor/*' | xargs -P4 php -l 2>&1 | grep -v 'No syntax errors'
+fi
+```
+
+**Rule:** Record result as `PASS (sampled — N/M files checked)` when using the fallback. Full-tree check is always preferred when time permits.
+
+## php:*-apache CMD Inheritance Trap
+
+**Trigger:** Dockerfiles using `php:*-apache` base image with a custom entrypoint script that uses `$# -gt 0` guard.
+
+**Problem:** The `php:*-apache` base image sets `CMD ["apache2-foreground"]`. When you add `ENTRYPOINT ["docker-entrypoint.sh"]`, Docker passes the CMD as arguments to the entrypoint. Inside the entrypoint, `$# -gt 0` is ALWAYS true (because `apache2-foreground` is passed as $1), causing the guard to always fire — typically exec-ing the CMD and skipping all entrypoint setup logic.
+
+**Before (broken):**
+```bash
+#!/bin/bash
+# docker-entrypoint.sh
+if [ "$#" -gt 0 ]; then
+    exec "$@"  # Always fires! Skips all setup below.
+fi
+# Setup logic never runs...
+```
+
+**After (fixed):**
+```bash
+#!/bin/bash
+# docker-entrypoint.sh
+# Perform setup unconditionally
+php artisan config:cache 2>/dev/null || true
+php artisan route:cache 2>/dev/null || true
+
+# Then exec the CMD (apache2-foreground)
+exec "$@"
+```
+
+**Detection:**
+```bash
+grep -n '\$#.*-gt 0\|\$#.*-ge 1' entrypoint*.sh docker-entrypoint*.sh 2>/dev/null
+grep -n 'FROM.*php.*apache' Dockerfile
+# Both present = potential CMD inheritance trap
+```
+
+**Rule:** For `php:*-apache` images, NEVER use `$# -gt 0` as a conditional guard in the entrypoint. Always perform setup logic unconditionally and end with `exec "$@"`.
+
+## Pre-Dockerfile configPath() Override Detection
+
+**Trigger:** PHP/Laravel projects where the application overrides framework-default config directory paths.
+
+**Problem:** Laravel's `configPath()` helper or custom `$app->useConfigPath()` calls can redirect config loading to a non-standard directory. If the Dockerfile COPYs only the standard `config/` directory, the actual config files may be missing at runtime.
+
+**Detection (run BEFORE writing Dockerfile COPY instructions):**
+```bash
+grep -rn 'configPath\|useConfigPath\|config_path' app/ bootstrap/ --include='*.php' | grep -v vendor
+grep -rn "basePath.*config\|configurationIsCached" bootstrap/ --include='*.php' | grep -v vendor
+```
+
+**Rule:** Before writing any Dockerfile COPY instruction for PHP config files, run this detection step. If a non-standard config path is found, ensure the Dockerfile COPYs that path instead of (or in addition to) the standard `config/` directory. Document the override in the task report.
+
+## terminationGracePeriodSeconds — Direct Apache PID 1
+
+**Trigger:** PHP applications using Apache as PID 1 (no supervisord wrapper) — i.e., `php:*-apache` image with default CMD.
+
+**Formula:** `terminationGracePeriodSeconds` = Apache `Timeout` directive value + 30s buffer.
+
+**Default:** Apache `Timeout` defaults to 60s → `terminationGracePeriodSeconds: 90`.
+
+**Detection:**
+```bash
+# Check if Apache is PID 1 (no supervisord)
+grep -n 'supervisord\|supervisor' Dockerfile | grep -v '#'
+# If empty: Apache is PID 1
+
+# Check custom Timeout value
+grep -rn 'Timeout ' /etc/apache2/ apache2.conf 2>/dev/null | grep -v '#'
+# If empty: use default 60s
+```
+
+**Manifest:**
+```yaml
+spec:
+  terminationGracePeriodSeconds: 90  # Apache Timeout 60s + 30s buffer
+```
+
+**Rule:** When Apache is PID 1 (no supervisord), set `terminationGracePeriodSeconds` to `Apache Timeout + 30s`. If supervisord wraps Apache, use the supervisord formula (stopwaitsecs + 30s) from §23 instead.
+
+## 5-Pass Grep Exclusions — tools/ and scripts/
+
+**Trigger:** PHP projects containing `tools/`, `scripts/`, or `bin/` subdirectories with utility/migration PHP scripts not part of the runtime application.
+
+**Problem:** PHP files in `tools/`, `scripts/`, and `bin/` often contain admin utilities, data migration scripts, or CI helpers that reference env vars not relevant to the production deployment. Including them inflates ENV_VARIABLES.md with non-operational vars.
+
+**Detection:**
+```bash
+find . -type d \( -name tools -o -name scripts -o -name bin \) -not -path '*/vendor/*' 2>/dev/null
+```
+
+**Rule:** Add `--exclude-dir=tools --exclude-dir=scripts` to all 5-pass grep commands when these directories contain non-runtime utility scripts. Inspect first: if `tools/` contains code that runs in production (e.g., cron scripts), include it. If it contains one-off migration/setup scripts, exclude it.
+
+**Verification:** After excluding, confirm no production-critical env vars were dropped by cross-referencing against `config/` directory env() calls.
+
+## Undefined Constants Detection Before Three-Tier Fallback
+
+**Trigger:** PHP applications using `define()` constants for configuration, where the three-tier fallback (`getenv() ?: CONSTANT ?: default`) references constants that may not be defined in all execution contexts.
+
+**Problem:** When migrating from `define('DB_HOST', 'localhost')` to `getenv('DB_HOST') ?: DB_HOST`, the constant `DB_HOST` may not exist in CLI/CronJob context (where the config file defining it isn't loaded), causing a fatal "undefined constant" error.
+
+**Detection (run BEFORE applying three-tier fallback):**
+```bash
+# Find all define() constants in config files
+grep -rhoP "define\(['\"]([A-Z][A-Z0-9_]+)" . --include='*.php' --exclude-dir=vendor | sort -u > /tmp/defined_constants.txt
+
+# Find all bare constant references in the target file
+grep -oP '\b[A-Z][A-Z0-9_]{2,}\b' target_file.php | sort -u > /tmp/used_constants.txt
+
+# Check which used constants are NOT defined in any scanned file
+comm -23 /tmp/used_constants.txt /tmp/defined_constants.txt
+```
+
+**Rule:** Before applying the three-tier fallback pattern to any constant, verify the constant is defined in ALL execution contexts (web, CLI, CronJob). If not, use `defined('CONST') ? CONST : 'default'` as the second tier, or skip the constant tier entirely and use `getenv('VAR') ?: 'default'` (two-tier).
+
+**Safe two-tier pattern (when constant may not exist):**
+```php
+$dbHost = getenv('DB_HOST') ?: 'localhost';
+// NOT: getenv('DB_HOST') ?: DB_HOST ?: 'localhost'  (fatal if DB_HOST undefined)
+```
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/python-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/python-patterns.md
@@ -1,0 +1,1574 @@
+# Python Patterns Reference
+
+Python-specific containerisation gotchas for Phase 2 transformation. Applies when `requirements.txt`, `setup.py`, `pyproject.toml`, or `Pipfile` is present.
+
+## Table of Contents
+
+1. [Python Test Execution Environment](#python-test-execution-environment)
+2. [Tool Failure Recovery (General)](#tool-failure-recovery-general)
+3. [botocore DataNotFoundError](#botocore-datanotfounderror)
+4. [Python Environment Pre-flight](#python-environment-pre-flight)
+5. [C Extension System Dependencies](#c-extension-system-dependencies)
+6. [Dockerfile Non-Root User Ordering](#dockerfile-non-root-user-ordering)
+7. [venv vs System Prefix Docker Builds](#venv-vs-system-prefix-docker-builds)
+8. [Shared Library for Multi-Image Projects](#shared-library-for-multi-image-projects)
+9. [BytesIO.fileno() Trap](#bytesiofileno-trap)
+10. [Module-Level os.environ Reads](#module-level-osenviron-reads)
+11. [SIGTERM Background+Wait Pattern](#sigterm-backgroundwait-pattern)
+12. [Heredoc Quoting in Entrypoints](#heredoc-quoting-in-entrypoints)
+13. [Health Check HTTP 4xx Handling](#health-check-http-4xx-handling)
+14. [Celery Beat Writable Paths](#celery-beat-writable-paths)
+15. [Celery Beat DB Egress](#celery-beat-db-egress)
+16. [Celery config_from_object Ordering](#celery-config_from_object-ordering)
+17. [Celery Fork-Safety](#celery-fork-safety)
+18. [Flask Blueprint Probe Discovery](#flask-blueprint-probe-discovery)
+19. [Flask-Session Init Order](#flask-session-init-order)
+20. [Session Management Patterns](#session-management-patterns)
+21. [Flask/Django Decomposition Heuristics](#flaskdjango-decomposition-heuristics)
+22. [Pydantic-Settings BaseSettings](#pydantic-settings-basesettings)
+23. [APScheduler Async Compatibility](#apscheduler-async-compatibility)
+24. [Probe Path Authentication Bypass](#probe-path-authentication-bypass)
+25. [Dockerfile Ordering Verification](#dockerfile-ordering-verification)
+26. [pip install --no-deps Dependency Scan](#pip-install-no-deps-dependency-scan)
+27. [Gunicorn preload_app Companion Rule](#gunicorn-preload_app-companion-rule)
+28. [Two-Pass Env Var Discovery Mandate](#two-pass-env-var-discovery-mandate)
+29. [Dockerfile Non-Root UID Pinning](#dockerfile-non-root-uid-pinning)
+30. [Post-Migration Dead Config Key Removal](#post-migration-dead-config-key-removal)
+31. [Lazy Import Detection in Function Bodies](#lazy-import-detection-in-function-bodies)
+32. [Exec Probe sys.path.insert Pattern](#exec-probe-syspathinsert-pattern)
+33. [pytest Configuration and Compatibility](#pytest-configuration-and-compatibility)
+34. [DB Connector Secondary Config Reads](#db-connector-secondary-config-reads)
+35. [WSGI Environ False-Positive Exclusion](#wsgi-environ-false-positive-exclusion)
+
+---
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify Python source compiles without syntax errors, dependencies resolve, and imports succeed — all BEFORE `docker build`.
+
+### Commands
+```bash
+# 1. Compile-check all Python files (excluding venv/site-packages)
+find . -name '*.py' -not -path '*/.venv/*' -not -path '*/site-packages/*' -not -path '*/__pycache__/*' | xargs python3 -m py_compile 2>&1
+# Expected: empty output (no errors). Any output = FAIL.
+
+# 2. Dependency install (verify resolution)
+pip install -r requirements.txt --dry-run 2>&1 || pip install -r requirements.txt 2>&1
+# Expected: exit 0
+
+# 3. Import check (verify main module loads)
+python3 -c "import importlib; importlib.import_module('<main_package>')" 2>&1
+# Expected: exit 0
+
+# 4. Unit tests (infrastructure-excluded)
+python3 -m pytest -m 'not integration and not db' -x --tb=short 2>&1 || true
+# Exit 0 = PASS; infrastructure failures = CONDITIONAL PASS; import errors = FAIL
+```
+
+### Expected Output
+- Step 1: Zero lines of output (all files compile)
+- Step 2: Exit 0 with all packages resolved
+- Step 3: Exit 0 (main module imports successfully)
+- Step 4: Exit 0 or infrastructure-only failures
+
+### CONDITIONAL PASS Triggers
+- `python3` not installed and `mise install python` fails → CONDITIONAL PASS
+- Python version mismatch (e.g., project requires 3.11, host has 3.9) → CONDITIONAL PASS
+- C-extension build failure (missing system libs like `libpq-dev`) → CONDITIONAL PASS
+- Network timeout on pip download (after 1 retry) → CONDITIONAL PASS
+
+### Toolchain Bootstrap
+```bash
+# Check Python availability
+command -v python3 && python3 --version
+# If absent or wrong version, try mise
+command -v mise && mise install python 2>/dev/null
+export PATH=$HOME/.local/share/mise/shims:$PATH
+python3 --version
+# Verify pip
+python3 -m pip --version || python3 -m ensurepip --upgrade
+```
+
+### Validated Example Repositories
+- **Trac** (trac.edgewall.org): `py_compile` passes on all source files; multi-top-level-package structure (trac/, tracopt/, contrib/). Validated 2026-06.
+
+
+## Python Test Execution Environment
+
+Multi-Python environments (mise, pyenv, system Python coexisting) cause ABI mismatches when pytest loads C-extension modules compiled for a different Python version.
+
+**Interpreter Discovery**:
+```bash
+pip3 show pytest | grep Location
+```
+
+**pip3/python3 interpreter split detection**: If `pip3` points to a different Python than `python3`, packages install to the wrong site-packages. Verify:
+```bash
+python3 -c "import sys; print(sys.executable)"
+pip3 --version  # Check path matches
+```
+
+**Canonical invocation** (mise-managed Python):
+```bash
+mise exec python@3.10 -- python3 -m pytest tests/ -x
+```
+
+**sys.path contamination detection**:
+```bash
+python3 -c "import sys; [print(p) for p in sys.path if 'site-packages' in p]"
+```
+
+**Correction**: Set `PYTHONNOUSERSITE=1`:
+```bash
+PYTHONNOUSERSITE=1 mise exec python@3.10 -- python3 -m pytest tests/
+```
+
+## Tool Failure Recovery (General)
+
+**HARD CAP**: If ANY tool (pytest, pip, boto3, celery, gunicorn, or any other) fails after **2 resolution attempts**, record `tool-blocked: <tool> — <error summary>` in the task report and proceed without that tool. Do NOT iterate further.
+
+Resolution attempt = one of:
+- Switching interpreter or tool version
+- Setting environment variables (PYTHONNOUSERSITE, PATH, etc.)
+- Reinstalling packages (`pip install --force-reinstall`)
+- Adjusting PATH/PYTHONPATH/sys.path
+
+**Specific patterns that trigger immediate fail-fast (no retry needed):**
+- `botocore.exceptions.DataNotFoundError` → packaging error, not transient
+- `ModuleNotFoundError` for packages that ARE in requirements.txt → ABI mismatch
+- Docker daemon connection errors → infrastructure issue
+
+## botocore DataNotFoundError
+
+`botocore.exceptions.DataNotFoundError: Unable to load data for: endpoints` is a **botocore packaging error**, NOT a network/AWS connectivity problem.
+
+**Diagnosis**:
+```bash
+python3 -c "import botocore; print(botocore.__file__)"
+ls "$(python3 -c 'import botocore; import os; print(os.path.dirname(botocore.__file__))')/data/"
+```
+
+**Fix**:
+```bash
+pip install --force-reinstall botocore boto3
+```
+
+**HARD RULE: On DataNotFoundError, execute `exit 1` immediately — no sleep, no retry, no delay.** This is a local packaging issue (incorrect path calculation), not a transient error.
+
+**Pre-flight gate** (run at task start for any Python project using AWS SDK):
+```bash
+python3 -c 'import botocore.data; print("botocore data OK")' || { echo 'FATAL: botocore DataNotFoundError — packaging error, non-transient'; exit 1; }
+```
+
+**Source:** https://stackoverflow.com/questions/71533781/botocore-exceptions-datanotfounderror-unable-to-load-data-for-sqs — "This unusual series of events is what triggers the DataNotFoundError exception because, indeed, botocore cannot load the service definition data (because it has calculated an incorrect path for it)."
+
+## Python Environment Pre-flight
+
+Run at the START of any Python project migration task:
+
+```bash
+# 1. Identify active Python
+which python3 && python3 --version
+# 2. Check for version manager
+which mise && mise current python 2>/dev/null
+which pyenv && pyenv version 2>/dev/null
+# 3. Verify no sys.path contamination
+python3 -c "import sys; mixed=[p for p in sys.path if 'site-packages' in p]; print('\n'.join(mixed))"
+# 4. Verify boto3/botocore are loadable (if AWS SDK needed)
+python3 -c "import boto3; print(boto3.__version__)" 2>&1 || echo "boto3 not available"
+```
+
+## C Extension System Dependencies
+
+| Python Package | System Packages (Debian/Ubuntu) | Notes |
+|---|---|---|
+| `python-ldap` | `libldap2-dev`, `libsasl2-dev` | Also needs `gcc` |
+| `psycopg2` | `libpq-dev` | Use `psycopg2-binary` to avoid |
+| `mysqlclient` | `default-libmysqlclient-dev` | Also needs `gcc`, `pkg-config` |
+| `Pillow` | `libjpeg-dev`, `libpng-dev`, `zlib1g-dev` | Optional: `libtiff-dev`, `libwebp-dev` |
+| `lxml` | `libxml2-dev`, `libxslt1-dev` | |
+| `cryptography` | `libssl-dev`, `libffi-dev` | Rust toolchain for some versions |
+| `pylibmc` | `libmemcached-dev`, `zlib1g-dev` | |
+| `cffi` | `libffi-dev` | Often pulled as transitive dep |
+| `numpy` / `scipy` | `gfortran`, `libopenblas-dev` | Pre-built wheels usually avoid |
+| `greenlet` | `gcc` | Transitive from SQLAlchemy |
+| `grpcio` | `gcc`, `g++` | Can use pre-built wheel |
+| `xmlsec` | `libxmlsec1-dev`, `pkg-config` | For SAML/SSO |
+
+**Detection command:**
+```bash
+grep -iE '^(python-ldap|psycopg2|mysqlclient|Pillow|lxml|cryptography|pylibmc|cffi|numpy|scipy|greenlet|grpcio|xmlsec)' requirements.txt
+```
+
+## Dockerfile Non-Root User Ordering
+
+**CRITICAL**: `RUN useradd` MUST appear BEFORE any `COPY --chown=<user>` directive.
+
+```dockerfile
+# CORRECT ordering:
+FROM python:3.12-slim
+RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+COPY --chown=appuser:appuser requirements.txt /app/
+COPY --chown=appuser:appuser . /app/
+USER appuser
+```
+
+**Alpine variant**: `RUN addgroup -S appuser && adduser -S -G appuser -h /app appuser`
+
+## venv vs System Prefix Docker Builds
+
+**Approach 1: venv (recommended for multi-stage)**
+```dockerfile
+FROM python:3.12-slim AS builder
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.12-slim
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+COPY . /app
+```
+
+## Shared Library for Multi-Image Projects
+
+When multiple Docker images share config, models, storage modules:
+
+```dockerfile
+COPY common/ /build/common/
+RUN pip install /build/common/
+COPY web/ /app/
+```
+
+## BytesIO.fileno() Trap
+
+`io.BytesIO` does NOT support `fileno()`:
+
+```python
+# BAD:
+size = os.fstat(fd.fileno()).st_size
+# GOOD:
+size = len(data)  # or buffer.getbuffer().nbytes
+```
+
+## Module-Level os.environ Reads
+
+Module-level assignments execute at import time — before runtime setup:
+
+```python
+# BAD in utility modules:
+DATABASE_URL = os.environ.get('DATABASE_URL', 'sqlite:///db.sqlite3')
+
+# GOOD: lazy evaluation
+def get_database_url():
+    return os.environ.get('DATABASE_URL', 'sqlite:///db.sqlite3')
+```
+
+**Rule**: Module-level env reads are fine in settings entry point (Django `settings.py`). Problematic in utility modules imported before environment is configured.
+
+## SIGTERM Background+Wait Pattern
+
+```python
+import signal, sys
+
+def sigterm_handler(signum, frame):
+    worker.stop()
+    worker.join(timeout=25)
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, sigterm_handler)
+```
+
+**For gunicorn/uvicorn**: These handle SIGTERM natively — do NOT add custom handler. Configure `--graceful-timeout 25`.
+
+**Exception clause**: If a task explicitly requires a SIGTERM handler despite gunicorn/uvicorn native handling (e.g., background thread cleanup, custom metrics flush), add the handler with a `# MIGRATION: custom SIGTERM alongside gunicorn post-fork override` comment explaining that gunicorn will still handle worker lifecycle but this handler covers application-level cleanup. Safe to include in both deployment modes.
+
+## Heredoc Quoting in Entrypoints
+
+```bash
+# CORRECT: unquoted delimiter — variables expand at runtime
+cat > /app/config.ini <<EOF
+host = ${DB_HOST}
+EOF
+
+# WRONG for os.environ-reading embedded scripts — use QUOTED to prevent shell expansion:
+cat > /app/run.py <<'EOF'
+import os
+host = os.environ.get('DB_HOST')
+EOF
+```
+
+**Rule**: Use unquoted `<<EOF` when the heredoc content needs shell variable expansion. Use quoted `<<'EOF'` when the content is a script (Python, Ruby) that will read env vars itself at runtime — prevents the shell from expanding `$VAR` during write.
+
+## Health Check HTTP 4xx Handling
+
+```python
+# Django — exempt health endpoint from auth middleware
+urlpatterns = [path('healthz', health_check)]
+
+def health_check(request):
+    return JsonResponse({'status': 'ok'})
+```
+
+**Rule**: Health check endpoints MUST return 200 without authentication.
+
+## Celery Beat Writable Paths
+
+Celery Beat with `readOnlyRootFilesystem: true` requires writable paths for schedule and PID files:
+
+```bash
+# Always pass explicit paths to writable locations
+celery -A app beat --schedule=/tmp/celerybeat-schedule --pidfile=/tmp/celerybeat.pid
+```
+
+**emptyDir requirements:**
+| Path | Purpose |
+|------|---------|
+| `/tmp` | Schedule file (`celerybeat-schedule`), PID file |
+
+**If `--pidfile` points outside `/tmp`** (e.g., `/var/run/celery/beat.pid`), mount a SECOND emptyDir at that path.
+
+**Detection:**
+```bash
+grep -rn 'beat\|Beat\|CELERYBEAT' . --include='*.py' --include='*.cfg' --include='*.ini'
+grep -rn 'pidfile\|schedule' . --include='*.py' | grep -i beat
+```
+
+**Kubernetes manifest:**
+```yaml
+containers:
+- name: celery-beat
+  command: ["celery", "-A", "app", "beat", "--schedule=/tmp/celerybeat-schedule", "--pidfile=/tmp/celerybeat.pid"]
+  volumeMounts:
+  - name: tmp
+    mountPath: /tmp
+```
+
+## Celery Beat DB Egress
+
+Celery Beat with `django_celery_beat` needs egress to BOTH broker AND database:
+
+```yaml
+egress:
+- to: [{podSelector: {matchLabels: {app: redis}}}]
+  ports: [{port: 6379}]
+- to: [{podSelector: {matchLabels: {app: postgres}}}]
+  ports: [{port: 5432}]
+```
+
+## Celery config_from_object Ordering
+
+```python
+# BAD: explicit override after config_from_object wins silently
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.conf.broker_url = 'redis://localhost:6379'  # Breaks env var config!
+
+# GOOD: all Celery config in Django settings (prefixed CELERY_)
+```
+
+## Celery Fork-Safety
+
+Celery workers using `prefork` pool MUST NOT create database connections or Redis clients at module import time:
+
+```python
+# BAD: connection created before fork — shared file descriptor across children
+db = connect_to_db()
+
+@app.task
+def my_task():
+    db.execute(...)  # Corrupted across forked processes!
+
+# GOOD: connect inside task or use signal
+from celery.signals import worker_process_init
+
+@worker_process_init.connect
+def init_worker(**kwargs):
+    global db
+    db = connect_to_db()  # Fresh connection per child
+```
+
+**Detection:**
+```bash
+grep -n 'connect\|create_engine\|Redis(' . --include='*.py' | grep -v 'def \|#\|@'
+```
+
+## Flask Blueprint Probe Discovery
+
+Flask applications register health endpoints on Blueprints. Probe path must match the Blueprint URL prefix:
+
+```python
+# If health blueprint is registered as:
+app.register_blueprint(health_bp, url_prefix='/api')
+# Then probe path is /api/healthz, NOT /healthz
+```
+
+**Detection:**
+```bash
+grep -rn 'register_blueprint\|@.*route.*health\|@.*route.*ready' . --include='*.py'
+```
+
+## Flask-Session Init Order
+
+Flask-Session 0.8.x requires session interface initialization AFTER app config is set:
+
+```python
+# CORRECT order:
+app = Flask(__name__)
+app.config['SESSION_TYPE'] = os.environ.get('SESSION_TYPE', 'redis')
+app.config['SESSION_REDIS'] = redis.from_url(os.environ.get('REDIS_URL', 'redis://localhost:6379'))
+Session(app)  # MUST be after config
+
+# WRONG: Session() before config → falls back to NullSession
+Session(app)
+app.config['SESSION_TYPE'] = 'redis'  # Too late!
+```
+
+## Session Management Patterns
+
+**Django:**
+```python
+# Check current session engine BEFORE adding Redis
+# settings.py
+SESSION_ENGINE = 'django.contrib.sessions.backends.db'  # Already DB-backed → Redis NOT needed
+# OR
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'  # Needs Redis
+```
+
+**Flask:**
+```python
+# Default Flask sessions are client-side signed cookies — already stateless!
+# Only add server-side sessions if storing large session data
+```
+
+**Rule**: DB-backed sessions are already distributed (survive pod restart, work across replicas). Only migrate to Redis if: (1) session reads are a DB performance bottleneck, OR (2) sessions are file-based/in-memory.
+
+## Flask/Django Decomposition Heuristics
+
+### Flask Blueprint → Service Mapping
+Each Blueprint with its own `models.py` is a bounded context candidate:
+```bash
+find . -name 'models.py' -path '*/blueprints/*' -o -name 'models.py' -path '*/modules/*'
+```
+
+### Django App → Service Mapping
+Each app in `INSTALLED_APPS` with its own `models.py`:
+```bash
+grep -oP "'\K[^']+(?=')" project/settings.py | grep -v django | grep -v rest_framework
+```
+
+### SESSION_DRIVER=redis as Decomposition Blocker
+If sessions use Redis with a shared keyspace, decomposition requires either:
+1. Per-service Redis namespace: `REDIS_KEY_PREFIX=svc_name:`
+2. JWT migration: Replace server-side sessions with stateless JWT tokens
+
+### Django Signal Decoupling for Service Extraction
+Before extracting SearchService, replace synchronous signals with async:
+```python
+# BEFORE (blocking):
+@receiver(post_save, sender=Article)
+def update_search_index(sender, instance, **kwargs):
+    elasticsearch.index(instance)
+
+# AFTER (async):
+@receiver(post_save, sender=Article)
+def queue_search_index(sender, instance, **kwargs):
+    index_article.delay(instance.pk)
+```
+
+## Pydantic-Settings BaseSettings
+
+**Problem**: pydantic-settings `BaseSettings` declares env vars as class field names, invisible to standard `os.environ`/`getenv` grep.
+
+**Detection**:
+```bash
+grep -rn 'class.*BaseSettings' . --include='*.py'
+```
+
+**SettingsConfigDict kwargs exclusion**: When using `model_config = SettingsConfigDict(env_prefix='APP_', ...)`, the kwargs (`env_prefix`, `env_file`, `case_sensitive`, `env_nested_delimiter`, etc.) are NOT env var names. Exclude these from the inventory:
+```bash
+# WRONG — includes SettingsConfigDict kwargs as false env vars
+grep -A50 'class.*BaseSettings' settings.py | grep -oP '^\s+([a-z][a-z0-9_]+)\s*[:=]'
+# CORRECT — exclude model_config line and its kwargs
+grep -A50 'class.*BaseSettings' settings.py | grep -v 'model_config\|SettingsConfigDict' | grep -oP '^\s+([a-z][a-z0-9_]+)\s*[:=]'
+```
+
+**Two-pass inventory**:
+```bash
+# Pass 1: Field names from BaseSettings subclass (these ARE env var names, uppercased)
+grep -A50 'class.*BaseSettings' . --include='*.py' | grep -v 'model_config\|SettingsConfigDict\|class_validator\|field_validator' | grep -oP '^\s+([a-z][a-z0-9_]+)\s*[:=]' | tr -d ' :=' | tr '[:lower:]' '[:upper:]' | sort -u
+
+# Pass 2: Usage grep for settings.FIELD_NAME
+grep -rn 'settings\.\|config\.' . --include='*.py' | grep -oP '\.((?:[A-Z][A-Z0-9_]+|[a-z][a-z0-9_]+))' | sort -u
+```
+
+**Rule**: For pydantic-settings projects, field names (uppercased, with env_prefix if configured) ARE the env var names. Include these in ENV_VARIABLES.md even though no `os.environ.get()` call exists. Digit-inclusive pattern required: `[a-z][a-z0-9_]+`.
+
+## APScheduler Async Compatibility
+
+**BackgroundScheduler + async def → silent discard**: BackgroundScheduler runs jobs in a thread pool. Async functions are called but the coroutine is **never awaited** — jobs silently produce no effect.
+
+**Fix**: Use `AsyncIOScheduler` for async job functions.
+
+**Horizontal scaling trap**: Any in-process scheduler + HPA → N-fold job duplication. Extract to Kubernetes CronJob with `concurrencyPolicy: Forbid`.
+
+**Detection**:
+```bash
+grep -rn 'BackgroundScheduler\|AsyncIOScheduler\|APScheduler' . --include='*.py'
+```
+
+## APScheduler Sub-Minute Interval CronJob Conversion
+
+**Trigger:** APScheduler using `IntervalTrigger` with intervals less than 60 seconds (e.g., `IntervalTrigger(seconds=30)`).
+
+**Problem:** Kubernetes CronJob minimum granularity is 1 minute (`* * * * *`). Sub-minute intervals cannot be expressed directly in `schedule:`.
+
+**Solution — activeDeadlineSeconds approach:**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: high-frequency-task
+spec:
+  schedule: "* * * * *"  # Every minute — K8s minimum granularity
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 55  # Kill before next minute's job starts
+      template:
+        spec:
+          containers:
+          - name: worker
+            command: ["python3", "-c", "from app.tasks import run_task; run_task()"]
+```
+
+**Alternative — loop-within-container for true sub-minute:**
+```python
+# CronJob entry point for 30-second intervals
+import time, signal, sys
+
+def handler(sig, frame): sys.exit(0)
+signal.signal(signal.SIGTERM, handler)
+
+while True:
+    run_task()
+    time.sleep(30)
+    if time.time() % 60 > 55:  # Exit before next CronJob instance
+        break
+```
+
+**Rule:** For sub-minute intervals, schedule CronJob at `* * * * *` with `activeDeadlineSeconds` set to less than 60 seconds. Document the original interval in a YAML comment: `# Original: APScheduler IntervalTrigger(seconds=30)`. Remove the APScheduler `add_job()` call from the primary Deployment source after extraction.
+
+## Probe Path Authentication Bypass
+
+**Problem:** Python web frameworks often apply auth middleware globally. Probe paths that require authentication return 401/403/500, causing pods to never become Ready.
+
+**Django — exempt from LoginRequiredMiddleware:**
+```python
+from django.urls import path
+from django.views.decorators.http import require_GET
+
+@require_GET
+def healthz(request):
+    return JsonResponse({'status': 'ok'})
+
+# In urls.py — place BEFORE any auth-catchall:
+urlpatterns = [
+    path('healthz', healthz),  # No login_required decorator
+    # ... other paths
+]
+```
+
+**Flask — before login manager:**
+```python
+@app.route('/healthz')
+def healthz():
+    return jsonify(status='ok')
+# Ensure this route is registered BEFORE @login_required is applied globally
+```
+
+**Trac/WSGI — admin paths require auth:**
+When using Trac or similar WSGI apps, do NOT use `/login` or any path that triggers auth middleware as a probe target. Use a static resource or dedicated health endpoint instead.
+
+**Rule**: Always verify chosen probe path returns HTTP 2xx without credentials. Test with: `curl -s -o /dev/null -w '%{http_code}' http://localhost:PORT/healthz`
+
+## Dockerfile Ordering Verification
+
+When verifying Dockerfile instruction ordering, strip comments first to avoid MIGRATION comment false positives:
+
+```bash
+# GOOD: strip comments, then check ordering
+grep -v '^\s*#' Dockerfile | grep -n '^FROM\|^RUN\|^COPY\|^USER'
+
+# BAD: MIGRATION comments match instruction names
+grep -n 'FROM\|RUN\|COPY\|USER' Dockerfile
+```
+
+**Rule**: When asserting instruction ordering (e.g., USER after COPY --chown), always filter through `grep -v '^\s*#'` first.
+
+## pip install --no-deps Dependency Scan
+
+**Trigger:** Dockerfile uses `pip install --no-deps` for the application package (common when building from setup.cfg/pyproject.toml to avoid re-downloading pinned deps).
+
+**Problem:** `--no-deps` requires ALL `install_requires` / `[project] dependencies` to be pre-installed separately. Missing dependencies cause `ImportError` at container startup with no build-time signal.
+
+**Detection:**
+```bash
+grep -n '\-\-no-deps' Dockerfile
+```
+
+**Pre-write scan — before writing the Dockerfile RUN pip install line:**
+```bash
+# For setup.cfg:
+sed -n '/^\[options\]/,/^\[/{ /install_requires/,/^[^ ]/p }' setup.cfg | grep -v '^\[' | grep -v '^install_requires' | sed 's/[<>=!].*//' | tr -d ' '
+
+# For pyproject.toml:
+sed -n '/^\[project\]/,/^\[/{/^dependencies/,/^\]/p}' pyproject.toml | grep -v '^\[' | grep -v '^dependencies' | sed 's/[<>=!].*//' | tr -d ' "'
+```
+
+**Rule:** For each active (non-conditional, non-extra) dependency in the list that is NOT already in the explicit `pip install` pre-install line, add it. Missing deps cause `ImportError` at container startup.
+
+**Verification:**
+```bash
+# After building, verify all deps resolve:
+pip check 2>&1 | grep -v 'No broken requirements'
+# Or inside container:
+python3 -c "import pkg_resources; pkg_resources.require(open('setup.cfg').read())"
+```
+
+## Gunicorn preload_app Companion Rule
+
+**Trigger:** Flask/Django applications using gunicorn with `preload_app = True` in `gunicorn.conf.py`.
+
+**Problem:** When `preload_app = True` is set, gunicorn loads the app once in the master process before forking workers. If you remove or modify gunicorn.conf.py during migration (e.g., extracting APScheduler, changing worker class), but leave `preload_app = True`, the app loads at master-fork time with the OLD configuration — workers see stale module-level state.
+
+**Companion steps when modifying gunicorn.conf.py:**
+1. If removing a scheduler (APScheduler) from the app, verify gunicorn.conf.py `on_starting`/`post_fork` hooks do NOT reference the removed scheduler module.
+2. If changing worker class (sync → gevent/uvicorn), verify `preload_app` is compatible with the new worker class.
+3. After any gunicorn.conf.py modification, verify the app still starts: `gunicorn --check-config -c gunicorn.conf.py app:create_app()` (or equivalent).
+
+**terminationGracePeriodSeconds alignment:**
+```yaml
+# gunicorn.conf.py
+graceful_timeout = 120  # seconds gunicorn waits for workers to finish
+timeout = 120
+
+# kubernetes manifest
+terminationGracePeriodSeconds: 125  # graceful_timeout + 5
+```
+
+**Rule:** `terminationGracePeriodSeconds = gunicorn graceful_timeout + 5`. The default ≥30s floor is a minimum — if gunicorn's graceful_timeout exceeds 25s, the K8s value must be higher.
+
+**Detection:**
+```bash
+grep -n 'preload_app\|graceful_timeout\|timeout\|on_starting\|post_fork' gunicorn.conf.py gunicorn_config.py 2>/dev/null
+```
+
+**Dead import after extraction:** After extracting APScheduler or any module to a CronJob, grep gunicorn.conf.py for imports of the removed module — dead imports cause `ImportError` at gunicorn master startup.
+
+## Two-Pass Env Var Discovery Mandate
+
+**Trigger:** ALL Python projects during Sub-Phase §3 (Configuration Externalisation).
+
+**Problem:** Single-pass grep misses env vars read through framework-specific mechanisms (pydantic-settings, Flask config objects, Django settings.py chains, click.option with envvar=).
+
+**Mandatory two-pass procedure:**
+
+**Pass 1 — Standard os.environ/os.getenv:**
+```bash
+grep -rhoP "os\.environ(?:\.get)?\(?['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.py' | grep -oP '[A-Z][A-Za-z0-9_]+' | sort -u
+```
+
+**Pass 2 — Framework-specific:**
+```bash
+# pydantic-settings BaseSettings fields (uppercased = env var names)
+grep -A50 'class.*BaseSettings' . --include='*.py' | grep -oP '^\s+([a-z][a-z0-9_]+)\s*[:=]' | tr -d ' :=' | tr '[:lower:]' '[:upper:]' | sort -u
+
+# Flask config.from_envvar / app.config[]
+grep -rn 'from_envvar\|config\[' . --include='*.py' | grep -oP '[A-Z][A-Z0-9_]+' | sort -u
+
+# click.option(envvar=)
+grep -rn "envvar=" . --include='*.py' | grep -oP "envvar=['\"]([A-Z][A-Z0-9_]+)" | grep -oP '[A-Z][A-Z0-9_]+' | sort -u
+```
+
+**Rule:** Both passes MUST run before writing ENV_VARIABLES.md. Diff results against ENV_VARIABLES.md within the same task — never defer.
+
+## Dockerfile Non-Root UID Pinning
+
+**Problem:** `useradd -r` (system account) or `adduser --system` allocates a dynamic UID in the 100-999 range. When the Kubernetes manifest specifies `runAsUser: 1000`, the container starts as a different user than the file owner — causing permission denied errors.
+
+**WRONG:**
+```dockerfile
+RUN useradd -r appuser
+```
+
+**CORRECT:**
+```dockerfile
+RUN groupadd -r appgroup && useradd -r -g appgroup --uid 1000 appuser
+```
+
+**Alpine variant:**
+```dockerfile
+RUN addgroup -S appgroup && adduser -S -G appgroup -u 1000 appuser
+```
+
+**Pre-Dockerfile audit:**
+```bash
+grep -n 'useradd\|adduser' Dockerfile | grep -v -- '--uid\|-u 1000'
+# Any match = UID mismatch risk
+```
+
+**Rule:** ALWAYS specify `--uid 1000` (or the exact UID matching `runAsUser` in the manifest). Never rely on system-allocated UIDs.
+
+## Post-Migration Dead Config Key Removal
+
+**Trigger:** After extracting a component (APScheduler, Celery, Redis sessions) to a separate CronJob or removing it entirely.
+
+**Problem:** Config keys for the removed component remain in application config files (settings.py, .env, gunicorn.conf.py). These dead keys cause:
+- `ImportError` if they trigger lazy imports of removed packages
+- Misleading ENV_VARIABLES.md entries for variables no longer consumed
+- Docker build failures if removed packages are no longer in requirements.txt
+
+**Procedure:**
+1. List all config keys associated with the removed component.
+2. Grep source for each key: `grep -rn 'REMOVED_KEY' . --include='*.py' --include='*.cfg' --include='*.ini'`
+3. For each match NOT in test files: remove or comment out.
+4. Update ENV_VARIABLES.md: remove rows for keys no longer consumed by any source file.
+5. Verify: `python3 -c "import app"` (or equivalent) — no ImportError.
+
+**Detection:**
+```bash
+# After removing a package from requirements.txt, find residual references:
+REMOVED_PKG="apscheduler"  # example
+grep -rn "$REMOVED_PKG" . --include='*.py' --include='*.cfg' | grep -v 'requirements\|test'
+```
+
+## YAML Block Scalar + Heredoc Alignment
+
+**Trigger:** Python entrypoint scripts or ConfigMap data values that use YAML block scalar (`|`) syntax containing heredoc-like content or multi-line commands.
+
+**Problem:** YAML `|` (literal block scalar) preserves all newlines and indentation relative to the block's indentation level. If the heredoc delimiter inside the block scalar is not aligned correctly relative to the YAML indentation, the script fails with "unexpected end of file" or "here-document delimited by end-of-file".
+
+**WRONG — misaligned delimiter:**
+```yaml
+data:
+  entrypoint.sh: |
+    #!/bin/bash
+    cat > /app/config.ini <<EOF
+    host = ${DB_HOST}
+    port = ${DB_PORT}
+EOF
+```
+The `EOF` terminator must be at column 0 of the heredoc, but YAML preserves leading spaces. The above renders as `    EOF` in the actual file (indented), which doesn't match the unindented `<<EOF` delimiter.
+
+**CORRECT — use <<-EOF with tab indent, or dedent the delimiter:**
+```yaml
+data:
+  entrypoint.sh: |
+    #!/bin/bash
+    cat > /app/config.ini <<EOF
+    host = ${DB_HOST}
+    port = ${DB_PORT}
+    EOF
+```
+Here `EOF` is at the same indentation level as the heredoc content inside the YAML block scalar, so the rendered file has the delimiter aligned with the content.
+
+**Alternative — avoid heredocs entirely:**
+```yaml
+data:
+  entrypoint.sh: |
+    #!/bin/bash
+    printf '[app]\nhost = %s\nport = %s\n' "$DB_HOST" "$DB_PORT" > /app/config.ini
+```
+
+**Rule:** When embedding shell heredocs inside YAML `|` block scalars, ensure the terminating delimiter appears at exactly the indentation level the shell expects (typically column 0 of the heredoc, which means it should be at the same YAML indent as the heredoc content lines). Prefer `printf` or `envsubst` over heredocs in YAML-embedded scripts to avoid alignment issues.
+
+**Detection:**
+```bash
+# Find YAML block scalars containing heredoc markers
+grep -n '<<' kubernetes/*.yaml | grep -v '^\s*#'
+```
+
+
+
+## Lazy Import Detection in Function Bodies
+
+**Problem:** Standard top-of-file grep (`grep -rn '^import\|^from.*import'`) misses imports inside function bodies. Python allows imports anywhere — lazy imports inside functions are invisible to top-level dependency analysis.
+
+**When to run:** During dependency analysis (Sub-Phase §3) and env var enumeration.
+
+**Detection — two-pass approach:**
+```bash
+# Pass 1: Top-level imports (standard)
+grep -rn '^import \|^from .* import' . --include='*.py' | grep -v test | grep -v __pycache__
+
+# Pass 2: Lazy imports inside function bodies (indented import statements)
+grep -rn '^\s\+import \|^\s\+from .* import' . --include='*.py' | grep -v test | grep -v __pycache__
+```
+
+**Why it matters:**
+- Lazy imports can pull in modules that read env vars at import time
+- Dependency analysis for Dockerfile `pip install` completeness must include lazily-imported packages
+- CronJob extraction may miss connection-eager modules imported lazily
+
+**Common patterns:**
+```python
+def process_upload(file):
+    import boto3  # Lazy import — only loaded when function is called
+    s3 = boto3.client('s3')
+    s3.upload_fileobj(file, os.environ['S3_BUCKET'], file.filename)
+```
+
+**Rule:** After the standard top-level import grep, always run the indented-import grep (Pass 2). Include all lazily-imported packages in requirements.txt and Dockerfile dependency analysis.
+
+## Exec Probe sys.path.insert Pattern
+
+**Purpose:** For Python applications that don't expose an HTTP endpoint (workers, CLI tools), provide an exec probe using `python -c` with `sys.path.insert` to verify the application module is importable.
+
+**Probe configuration:**
+```yaml
+livenessProbe:
+  exec:
+    command:
+      - python3
+      - -c
+      - "import sys; sys.path.insert(0, '/app'); import app; print('OK')"
+  initialDelaySeconds: 10
+  periodSeconds: 30
+```
+
+**When to use:**
+- Worker Deployments without HTTP endpoints
+- CronJob containers where HTTP probes are not applicable
+- Any container where the primary health signal is "Python module imports successfully"
+
+**Variations:**
+```yaml
+# Django management check
+command: ["python3", "manage.py", "check", "--deploy"]
+
+# Celery worker ping
+command: ["celery", "-A", "app", "inspect", "ping", "-t", "5"]
+
+# Generic module import
+command: ["python3", "-c", "import sys; sys.path.insert(0, '/app'); from app.worker import main"]
+```
+
+**Rule:** For Python worker containers without HTTP, use exec probe with module import verification. The `sys.path.insert(0, '/app')` pattern handles cases where WORKDIR is not on `sys.path` (common with `COPY . /app` Dockerfiles).
+
+## pytest Configuration and Compatibility
+
+**Problem:** pytest configuration issues cause test failures that are unrelated to migration quality. Common issues: iniconfig version conflicts, test file discovery patterns, and fixture paths.
+
+**iniconfig 2.x compatibility:**
+```bash
+# Check for iniconfig conflicts
+pip show iniconfig | grep Version
+# If < 2.0 and pytest >= 7.2, upgrade:
+pip install 'iniconfig>=2.0'
+```
+
+**Test file discovery — python_files pattern:**
+```ini
+# pytest.ini or pyproject.toml [tool.pytest.ini_options]
+python_files = [!_]*.py
+# This EXCLUDES files starting with underscore (like __init__.py) from test collection
+# Without this, pytest may try to collect __init__.py as a test module
+```
+
+**Common test-run failures and fixes:**
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `ModuleNotFoundError` during collection | sys.path doesn't include project root | Add `pythonpath = .` to pytest.ini |
+| `fixture not found` | conftest.py not in test path | Verify conftest.py location matches rootdir |
+| `iniconfig.IniConfig` import error | Version mismatch | `pip install --upgrade iniconfig` |
+| `PytestUnknownMarkWarning` | Custom markers not registered | Add `markers =` section to pytest.ini |
+
+**Amazon Linux / minimal containers — system Python lacks pip:**
+```bash
+# If pip3 is not available:
+python3 -m ensurepip --upgrade 2>/dev/null || curl -sSL https://bootstrap.pypa.io/get-pip.py | python3
+```
+
+**Rule:** Before running pytest in migration validation, verify: (1) pytest is importable (`python3 -m pytest --version`), (2) iniconfig version is compatible, (3) `pythonpath` is configured. Document test infrastructure issues as CONDITIONAL PASS with root cause — they are not migration failures.
+
+## DB Connector Secondary Config Reads
+
+**Problem:** Database connectors often have secondary configuration paths (backup, dump, migrate commands) that bypass the primary env-var-based configuration. These reads create credential exposures that are invisible to the standard env var grep.
+
+**Detection — find secondary config reads:**
+```bash
+# Look for backup/dump/migrate functions that may read credentials directly
+grep -rn 'backup\|dump\|migrate\|pg_dump\|mysqldump\|mongodump' . --include='*.py' | \
+  grep -v test | grep -v __pycache__ | grep -v node_modules
+
+# Check management commands for direct config reads
+grep -rn "get_connection\|connections\[" . --include='*.py' | grep -v test
+
+# Django management command credential reads
+grep -rn "settings\.DATABASES\|connection\.settings_dict" . --include='*.py'
+```
+
+**Common secondary read patterns:**
+
+```python
+# WRONG — backup command reads credentials directly from settings, not env
+def backup_database():
+    from django.conf import settings
+    db = settings.DATABASES['default']
+    cmd = f"pg_dump -h {db['HOST']} -U {db['USER']} {db['NAME']}"
+    # Credentials baked into command string!
+
+# CORRECT — use env vars consistently
+def backup_database():
+    cmd = f"pg_dump -h $DB_HOST -U $DB_USER $DB_NAME"
+    env = {
+        'PGPASSWORD': os.environ.get('DB_PASSWORD', ''),
+    }
+    subprocess.run(cmd, shell=True, env={**os.environ, **env})
+```
+
+**Rule:** After primary credential externalisation (Forms A–F), grep for backup/dump/migrate functions that construct connection strings or commands. These secondary paths must also read from env vars — not from Django settings or framework config objects that may retain hardcoded fallbacks.
+
+## Bare Underscore Gettext Shadow
+
+**Trigger:** Python files that use both tuple unpacking with `_` (throwaway variable) and `_()` for gettext/i18n translations.
+
+**Problem:** When a function uses `_` as a throwaway variable in tuple unpacking (e.g., `_, value = some_func()`), Python's lexical scoping marks `_` as a local variable for the entire function scope. Subsequent calls to `_("translatable string")` fail with `UnboundLocalError: local variable '_' referenced before assignment` because the gettext `_` is shadowed.
+
+**Detection:**
+```bash
+# Find files using both _ as throwaway AND _() for gettext
+grep -rln 'from gettext import\|_ = gettext\|import gettext' . --include='*.py' | while read f; do
+  grep -n '^\s.*,\s*_\s*=\|_,\s.*=' "$f" && echo "SHADOW RISK: $f"
+done
+```
+
+**WRONG:**
+```python
+from gettext import gettext as _
+
+def process():
+    _, value = get_pair()  # _ is now a local variable
+    return _("Success")   # UnboundLocalError!
+```
+
+**CORRECT:**
+```python
+from gettext import gettext as _
+
+def process():
+    _unused, value = get_pair()  # Use descriptive throwaway name
+    return _("Success")          # gettext _ works correctly
+```
+
+**Rule:** In any function that calls `_()` for translations, NEVER use bare `_` as a throwaway variable. Use `_unused`, `_dummy`, or a descriptive name instead.
+
+## mise Interpreter-Split Diagnosis
+
+**Trigger:** pytest `ModuleNotFoundError` for packages confirmed in `requirements.txt`, in environments managed by `mise` (formerly `rtx`).
+
+**Problem:** When `mise` manages Python versions, `pip3` and `python3` may resolve to DIFFERENT interpreters. Packages installed via `pip3` go to one site-packages while `python3 -m pytest` looks in another.
+
+### Toolchain Bootstrap Fallback (Tier 2)
+
+When `pip3 --version` and `python3 -c "import sys; print(sys.executable)"` show different paths (interpreter split), identify a Python binary that has both interpreter and pip available, consistent across the execution environment. Use that resolved binary path for all subsequent pip and pytest invocations to ensure consistent site-packages resolution.
+
+**Detection:**
+```bash
+# Check if pip3 and python3 point to same interpreter
+pip3 --version  # Shows which python and path
+python3 -c "import sys; print(sys.executable)"
+# If paths differ → interpreter split
+```
+
+**Fix:**
+```bash
+# Always use mise exec to ensure consistent interpreter
+mise exec python@3.10 -- python3 -m pip install -r requirements.txt
+mise exec python@3.10 -- python3 -m pytest tests/
+```
+
+**Rule:** When `mise` is detected (`command -v mise`), ALWAYS prefix Python commands with `mise exec python@<version> --`. Never use bare `pip3` or `python3` — they may resolve to system Python, not the mise-managed version.
+
+## pip install Source-File COPY in Dockerfile
+
+**Trigger:** Dockerfile using `pip install .` or `pip install -e .` to install the application package from `pyproject.toml` or `setup.cfg`.
+
+**Problem:** `pip install .` reads the package metadata (pyproject.toml/setup.cfg) AND the source files listed in `packages` or auto-discovered via `find_packages()`. If source files are not yet COPY'd into the Docker build context, `pip install .` succeeds but installs an EMPTY package (no modules).
+
+**WRONG — source files not yet copied:**
+```dockerfile
+COPY pyproject.toml .
+RUN pip install .  # Installs empty package — no source!
+COPY src/ ./src/   # Too late
+```
+
+**CORRECT — copy source before pip install:**
+```dockerfile
+COPY pyproject.toml .
+COPY src/ ./src/
+RUN pip install .  # Now finds source files
+```
+
+**Detection:**
+```bash
+grep -n 'pip install \.\|pip install -e \.' Dockerfile
+# Check if COPY for source directory appears BEFORE this line
+```
+
+**Rule:** When using `pip install .` in a Dockerfile, COPY both the metadata file (pyproject.toml/setup.cfg) AND all source directories BEFORE the `pip install` command. The only exception is `pip install --no-deps -r requirements.txt` (which doesn't read source files).
+
+## ChoiceOption Default Derivation
+
+**Trigger:** Python CLI frameworks (Click, argparse) using choice/enum options where the default must be one of the valid choices.
+
+**Problem:** When externalising a choice option's default to an env var, the env var value must be one of the allowed choices. If the env var contains a value not in the choices list, the framework raises a validation error at startup.
+
+**Pattern:**
+```python
+# Click
+@click.option('--log-level', type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR']),
+              default=lambda: os.environ.get('LOG_LEVEL', 'INFO'))
+
+# argparse
+parser.add_argument('--mode', choices=['development', 'production', 'testing'],
+                    default=os.environ.get('APP_MODE', 'production'))
+```
+
+**Rule:** When externalising choice-based options:
+1. The ENV_VARIABLES.md entry MUST document the valid choices
+2. The ConfigMap default MUST be one of the valid choices (typically `choices[0]` or the most common production value)
+3. Add a YAML comment listing valid values: `APP_MODE: "production"  # Valid: development, production, testing`
+
+
+## Custom WSGI Route-Enumeration Heuristic
+
+**Trigger:** Python WSGI applications (Flask, Django, FastAPI) being assessed for microservice decomposition.
+
+**Problem:** Standard decomposition heuristics look for Blueprint/Router registration. Custom WSGI apps may define routes via decorators, dictionaries, or class-based views without standard registration patterns.
+
+**Heuristic for route discovery:**
+```bash
+# Flask/FastAPI — decorator-based routes
+grep -rn '@app\.\(get\|post\|put\|delete\|route\)' . --include='*.py' | grep -v test | grep -v venv
+
+# Django — urls.py patterns
+grep -rn 'path(\|url(' */urls.py --include='*.py'
+
+# Custom WSGI dispatch table
+grep -rn 'url_map\|route_table\|ROUTES\s*=' . --include='*.py' | grep -v test
+```
+
+**Rule:** When decomposition assessment finds no standard router patterns, search for the custom route-enumeration heuristic above. Group routes by URL prefix (e.g., `/api/users/*`, `/api/orders/*`) to identify bounded contexts for decomposition candidates.
+
+## Module-Level Singleton Pool-Size Amplifier Warning
+
+**Trigger:** Python applications with module-level database/Redis connection pool instantiation AND Kubernetes HPA.
+
+**Problem:** When a module-level singleton creates a connection pool at import time (e.g., `pool = create_pool(max_connections=20)`), EVERY pod replica gets its own pool. With HPA scaling to N replicas, total connections = N × pool_size. This can exhaust database connection limits.
+
+**Detection:**
+```bash
+grep -rn 'pool.*=.*Pool\|create_pool\|ConnectionPool\|max_connections' . --include='*.py' | grep -v test | grep -v venv
+# Check if at module level (not inside a function)
+```
+
+**Rule:** Document connection pool sizes in INFRASTRUCTURE_REQUIREMENTS.md §1 with the formula: `total_max_connections = max_replicas × pool_size_per_pod`. Add a MIGRATION comment in the connection pool configuration noting this scaling relationship.
+
+**Mitigation options:**
+1. Use `pool_size = int(os.environ.get('DB_POOL_SIZE', '5'))` — make configurable via ConfigMap
+2. Set total DB `max_connections` ≥ `maxReplicas × pool_size + overhead`
+3. Use PgBouncer as connection multiplexer (document in INFRASTRUCTURE_REQUIREMENTS.md)
+
+## @cached_property + Environment Variable Override Conflict
+
+**Trigger:** Python applications using `@cached_property` (or `@functools.lru_cache`) for configuration values sourced from environment variables.
+
+**Problem:** `@cached_property` caches the value on first access. If the env var is read inside a cached property, changing the env var at runtime (e.g., via ConfigMap update + pod restart) has no effect until the cache is invalidated — which for `@cached_property` means creating a new instance.
+
+**Detection:**
+```bash
+grep -rn '@cached_property\|@lru_cache' . --include='*.py' | grep -v test | grep -v venv
+# Cross-reference with os.environ reads:
+grep -B5 'os\.environ\|os\.getenv' . --include='*.py' | grep -B5 'cached_property\|lru_cache'
+```
+
+**Rule:** Configuration values sourced from env vars should NOT be cached via `@cached_property` or `@lru_cache`. Either:
+1. Read env vars once at module import and store in module-level constants (acceptable — pod restart refreshes)
+2. Use pydantic-settings `BaseSettings` which handles env var reading at instantiation time
+3. If `@cached_property` is used for expensive computation on config values, document that config changes require pod restart
+
+**Example:**
+```python
+# PROBLEMATIC — cached_property masks env var updates:
+class Config:
+    @cached_property
+    def db_host(self):
+        return os.environ.get('DB_HOST', 'localhost')
+
+# ACCEPTABLE — module-level read, pod restart refreshes:
+DB_HOST = os.environ.get('DB_HOST', 'localhost')
+```
+
+
+## INI-Backed Config Dual-Path Naming
+
+**Trigger:** Python applications using `configparser` (INI files) alongside environment variable overrides.
+
+**Problem:** INI-backed config systems (like Trac's `trac.ini` or Mercurial's `hgrc`) use `section.option` naming with case-insensitive keys. When externalising to env vars, the mapping is not straightforward — `[database] host` could map to `DATABASE_HOST` or `TRAC_DATABASE_HOST` depending on the framework's env var bridge.
+
+**Rule:** When an application reads config from BOTH an INI file AND environment variables:
+1. Check if the framework provides an env var override mechanism (e.g., `TRAC_` prefix convention)
+2. If yes: use the framework's naming convention for ENV_VARIABLES.md keys
+3. If no: create an explicit bridge in the entrypoint script or application startup code
+4. Document BOTH the INI path AND the env var name in ENV_VARIABLES.md
+
+**Detection:**
+```bash
+grep -rn 'configparser\|ConfigParser\|SafeConfigParser\|RawConfigParser' . --include='*.py' | grep -v test
+grep -rn '\.ini\|\.cfg\|trac\.ini\|setup\.cfg' . --include='*.py' | grep -v test
+```
+
+## Multi-Top-Level-Package Dockerfile COPY
+
+**Trigger:** Python projects with multiple top-level packages (not a single `src/` directory).
+
+**Problem:** The standard `COPY . .` pattern copies everything including dev files. When trying to COPY specific packages for a leaner image, missing a top-level package causes `ModuleNotFoundError` at runtime.
+
+**Detection:**
+```bash
+# Find all top-level Python packages (directories with __init__.py)
+find . -maxdepth 2 -name '__init__.py' -not -path '*/test*' -not -path '*/.venv/*' | sed 's|/[^/]*$||' | sort -u
+```
+
+**Rule:** When a Python project has multiple top-level packages, the Dockerfile MUST copy ALL of them. Use the detection command above to enumerate, then verify each package appears in a COPY instruction:
+```dockerfile
+# Example: project with trac/, tracopt/, contrib/ packages
+COPY trac/ ./trac/
+COPY tracopt/ ./tracopt/
+COPY contrib/ ./contrib/
+COPY setup.py setup.cfg ./
+```
+
+**Verification (post-Dockerfile-write):**
+```bash
+# Extract COPY destinations from Dockerfile, compare against discovered packages
+grep '^COPY' Dockerfile | grep -v '\-\-from'
+```
+
+## ChoiceOption First-Element-as-Default Pattern
+
+**Trigger:** Python applications using custom `Option` classes with `choices` parameter where the first element serves as the default value.
+
+**Problem:** When externalising a `ChoiceOption` to an env var, the default value must be the first element of the choices list (framework convention). Setting an env var to a value not in the choices list causes a validation error at startup.
+
+**Rule:** For config options with constrained choices:
+1. Document the valid choices in ENV_VARIABLES.md description column
+2. Set the ConfigMap default to the first element of the choices list (framework convention)
+3. Add a YAML comment listing valid values
+
+```yaml
+# ConfigMap example:
+data:
+  LOG_LEVEL: "WARNING"  # Valid: DEBUG, INFO, WARNING, ERROR, CRITICAL
+```
+
+
+## Multi-Line os.environ.get() Split Calls
+
+**Trigger:** Python code using `os.environ.get()` or `os.environ[]` split across multiple lines.
+
+**Problem:** Standard single-line grep (`grep -rn 'os.environ.get'`) misses multi-line calls where the variable name is on the next line:
+
+```python
+# Missed by single-line grep:
+db_host = os.environ.get(
+    'DATABASE_HOST', 'localhost'
+)
+```
+
+**Supplementary detection:**
+```bash
+# Find multi-line os.environ patterns (line ends with 'os.environ.get(' or 'os.environ[')
+grep -rn 'os\.environ\.\(get\|setdefault\)\s*($' . --include='*.py' | grep -v 'venv\|site-packages'
+# Then read the NEXT line to extract the variable name:
+grep -A1 'os\.environ\.\(get\|setdefault\)\s*($' . --include='*.py' -r | grep -oP "['\"]([A-Z][A-Z0-9_]+)['\"]" | sort -u
+```
+
+**Rule:** For Python projects, after Pass 1/Pass 3, run the supplementary multi-line scan above. Any new variables found must be added to ENV_VARIABLES.md.
+
+## Tuple-List Config-Mapping Loop Variables
+
+**Trigger:** Python applications using tuple-list patterns to map config keys to env vars:
+
+```python
+CONFIG_MAP = [
+    ('database.host', 'DB_HOST', 'localhost'),
+    ('database.port', 'DB_PORT', '5432'),
+    ('redis.url', 'REDIS_URL', 'redis://localhost:6379'),
+]
+for config_key, env_var, default in CONFIG_MAP:
+    config[config_key] = os.environ.get(env_var, default)
+```
+
+**Problem:** Pass 1 grep for `os.environ.get` matches only the loop body (the generic pattern), not the individual variable names stored in the tuple list. The actual env var names are string literals in the data structure.
+
+**Detection:**
+```bash
+# Find tuple-list config patterns
+grep -B5 -A1 'os\.environ\.\(get\|setdefault\).*env_var\|os\.environ\.\(get\|setdefault\).*key' . -r --include='*.py' | grep -oP "['\"]([A-Z][A-Z0-9_]+)['\"]" | sort -u
+# Also scan for uppercase string literals in list/tuple assignments near config code
+grep -rn '\(.*[A-Z][A-Z0-9_]\{2,\}.*,.*[A-Z][A-Z0-9_]\{2,\}.*\)' . --include='*.py' | grep -v 'test\|venv'
+```
+
+**Rule:** When Python code uses data-driven config mapping (lists of tuples, dicts mapping config keys to env vars), extract variable names from the DATA STRUCTURE, not from the loop body. Each string matching `[A-Z][A-Z0-9_]+` in the tuple list is a candidate env var.
+
+## Redis Triple-Role Pattern
+
+**Trigger:** Python/Django applications using Redis for multiple purposes (cache + session + Celery broker) where the same `REDIS_URL` serves all three.
+
+**Problem:** A single `REDIS_URL` env var may serve three distinct roles. When externalising, workers sometimes create three separate env vars (`CACHE_REDIS_URL`, `SESSION_REDIS_URL`, `CELERY_BROKER_URL`) even though the source code uses a single `REDIS_URL` for all three.
+
+**Detection:**
+```bash
+# Check if single REDIS_URL serves multiple roles
+grep -rn 'REDIS_URL\|REDIS_HOST' . --include='*.py' | grep -v 'test\|venv' | awk -F: '{print $1}' | sort -u | wc -l
+# If referenced in 3+ distinct files (cache, session, celery config), it's triple-role
+```
+
+**Rule:** Follow source code — if the source uses ONE `REDIS_URL` for all three roles, the ConfigMap/Secret should contain ONE `REDIS_URL` entry (Secret-classified per Connection URL rule). Only create separate entries if the source code already reads from separate env vars. Document the triple-role in ENV_VARIABLES.md description: "Used for cache, sessions, and Celery broker."
+
+## ProbeMiddleware Split-Entrypoint Caveat
+
+**Trigger:** Python web applications where a health probe middleware (e.g., custom `/health` endpoint) is registered only in the web entrypoint, but Celery workers or management commands share the same codebase.
+
+**Problem:** When extracting Celery workers or scheduled tasks to separate Deployments/CronJobs, the health probe middleware is not active (because the web server isn't running). Workers need exec probes (`kill -0 1`), not HTTP probes.
+
+**Detection:**
+```bash
+# Find probe middleware registration
+grep -rn 'health\|readiness\|liveness' . --include='*.py' | grep -i 'middleware\|urlpatterns\|app\.route\|app\.get'
+# Check if it depends on web server running:
+grep -rn 'urlpatterns\|@app.route.*health\|@app.get.*health' . --include='*.py'
+```
+
+**Rule:** When splitting a Python application into web + worker Deployments:
+- Web Deployment: HTTP probes pointing to the health middleware path
+- Worker/CronJob Deployment: exec probes only (`["/bin/sh", "-c", "kill -0 1"]`)
+- Do NOT add HTTP probes to worker Deployments that don't run a web server
+
+
+## pytest iniconfig 2.x + setup.cfg Indentation Issue
+
+**Trigger:** Python projects using pytest >=9.x with `setup.cfg` containing `[options.extras_require]`.
+
+**Problem:** `iniconfig` 2.x (used by pytest >=7.2) rejects indented continuation values in `setup.cfg`. Lines like:
+```ini
+[options.extras_require]
+dev =
+    pytest
+    flake8
+```
+...fail with a parse error when `iniconfig` 2.x encounters the indented `pytest` line.
+
+**Fix:** Remove leading whitespace from continuation values in `setup.cfg`:
+```ini
+[options.extras_require]
+dev = pytest,flake8
+```
+
+**Detection:**
+```bash
+grep -A5 '\[options.extras_require\]' setup.cfg | grep '^\s\+[a-z]'
+# Any match = potential iniconfig 2.x parse failure
+```
+
+**Rule:** If `setup.cfg` is present and pytest >=9.x is used, ensure `[options.extras_require]` entries have NO leading whitespace on continuation lines. This is a general Python containerisation pattern — not specific to any framework.
+
+## Framework Test* Class Collection Conflict
+
+**Trigger:** Python framework projects (Trac, Zope, Django) with non-test helper classes named `Test*` (e.g., `TestManager`, `TestEnvironment`, `TestCase` base classes).
+
+**Problem:** pytest default `python_classes = Test*` collection pattern discovers these framework helper classes and attempts to run them as tests. This causes collection errors or spurious test execution.
+
+**Fix — override in pytest.ini or pyproject.toml:**
+```ini
+# pytest.ini
+[pytest]
+python_classes = *TestCase *Tests
+```
+
+Or in `pyproject.toml`:
+```toml
+[tool.pytest.ini_options]
+python_classes = ["*TestCase", "*Tests"]
+```
+
+**Detection:**
+```bash
+# Find non-test classes named Test* that pytest would collect
+grep -rn '^class Test' . --include='*.py' | grep -v 'test_\|tests/\|_test\.py' | head -10
+```
+
+**Rule:** For framework projects with non-test `Test*` classes, override `python_classes` in pytest configuration to avoid false collection. This prevents test task failures that are unrelated to migration quality.
+
+## SIGTERM + socketserver.serve_forever() Deadlock
+
+**Trigger:** Python WSGI/HTTP servers using `socketserver.serve_forever()` (or `HTTPServer.serve_forever()`) in the main thread.
+
+**Problem:** Calling `httpd.shutdown()` directly in a SIGTERM signal handler when `serve_forever()` runs in the same thread causes a deadlock. `shutdown()` tries to acquire the `_block_on_close` lock that `serve_forever()` already holds in the main thread.
+
+**Fix — daemon-thread shutdown pattern:**
+```python
+import signal, sys, threading
+
+_httpd_ref = [None]  # Mutable container for signal handler access
+
+def sigterm_handler(signum, frame):
+    httpd = _httpd_ref[0]
+    if httpd:
+        # Call shutdown() from a separate thread to avoid deadlock
+        threading.Thread(target=httpd.shutdown, daemon=True).start()
+
+signal.signal(signal.SIGTERM, sigterm_handler)
+
+httpd = make_server('0.0.0.0', int(os.environ.get('PORT', '8080')), app)
+_httpd_ref[0] = httpd
+httpd.serve_forever()
+sys.exit(0)
+```
+
+**Key points:**
+1. Never call `httpd.shutdown()` directly in the signal handler — deadlock
+2. Use a daemon thread to call `shutdown()` from outside the serve_forever() loop
+3. The mutable container pattern (`_httpd_ref = [None]`) allows the signal handler to access the server reference without module-level assignment issues
+
+**Detection:**
+```bash
+grep -rn 'serve_forever\|BaseHTTPServer\|socketserver' . --include='*.py' | grep -v test
+```
+
+## S3 Body Stream Non-Seekability
+
+**Trigger:** Python code calling `s3.get_object()` and then attempting `.seek()` on the `Body` stream.
+
+**Problem:** The `Body` returned by `boto3 s3.get_object()` is a `StreamingBody` — it is NOT seekable. Code that calls `body.seek(0)` after partial reads raises `io.UnsupportedOperation: seek`.
+
+**Fix — wrap in io.BytesIO:**
+```python
+import io
+
+response = s3.get_object(Bucket=bucket, Key=key)
+body_bytes = response['Body'].read()
+seekable_body = io.BytesIO(body_bytes)
+# Now seekable_body.seek(0) works
+```
+
+**Also note:** Error codes differ:
+- `s3.head_object()` on non-existent key raises `ClientError` with HTTP 404
+- `s3.get_object()` on non-existent key raises `ClientError` with code `NoSuchKey`
+- Check BOTH codes when handling "object not found" scenarios
+
+**Detection:**
+```bash
+grep -rn 'get_object\|Body.*seek\|Body.*read' . --include='*.py' | grep -v test | grep -v venv
+```
+
+**Rule:** After any `get_object()` call, if the code path calls `.seek()` on the Body, wrap the read result in `io.BytesIO()` first. This applies to all S3-integrated Python code paths (file browsers, backup/restore, image processing).
+
+## WSGI Middleware Ordering for Health Probes
+
+**Trigger:** Python WSGI applications (Trac, custom WSGI) where authentication middleware wraps the entire application.
+
+**Problem:** If the health probe endpoint is registered inside the WSGI application that is wrapped by auth middleware, the probe receives 401/403 — causing the pod to never become Ready.
+
+**Fix — register health endpoint BEFORE auth middleware in the WSGI pipeline:**
+```python
+class HealthCheckMiddleware:
+    def __init__(self, app):
+        self.app = app
+    def __call__(self, environ, start_response):
+        if environ.get('PATH_INFO') == '/healthz':
+            start_response('200 OK', [('Content-Type', 'text/plain')])
+            return [b'ok']
+        return self.app(environ, start_response)
+
+# Apply BEFORE auth middleware in the pipeline:
+app = HealthCheckMiddleware(auth_middleware(actual_app))
+```
+
+**Rule:** Health check middleware MUST be the outermost wrapper in the WSGI pipeline — before any authentication, session, or logging middleware. This ensures probes bypass all middleware that might reject unauthenticated requests.
+
+## Logging stderr Migration — NullHandler Test Pattern
+
+**Trigger:** After redirecting logging to stderr (§5), tests that capture stderr for assertion break.
+
+**Problem:** Python test frameworks often capture `sys.stderr` using `io.StringIO()` to assert on log output. After migration redirects logging to stderr, these tests capture ALL log messages — including library noise — causing assertions on exact output to fail.
+
+**Fix — use NullHandler in test fixtures:**
+```python
+# conftest.py
+import logging
+
+@pytest.fixture(autouse=True)
+def suppress_logging():
+    """Prevent log output from polluting test stderr captures."""
+    root = logging.getLogger()
+    root.handlers = [logging.NullHandler()]
+    yield
+    root.handlers = []
+```
+
+**Rule:** After stderr logging migration, if tests fail due to unexpected log output in stderr, add a NullHandler fixture. Document pre-existing test failures as CONDITIONAL PASS — they are not migration defects.
+
+## INI Config Env-Var Bridge Pattern
+
+**Trigger:** Python applications using `configparser` (INI files) where config values need to be overridable via environment variables at container runtime.
+
+**Problem:** `configparser.get()` reads from the INI file only — it has no built-in env var override mechanism (unlike Spring's PropertySourcesPlaceholderConfigurer). Applications must implement their own bridge.
+
+**Pattern — Section.get() interception with _ENV_VAR_ALIASES:**
+```python
+import os
+import configparser
+
+_ENV_VAR_ALIASES = {
+    ('database', 'host'): 'DB_HOST',
+    ('database', 'port'): 'DB_PORT',
+    ('database', 'password'): 'DB_PASSWORD',
+    ('logging', 'level'): 'LOG_LEVEL',
+}
+
+class EnvOverrideConfig(configparser.ConfigParser):
+    def get(self, section, option, **kwargs):
+        env_key = _ENV_VAR_ALIASES.get((section, option))
+        if env_key and os.environ.get(env_key):
+            return os.environ[env_key]
+        return super().get(section, option, **kwargs)
+```
+
+**Rule:** For configparser-backed applications (Trac, Mercurial, Buildbot, custom apps):
+1. Identify all config keys that need runtime override (database, credentials, URLs)
+2. Create an `_ENV_VAR_ALIASES` mapping from `(section, option)` to env var name
+3. Override `get()` to check env vars first
+4. Document both the INI key path AND env var name in ENV_VARIABLES.md
+
+**Detection:**
+```bash
+grep -rn 'configparser\|ConfigParser\|SafeConfigParser' . --include='*.py' | grep -v test | grep -v venv
+```
+
+## S3 Optional Backend with Safe-Import Guard
+
+**Trigger:** Python applications adding S3 as an optional storage backend where `boto3` may not be installed in all environments (e.g., development without AWS).
+
+**Pattern — try/except ImportError guard:**
+```python
+try:
+    import boto3
+    from botocore.exceptions import ClientError
+    HAS_S3 = True
+except ImportError:
+    HAS_S3 = False
+
+class S3Storage:
+    def __init__(self):
+        if not HAS_S3:
+            raise RuntimeError("boto3 required for S3 storage. Install with: pip install boto3")
+        self.client = boto3.client('s3',
+            region_name=os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
+```
+
+**_S3TempFile pattern for streaming uploads:**
+```python
+import tempfile, os
+
+class _S3TempFile:
+    """Write to local temp file, upload to S3 on close."""
+    def __init__(self, bucket, key, client):
+        self._fd, self._path = tempfile.mkstemp(dir='/tmp')
+        self._file = os.fdopen(self._fd, 'wb')
+        self._bucket, self._key, self._client = bucket, key, client
+
+    def write(self, data):
+        self._file.write(data)
+
+    def close(self):
+        self._file.close()
+        self._client.upload_file(self._path, self._bucket, self._key)
+        os.unlink(self._path)
+```
+
+**Rule:** When adding boto3 as an optional dependency:
+1. Use try/except ImportError guard at module level
+2. Set `HAS_S3 = True/False` flag for runtime checks
+3. Temp files for upload MUST use `/tmp` (emptyDir-backed) — not application directories
+4. Add `boto3` to requirements.txt with version pin
+
+## Amazon Linux / Minimal Container Python Bootstrap
+
+**Trigger:** Python projects being validated in Amazon Linux or minimal container environments where system Python lacks pip.
+
+**Procedure:**
+```bash
+# Step 1: Verify Python3 exists
+command -v python3 || { echo "Python3 not available"; exit 1; }
+
+# Step 2: Bootstrap pip if missing
+python3 -m pip --version 2>/dev/null || python3 -m ensurepip --upgrade 2>/dev/null || \
+  curl -sSL https://bootstrap.pypa.io/get-pip.py | python3
+
+# Step 3: Install project dependencies
+python3 -m pip install -r requirements.txt --quiet
+
+# Step 4: Verify imports
+python3 -c "import <main_package>; print('OK')"
+```
+
+**Rule:** In minimal environments, always attempt `ensurepip` before falling back to `get-pip.py`. Record CONDITIONAL PASS only when Python3 itself is absent and mise install fails.
+
+## WSGI Environ False-Positive Exclusion
+
+**Trigger:** Python WSGI applications (Django, Flask, Pyramid, Bottle, Trac, or any app using `environ['KEY']` in request handlers).
+
+**Problem:** WSGI apps access per-request data via `environ['KEY']` — using the same dictionary-access syntax as `os.environ['KEY']`. The 5-pass env var grep (Pass 2 data-structure literal scan) picks up WSGI environ keys as false-positive env var candidates. These are per-request HTTP metadata, not OS-level environment variables.
+
+**RFC 3875 §4.1 CGI meta-variables to exclude:**
+- `AUTH_TYPE`
+- `CONTENT_LENGTH`
+- `CONTENT_TYPE`
+- `GATEWAY_INTERFACE`
+- `PATH_INFO`
+- `PATH_TRANSLATED`
+- `QUERY_STRING`
+- `REMOTE_ADDR`
+- `REMOTE_HOST`
+- `REMOTE_IDENT`
+- `REMOTE_USER`
+- `REQUEST_METHOD`
+- `SCRIPT_NAME`
+- `SERVER_NAME`
+- `SERVER_PORT`
+- `SERVER_PROTOCOL`
+- `SERVER_SOFTWARE`
+- All `HTTP_*` prefixed keys (e.g., `HTTP_HOST`, `HTTP_ACCEPT`, `HTTP_AUTHORIZATION`)
+
+**Additionally exclude WSGI-specific keys:**
+- `wsgi.input`, `wsgi.errors`, `wsgi.url_scheme`, `wsgi.multithread`, `wsgi.multiprocess`, `wsgi.run_once`
+
+**Detection — distinguish WSGI environ from os.environ:**
+```bash
+# os.environ reads (TRUE env vars — include in ENV_VARIABLES.md):
+grep -rn 'os\.environ\|os\.getenv' . --include='*.py' --exclude-dir=.venv --exclude-dir=tests
+
+# WSGI environ reads (per-request — EXCLUDE from ENV_VARIABLES.md):
+grep -rn "environ\['" . --include='*.py' | grep -v 'os\.environ' | grep -v vendor
+# Also check for environ.get() without os. prefix:
+grep -rn "environ\.get(" . --include='*.py' | grep -v 'os\.environ' | grep -v vendor
+```
+
+**Rule:** When a Python WSGI application uses `environ['KEY']` or `environ.get('KEY')` WITHOUT the `os.` prefix, and the key matches any RFC 3875 meta-variable name above, exclude it from ENV_VARIABLES.md. These are per-request HTTP context values, not operator-configurable OS environment variables.
+
+**Source:** RFC 3875 — https://datatracker.ietf.org/doc/html/rfc3875 — "Meta-variables with names beginning with 'HTTP_' contain values read from the client request header fields."

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/ruby-rails-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/ruby-rails-patterns.md
@@ -1,0 +1,795 @@
+# Ruby/Rails Patterns Reference
+
+Ruby and Rails-specific containerisation gotchas for Phase 2 transformation. Applies when `Gemfile` is present.
+
+## Table of Contents
+
+1. [ENV.fetch vs ENV[]](#envfetch-vs-env)
+2. [IRSA present? Pattern](#irsa-present-pattern)
+3. [ActiveStorage Dual-File Co-Dependency](#activestorage-dual-file-co-dependency)
+4. [cable.yml ERB for ActionCable](#cableyml-erb-for-actioncable)
+5. [ActionCable Redis Adapter NetworkPolicy](#actioncable-redis-adapter-networkpolicy)
+6. [emptyDir Paths for Rails](#emptydir-paths-for-rails)
+7. [stdout Sync for Logging](#stdout-sync-for-logging)
+8. [Puma Configuration](#puma-configuration)
+9. [Database.yml ERB Patterns](#databaseyml-erb-patterns)
+10. [whenever Gem → Sidekiq-Cron Migration](#whenever-to-sidekiq-cron)
+11. [ActiveStorage CleanupJob](#activestorage-cleanupjob)
+12. [YAML+ERB Ternary Pattern](#yaml-erb-ternary)
+13. [libvips42 for Image Processing](#libvips42-for-image-processing)
+14. [retry_on for Transient Failures](#retry_on-for-transient-failures)
+15. [ActionCable WebSocket Nginx Ingress Annotations](#actioncable-websocket-nginx-ingress)
+
+
+## Pre-Docker Local Validation
+
+**Purpose:** Verify Ruby source has no syntax errors, dependencies resolve, and basic tests pass — all BEFORE `docker build`.
+
+### Commands
+```bash
+# 1. Syntax check all Ruby files (excluding vendor/)
+find . -name '*.rb' -not -path '*/vendor/*' | xargs ruby -c 2>&1 | grep -v 'Syntax OK'
+# Expected: empty output. Any output = FAIL.
+
+# 2. Bundle check (verify deps installed)
+bundle check 2>&1
+# Expected: exit 0 ("The Gemfile's dependencies are satisfied")
+
+# 3. If bundle check fails, attempt install
+bundle install --jobs=4 2>&1
+# Expected: exit 0
+
+# 4. Unit tests (infrastructure-excluded)
+bundle exec rspec --tag ~@integration --tag ~@db --fail-fast 2>&1 || true
+# Exit 0 = PASS; infrastructure failures = CONDITIONAL PASS; syntax/import errors = FAIL
+```
+
+### Expected Output
+- Step 1: Zero lines of output (all files pass `ruby -c`)
+- Step 2: Exit 0
+- Step 4: Exit 0 or infrastructure-only failures
+
+### CONDITIONAL PASS Triggers
+- `ruby` not installed and `mise install ruby` fails → CONDITIONAL PASS
+- Ruby version mismatch (Gemfile constraint != host version) → CONDITIONAL PASS
+- Native extension build failure (missing system libs) → CONDITIONAL PASS
+- Bundler version mismatch → CONDITIONAL PASS (see §CONDITIONAL PASS for Ruby Bundler Version Mismatch)
+
+### Toolchain Bootstrap via mise/rbenv
+```bash
+# Check Ruby availability
+command -v ruby && ruby --version
+# If absent or wrong version, try mise
+RUBY_VER=$(grep -oP "^ruby ['"]?\K[0-9.]+" Gemfile 2>/dev/null || echo "")
+if command -v mise >/dev/null 2>&1 && [ -n "$RUBY_VER" ]; then
+  mise install ruby@$RUBY_VER 2>/dev/null
+  export PATH=$HOME/.local/share/mise/shims:$PATH
+fi
+ruby --version
+# Install bundler if missing
+gem install bundler --no-document 2>/dev/null || true
+```
+
+### Validated Example Repositories
+- NOT YET VALIDATED AGAINST REAL REPO — commands inferred from Ruby/Rails documentation. Mark as validated when a Ruby project passes through the pipeline.
+
+
+## ENV.fetch vs ENV[]
+
+```ruby
+# ENV[] returns nil silently on missing key
+host = ENV['DATABASE_HOST']  # nil if unset
+
+# ENV.fetch raises KeyError on missing key (preferred for required vars)
+host = ENV.fetch('DATABASE_HOST')
+host = ENV.fetch('DATABASE_HOST', 'localhost')  # with default
+```
+
+**Migration pattern**:
+```ruby
+# Before:
+config.host = 'db.internal.example.com'
+# After:
+config.host = ENV.fetch('DATABASE_HOST', 'localhost')
+```
+
+## IRSA present? Pattern
+
+```ruby
+credentials = if ENV['AWS_ACCESS_KEY_ID'].present? && ENV['AWS_SECRET_ACCESS_KEY'].present?
+  Aws::Credentials.new(ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY'])
+end
+
+s3_client = Aws::S3::Client.new(
+  region: ENV.fetch('AWS_REGION', 'us-east-1'),
+  credentials: credentials  # nil → SDK uses default provider chain (IRSA)
+)
+```
+
+**Critical**: `.present?` checks both non-nil AND non-empty. Secret YAML must have active empty-string entries:
+```yaml
+stringData:
+  AWS_ACCESS_KEY_ID: ""
+  AWS_SECRET_ACCESS_KEY: ""
+```
+
+## ActiveStorage Dual-File Co-Dependency
+
+ActiveStorage requires TWO files updated together:
+
+```yaml
+# config/storage.yml
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV.fetch('AWS_REGION', 'us-east-1') %>
+  bucket: <%= ENV.fetch('S3_BUCKET') %>
+```
+
+```ruby
+# config/environments/production.rb
+config.active_storage.service = :amazon
+```
+
+**Rule**: Both files MUST be updated atomically.
+
+## cable.yml ERB for ActionCable
+
+```yaml
+production:
+  adapter: redis
+  url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/1') %>
+  channel_prefix: <%= ENV.fetch('CABLE_CHANNEL_PREFIX', 'myapp_production') %>
+```
+
+**NetworkPolicy impact**: ActionCable adapter needs egress to Redis.
+
+## ActionCable Redis Adapter NetworkPolicy
+
+When ActionCable uses Redis adapter, the web Deployment needs Redis egress:
+
+```yaml
+# networkpolicy-web.yaml (egress section)
+egress:
+- to:
+  - podSelector:
+      matchLabels:
+        app: redis
+  ports:
+  - port: 6379
+    protocol: TCP
+```
+
+**Detection:**
+```bash
+grep -n 'adapter.*redis\|redis.*adapter' config/cable.yml
+```
+
+**Rule**: If `cable.yml` references Redis, the web workload's NetworkPolicy MUST include Redis egress — separate from any Sidekiq worker Redis egress.
+
+## emptyDir Paths for Rails
+
+Minimum emptyDir volumes for Rails with `readOnlyRootFilesystem: true`:
+
+| Mount Path | Purpose |
+|-----------|---------|
+| `/tmp` | Ruby tempfiles, Puma state |
+| `tmp/pids` | Puma/Sidekiq PID files |
+| `tmp/cache` | Rails file cache (if used) |
+| `tmp/sockets` | Unix sockets (if Puma uses them) |
+| `log/` | Log fallback (some gems write here) |
+| `storage/` | ActiveStorage local fallback (dev mode) |
+
+**Note**: Rails convention uses `tmp/` relative to app root, not system `/tmp`. Mount both.
+
+## stdout Sync for Logging
+
+```ruby
+$stdout.sync = true
+config.logger = ActiveSupport::Logger.new($stdout)
+config.log_level = ENV.fetch('LOG_LEVEL', 'info').to_sym
+```
+
+**Without `$stdout.sync = true`**: logs buffer and may be lost on SIGKILL.
+
+## Puma Configuration
+
+```ruby
+workers ENV.fetch('WEB_CONCURRENCY', 2).to_i
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 5).to_i
+threads threads_count, threads_count
+port ENV.fetch('PORT', 3000)
+preload_app!
+
+on_worker_boot do
+  ActiveRecord::Base.establish_connection
+end
+```
+
+**Connection pool**: `RAILS_MAX_THREADS` must match `pool:` in `database.yml`. Total DB connections = `WEB_CONCURRENCY × RAILS_MAX_THREADS`.
+
+## Database.yml ERB Patterns
+
+```yaml
+production:
+  adapter: postgresql
+  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
+  port: <%= ENV.fetch('DATABASE_PORT', 5432) %>
+  database: <%= ENV.fetch('DATABASE_NAME', 'myapp_production') %>
+  username: <%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  pool: <%= ENV.fetch('RAILS_MAX_THREADS', 5) %>
+```
+
+**Rule**: Use `ENV.fetch` for required vars, `ENV['KEY']` only for passwords (nil-safe for IRSA pattern).
+
+## whenever Gem → Sidekiq-Cron Migration
+
+The `whenever` gem generates crontab entries that require a single always-running process. In Kubernetes, migrate to Sidekiq-Cron or Kubernetes CronJobs.
+
+**Detection:**
+```bash
+grep -l 'whenever' Gemfile
+cat config/schedule.rb
+```
+
+**Option A — Kubernetes CronJob (preferred for simple tasks):**
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-service
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanup
+            command: ["bundle", "exec", "rails", "runner", "CleanupService.perform"]
+          restartPolicy: Never
+```
+
+**Option B — Sidekiq-Cron (for tasks needing Sidekiq infrastructure):**
+```ruby
+Sidekiq::Cron::Job.create(
+  name: 'Cleanup Service - every hour',
+  cron: '0 * * * *',
+  class: 'CleanupWorker'
+)
+```
+
+**Rule**: Remove `whenever` gem from Gemfile after migration.
+
+## ActiveStorage CleanupJob
+
+ActiveStorage creates orphaned blobs when attachments are replaced. Schedule cleanup:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: activestorage-cleanup
+spec:
+  schedule: "0 3 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: cleanup
+            command: ["bundle", "exec", "rails", "runner", "ActiveStorage::Blob.unattached.where('active_storage_blobs.created_at < ?', 2.days.ago).find_each(&:purge_later)"]
+          restartPolicy: Never
+```
+
+**Detection:** `grep -rn 'has_one_attached\|has_many_attached' app/models/`
+
+## YAML+ERB Ternary Pattern
+
+For Rails config files using ERB ternary with env vars:
+
+```yaml
+adapter: <%= ENV['CACHE_STORE'] == 'redis' ? 'redis' : 'file' %>
+url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379') if ENV['CACHE_STORE'] == 'redis' %>
+```
+
+**Trap**: ERB `nil` in YAML produces the literal string `""` (empty), not YAML null. Use explicit conditionals.
+
+## libvips42 for Image Processing
+
+Rails 7+ defaults to `vips` for ActiveStorage image variants:
+
+```dockerfile
+# Debian/Ubuntu
+RUN apt-get update && apt-get install -y --no-install-recommends libvips42
+
+# Alpine
+RUN apk add --no-cache vips
+```
+
+**Detection:**
+```bash
+grep -n 'image_processing\|mini_magick\|vips' Gemfile
+grep -n 'variant_processor' config/application.rb config/environments/*.rb
+```
+
+**Rule**: If `config.active_storage.variant_processor = :vips` (Rails 7 default), install `libvips42`.
+
+## retry_on for Transient Failures
+
+```ruby
+class NotificationJob < ApplicationJob
+  retry_on Net::OpenTimeout, wait: :exponentially_longer, attempts: 5
+  retry_on Redis::ConnectionError, wait: 5.seconds, attempts: 3
+  discard_on ActiveJob::DeserializationError
+end
+```
+
+**Rule**: Add `retry_on` for network-dependent jobs. Add `discard_on` for permanent failures. Without these, jobs retry indefinitely.
+
+**Kubernetes impact**: retry_on replaces external retry mechanisms — do NOT add restartPolicy-based retries for Jobs that already use retry_on.
+
+## ENV.fetch Pre-Docker-Build Audit
+
+**Trigger:** Before running `docker build` on any Rails application.
+
+**Problem:** `ENV.fetch('KEY')` (without a second argument) raises `KeyError` if the env var is not set. During `docker build`, when `RUN bundle exec rake assets:precompile` runs in `RAILS_ENV=production` mode, class-level or config-file `ENV.fetch` calls execute — and if the key is not set in the Docker build environment, the build fails.
+
+**Detection:**
+```bash
+# Find bare ENV.fetch calls (no default = no comma after first argument)
+grep -rn 'ENV\.fetch' config/ app/ lib/ --include='*.rb' | grep -v 'ENV\.fetch([^,]*,'
+```
+
+**Fix — add dummy env vars to the RUN line in Dockerfile:**
+```dockerfile
+RUN SECRET_KEY_BASE=dummy RAILS_ENV=production \
+    DATABASE_URL=postgres://dummy:dummy@localhost/dummy \
+    REDIS_URL=redis://localhost:6379 \
+    bundle exec rake assets:precompile
+```
+
+**Rules:**
+1. Every bare `ENV.fetch` hit in code that runs during asset precompile requires a dummy var.
+2. Common offenders: `SECRET_KEY_BASE`, `DATABASE_URL`, `REDIS_URL`, custom app secrets.
+3. Dummy values MUST NOT be empty strings — some Rails code validates non-empty.
+4. This audit is part of Sub-Phase §17b (Docker Build Verification) — run BEFORE `docker build`.
+
+**Source:** Rails applications using `ENV.fetch` for required configuration — KeyError during asset precompile is a common Docker build failure (https://github.com/rails/rails/issues/48581).
+
+---
+
+## ActionCable WebSocket Nginx Ingress Annotations
+
+**Trigger:** ActionCable uses Redis adapter in production AND the application is behind an nginx Ingress controller.
+
+**Problem:** WebSocket connections are long-lived. Default nginx proxy timeouts (60s) disconnect WebSocket clients, causing constant reconnection storms.
+
+**Solution — add Ingress annotations for WebSocket timeout:**
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: app-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "7"
+```
+
+**Detection:**
+```bash
+# Check if ActionCable uses Redis in production
+grep -A3 'production:' config/cable.yml | grep -q 'adapter.*redis' && echo "WebSocket + Redis detected"
+```
+
+**Rule**: When ActionCable uses Redis production adapter, add nginx Ingress annotations `proxy-read-timeout: 3600` and `proxy-send-timeout: 3600`. Without these, WebSocket connections drop every 60 seconds.
+
+**Alternative for path-specific timeout** (if only `/cable` path needs long timeout):
+```yaml
+annotations:
+  nginx.ingress.kubernetes.io/configuration-snippet: |
+    location /cable {
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+```
+
+## Puma Adjacent-Items Checklist
+
+**Trigger:** When externalising puma.rb configuration, audit ALL adjacent configuration items — not just the port.
+
+**ENV.fetch checklist for puma.rb:**
+
+| Config Item | ENV.fetch Call | Default | Purpose |
+|---|---|---|---|
+| Port | `ENV.fetch('PORT', 3000)` | 3000 | HTTP listen port |
+| Threads | `ENV.fetch('RAILS_MAX_THREADS', 5).to_i` | 5 | Per-worker thread count |
+| Workers | `ENV.fetch('WEB_CONCURRENCY', 2).to_i` | 2 | Process count (Puma cluster mode) |
+| Worker timeout | `ENV.fetch('WORKER_TIMEOUT', 60).to_i` | 60 | Maximum request processing time |
+
+**Detection — items still hardcoded after partial migration:**
+```bash
+grep -n 'workers\|threads\|port\|worker_timeout' config/puma.rb | grep -v 'ENV'
+```
+
+Any match indicates an item that was missed during configuration externalisation.
+
+**Connection pool alignment rule:** `RAILS_MAX_THREADS` MUST match `pool:` in `config/database.yml`. Total DB connections = `WEB_CONCURRENCY × RAILS_MAX_THREADS`. Document this relationship in ENV_VARIABLES.md.
+
+## ApplicationMailer Default From Externalisation
+
+**Trigger:** `ApplicationMailer` (or any mailer) with a hardcoded `default from:` address.
+
+**Before (hardcoded):**
+```ruby
+class ApplicationMailer < ActionMailer::Base
+  default from: 'noreply@myapp.com'
+end
+```
+
+**After (externalised):**
+```ruby
+class ApplicationMailer < ActionMailer::Base
+  default from: ENV.fetch('MAILER_FROM_ADDRESS', 'noreply@example.com')
+end
+```
+
+**Detection:**
+```bash
+grep -rn "default from:" app/mailers/ --include='*.rb' | grep -v 'ENV'
+```
+
+**ENV_VARIABLES.md entry:**
+- `MAILER_FROM_ADDRESS` — Sender email address for outbound mail. K8s Scope: ConfigMap.
+
+## ENV.fetch Full-Scope Audit
+
+**Trigger:** After initial configuration externalisation, verify ALL `ENV.fetch` and `ENV[]` calls across the ENTIRE codebase — not just config/ directory.
+
+**Problem:** `ENV.fetch` calls in initializers, middleware, and library files are easily missed during partial audits focused on config/ only.
+
+**Full-scope detection:**
+```bash
+# All ENV access patterns across entire app
+grep -rn 'ENV\.fetch\|ENV\[' app/ config/ lib/ --include='*.rb' | grep -v 'test\|spec' | sort
+```
+
+**Rule:** Run this audit AFTER initial externalisation to catch secondary ENV access points. Each match must have a corresponding entry in ENV_VARIABLES.md.
+
+## ActionCable Two-Level Redis Fallback
+
+**Trigger:** ActionCable with Redis adapter where the cable.yml ERB needs graceful degradation.
+
+**Problem:** If `REDIS_URL` is unset AND no default provided, ActionCable crashes at boot. But hardcoding a default defeats externalisation.
+
+**Pattern — two-level fallback with CABLE_REDIS_URL override:**
+```yaml
+# config/cable.yml
+production:
+  adapter: redis
+  url: <%= ENV.fetch('CABLE_REDIS_URL', ENV.fetch('REDIS_URL', 'redis://localhost:6379/1')) %>
+  channel_prefix: <%= ENV.fetch('CABLE_CHANNEL_PREFIX', 'app_production') %>
+```
+
+**Rule:** ActionCable MAY use a separate `CABLE_REDIS_URL` when cable traffic should go to a different Redis instance than the cache/session store. Document both `CABLE_REDIS_URL` (optional override) and `REDIS_URL` (primary) in ENV_VARIABLES.md. ConfigMap entry for CABLE_REDIS_URL is only needed when cable uses a dedicated Redis.
+
+## action_mailer.default_url_options Externalisation
+
+**Trigger:** Rails applications using ActionMailer with hardcoded host in `default_url_options`.
+
+**Before (hardcoded):**
+```ruby
+# config/environments/production.rb
+config.action_mailer.default_url_options = { host: 'www.myapp.com' }
+```
+
+**After (externalised):**
+```ruby
+config.action_mailer.default_url_options = { host: ENV.fetch('APP_HOST', 'localhost') }
+```
+
+**Detection:**
+```bash
+grep -rn 'default_url_options' config/ --include='*.rb' | grep -v 'ENV'
+```
+
+**Rule:** `default_url_options` host determines the domain in email links. Must be externalised to ConfigMap as `APP_HOST`. Failure to externalise causes emails to contain wrong/hardcoded domain in all deployment environments.
+
+## Post-Externalisation Test Sync (Rails)
+
+**Trigger:** After externalising configuration (Sub-Phase §3) or credentials (Sub-Phase §7) to `ENV.fetch('VAR')` without defaults.
+
+**Problem:** `ENV.fetch('KEY')` raises `KeyError` if the env var is not set. During `rspec` runs and Dockerfile `asset:precompile`, missing env vars cause immediate failure.
+
+**Procedure — spec/rails_helper.rb guards:**
+
+Add ENV guards BEFORE `require_relative` in `spec/rails_helper.rb`:
+```ruby
+# spec/rails_helper.rb — add at TOP, before require_relative
+ENV['DATABASE_URL'] ||= 'postgres://localhost/test'
+ENV['REDIS_URL'] ||= 'redis://localhost:6379'
+ENV['SECRET_KEY_BASE'] ||= 'test-secret-key-base-minimum-length-required'
+# Add all ENV.fetch vars that lack defaults
+```
+
+**Procedure — Dockerfile precompile dummy-env block:**
+```dockerfile
+RUN SECRET_KEY_BASE=dummy \
+    DATABASE_URL=postgres://dummy:dummy@localhost/dummy \
+    REDIS_URL=redis://localhost:6379 \
+    RAILS_ENV=production \
+    bundle exec rake assets:precompile
+```
+
+**Detection — find all bare ENV.fetch that need guards:**
+```bash
+grep -rn 'ENV\.fetch' config/ app/ lib/ --include='*.rb' | grep -v 'ENV\.fetch([^,]*,' | grep -oP "ENV\.fetch\(['\"]([^'\"]+)" | sort -u
+```
+
+**Rule:** Every bare `ENV.fetch('KEY')` (no second argument) that runs during test setup or asset precompile MUST have a corresponding `ENV['KEY'] ||= 'safe-default'` in rails_helper.rb AND a matching dummy in the Dockerfile precompile RUN line. Complete within the same task scope as the externalisation — do not defer.
+
+## Sidekiq SIDEKIQ_QUEUES Shell-Form Expansion
+
+**Trigger:** Rails applications using Sidekiq where queue names are configured via environment variable.
+
+**Problem:** When passing `SIDEKIQ_QUEUES` as a ConfigMap value (e.g., `"default,mailers,active_storage"`), the Deployment command must use shell form to expand it. Exec form passes the literal string `$SIDEKIQ_QUEUES` without expansion.
+
+**WRONG (exec form — no expansion):**
+```yaml
+command: ["bundle", "exec", "sidekiq", "-q", "$SIDEKIQ_QUEUES"]
+```
+
+**CORRECT (shell form — expands env var):**
+```yaml
+command: ["/bin/sh", "-c", "bundle exec sidekiq -q ${SIDEKIQ_QUEUES}"]
+```
+
+**Alternative — multiple -q flags via envFrom:**
+```yaml
+# ConfigMap:
+SIDEKIQ_QUEUES: "default,mailers,active_storage"
+# Command uses shell split:
+command: ["/bin/sh", "-c", "echo $SIDEKIQ_QUEUES | tr ',' '\\n' | xargs -I{} echo -q {} | xargs bundle exec sidekiq"]
+```
+
+**Rule:** Any Deployment command that references env vars for runtime configuration MUST use shell form (`/bin/sh -c`) for variable expansion. Exec form only works with literal values.
+
+## Puma plugin :tmp_restart emptyDir
+
+**Trigger:** Rails applications using Puma with the `plugin :tmp_restart` directive.
+
+**Problem:** Puma's `tmp_restart` plugin watches `/app/tmp/restart.txt` for touch-triggered restarts. With `readOnlyRootFilesystem: true`, writing to `/app/tmp/` fails unless it's an emptyDir mount.
+
+**Detection:**
+```bash
+grep -rn 'plugin :tmp_restart\|tmp/restart' config/puma.rb Procfile 2>/dev/null
+```
+
+**Rule:** When `plugin :tmp_restart` is active, mount a SINGLE emptyDir at `/app/tmp` — this covers both the restart.txt watch file and any other tmp operations. Do not mount separate subdirectories.
+
+```yaml
+volumeMounts:
+- name: app-tmp
+  mountPath: /app/tmp
+volumes:
+- name: app-tmp
+  emptyDir: {}
+```
+
+## storage.yml ERB Mandatory ENV.fetch Audit
+
+**Trigger:** Rails applications using ActiveStorage with `config/storage.yml`.
+
+**Problem:** `storage.yml` uses ERB for env var interpolation. Any `ENV.fetch('KEY')` without a default causes `KeyError` during `rails credentials:edit` or any Rake task that loads the storage config — even if the storage service isn't active.
+
+**Detection:**
+```bash
+grep -n 'ENV' config/storage.yml 2>/dev/null
+```
+
+**Rule:** ALL `ENV.fetch()` calls in `storage.yml` MUST have defaults OR be wrapped in conditional service blocks. Use `ENV.fetch('KEY', nil)` for optional services:
+
+```yaml
+# config/storage.yml
+amazon:
+  service: S3
+  access_key_id: <%= ENV.fetch('AWS_ACCESS_KEY_ID', '') %>
+  secret_access_key: <%= ENV.fetch('AWS_SECRET_ACCESS_KEY', '') %>
+  region: <%= ENV.fetch('AWS_REGION', 'us-east-1') %>
+  bucket: <%= ENV.fetch('S3_BUCKET', 'replace-with-bucket') %>
+```
+
+## ENV Grep Exclusion List for Ruby/Bundler Internals
+
+**Trigger:** Running env var grep on Ruby/Rails projects.
+
+**Problem:** Ruby and Bundler inject internal environment variables that should NOT appear in ENV_VARIABLES.md or ConfigMap/Secret manifests.
+
+**Exclusion list:**
+```bash
+# Filter these from grep output — they are Ruby/Bundler internals:
+grep -rhoP "ENV\[(['\"])([A-Z][A-Z0-9_]+)" . --include='*.rb' | \
+  grep -oP "[A-Z][A-Z0-9_]+" | sort -u | \
+  grep -vE '^(BUNDLE_|GEM_|RUBY_|RUBYOPT|RUBYLIB|LANG|LC_|HOME|USER|PATH|TERM|SHELL|RACK_ENV|NODE_ENV)' 
+```
+
+**Variables to ALWAYS exclude from K8s manifests:**
+- `BUNDLE_*` (Bundler internals)
+- `GEM_HOME`, `GEM_PATH` (Ruby gem paths)
+- `RUBY_VERSION`, `RUBYOPT`, `RUBYLIB` (Ruby runtime)
+- `HOME`, `USER`, `PATH`, `TERM`, `SHELL` (OS-level)
+- `LANG`, `LC_*` (locale — set in Dockerfile if needed)
+
+**Rule:** When running the source-authoritative env var grep for Ruby projects, pipe output through the exclusion filter above. Only application-specific env vars belong in ConfigMap/Secret.
+
+
+## Rails 7.x Sprockets Asset Pipeline
+
+**Trigger:** Rails 7.0+ applications with `assets:precompile` in the Dockerfile.
+
+**Problem:** Rails 7.1 removed the implicit sprockets-rails dependency. Without explicit inclusion, `rake assets:precompile` fails with `Don't know how to build task 'assets:precompile'` or `Sprockets::Rails::Task` not found.
+
+**Pre-Docker build gate checklist:**
+```bash
+# 1. Verify sprockets-rails gem is present
+grep -q 'sprockets-rails' Gemfile && echo "OK" || echo "MISSING: add gem 'sprockets-rails' to Gemfile"
+
+# 2. Verify manifest.js exists (required by Sprockets 4.x)
+ls app/assets/config/manifest.js 2>/dev/null && echo "OK" || echo "MISSING: create app/assets/config/manifest.js"
+```
+
+**manifest.js minimal content** (if missing):
+```javascript
+//= link_tree ../images
+//= link_directory ../stylesheets .css
+```
+
+**Rule:** Before running `docker build` on any Rails 7.x application that includes `assets:precompile`, verify both `sprockets-rails` gem AND `app/assets/config/manifest.js` exist.
+
+## Gemfile Ruby Version Pin Relaxation
+
+**Trigger:** Gemfile contains an exact Ruby version pin (`ruby '3.2.2'`) that conflicts with the Docker build environment.
+
+**Problem:** Exact version pins cause `bundle install` failure when the host/Docker Ruby version differs even by patch level. The Dockerfile FROM pin (`FROM ruby:3.2.2-alpine`) enforces production version; the Gemfile constraint only needs to allow the build to proceed.
+
+**Before (fails if host has 3.2.3):**
+```ruby
+ruby '3.2.2'
+```
+
+**After (permits any 3.2.x):**
+```ruby
+ruby '>= 3.2.0'
+```
+
+**Detection:**
+```bash
+grep -n "^ruby '" Gemfile | grep -v '>='
+# Any match with exact version = potential build failure
+```
+
+**Rule:** During K8s migration, relax exact Ruby version pins to `>= X.Y.0` format. The Dockerfile FROM line is the authoritative version pin for production.
+
+## Sidekiq-Cron Complete Removal Checklist
+
+**Trigger:** Removing `sidekiq-cron` gem when migrating scheduled tasks to Kubernetes CronJobs.
+
+**Problem:** Removing the gem from Gemfile without cleaning up all references causes `NameError: uninitialized constant Sidekiq::Cron` at runtime.
+
+**Procedure:**
+1. Remove from Gemfile: `sed -i "/sidekiq-cron/d" Gemfile`
+2. Run `bundle install` (or manually remove from Gemfile.lock if bundler unavailable)
+3. Remove initializer: `rm -f config/initializers/sidekiq_cron.rb` (or equivalent)
+4. Grep for residual references:
+```bash
+grep -rn 'Sidekiq::Cron\|sidekiq-cron\|sidekiq_cron' . --include='*.rb' | grep -v vendor
+# Must return zero matches
+```
+5. Remove schedule YAML if separate: `rm -f config/sidekiq_cron.yml config/schedule.yml`
+
+**Gemfile.lock transitive dep removal** (when bundler unavailable):
+1. Identify exclusive deps: grep each `sidekiq-cron` dependency name in the DEPENDENCIES section — only remove deps with no other parent.
+2. Never remove shared gems: `globalid`, `activesupport`, `zeitwerk`, `redis` are commonly shared.
+3. For multi-line block deletion: `sed -i '/^    sidekiq-cron/,/^$/d' Gemfile.lock`
+
+**Verification:** `bundle check` (if bundler available) OR `grep -c 'sidekiq-cron' Gemfile.lock` = 0.
+
+## ENV.fetch Block-Form False Positive
+
+**Trigger:** Ruby ENV.fetch with a block form that looks like a bare call but has a fallback.
+
+**Problem:** The Docker build gate scans for bare `ENV.fetch` calls (no second argument = KeyError if missing). Block-form calls like `ENV.fetch('KEY') { 'default' }` ARE safe but get flagged as false positives by the bare-call grep.
+
+**Detection (refined grep excluding block form):**
+```bash
+# Bare calls only (no second arg, no block):
+grep -rn 'ENV\.fetch' config/ app/ lib/ --include='*.rb' | grep -v 'ENV\.fetch([^,]*,' | grep -v 'ENV\.fetch([^)]*) {'
+```
+
+**Rule:** When auditing ENV.fetch calls before docker build, exclude the block form `ENV.fetch('X') { default }` from the "needs dummy var" list. Only truly bare `ENV.fetch('X')` (no second arg, no block) requires a dummy env var during asset precompile.
+
+## NetworkPolicy SMTP Egress for CronJobs
+
+**Trigger:** Rails application using ActionMailer with `deliver_now` (synchronous delivery) in code paths extracted to CronJobs.
+
+**Problem:** `deliver_now` sends mail synchronously within the calling process. When the calling code runs in a CronJob pod, the CronJob's NetworkPolicy must include SMTP egress — adding it only to the web Deployment's NetworkPolicy is insufficient because the CronJob runs in a separate pod with its own NetworkPolicy.
+
+**Detection:**
+```bash
+# Find synchronous mail delivery in code paths likely to become CronJobs
+grep -rn 'deliver_now\|deliver_now!' app/jobs/ app/workers/ app/services/ lib/tasks/ --include='*.rb' 2>/dev/null
+# Also check for mailer calls in scheduled task paths
+grep -rn '\.deliver_now\|Mailer.*perform\|mailer.*deliver' . --include='*.rb' | grep -v 'spec/\|test/'
+```
+
+**Rule:** If `deliver_now` (or any synchronous mail-sending method) is found in code paths scheduled as CronJobs or background jobs, the CronJob's NetworkPolicy MUST include SMTP egress:
+
+```yaml
+# In the CronJob's NetworkPolicy egress section:
+egress:
+- ports:
+  - port: 587
+    protocol: TCP
+  # ports-only pattern: no 'to:' field — allows egress to any SMTP relay
+```
+
+**Distinction from deliver_later:** `deliver_later` enqueues to Sidekiq/ActiveJob — the Sidekiq worker pod (not the CronJob) needs SMTP egress. `deliver_now` executes in the current process — whichever pod calls it needs the egress rule.
+
+**General mail egress trigger rule:** Code-grep for mail-sending patterns (`deliver_now`, `deliver_later`, `ActionMailer`, `mail()`) even when no SMTP env var is present — DB-stored mailer config is common in CMS/ecommerce platforms. When found, ensure the workload pod that executes the send has SMTP egress in its NetworkPolicy.
+
+## CONDITIONAL PASS for Ruby Bundler Version Mismatch
+
+**Trigger:** Host Ruby version does not satisfy Gemfile `ruby` constraint, or Bundler version mismatch prevents `bundle install` from completing.
+
+**Problem:** When the host Ruby version (e.g., 3.3.0) differs from the Gemfile constraint (e.g., `ruby '3.2.2'`), `bundle install` exits non-zero with a version mismatch error. This is an environmental constraint, not a transformation defect.
+
+**Classification:**
+- Host ruby version != Gemfile `ruby` constraint → `bundle install` exit non-zero → **CONDITIONAL PASS** (not hard failure)
+- Bundler major version mismatch (e.g., host has Bundler 2.5, Gemfile.lock was generated with 1.x) → **CONDITIONAL PASS**
+
+**Recording in TRANSFORMATION_SUMMARY.md:**
+```
+| Tier 1 | CONDITIONAL PASS | bundle install failed — host Ruby 3.3.0 != Gemfile constraint 3.2.2. Dockerfile FROM ruby:3.2.2 is correct for production. |
+```
+
+**Rule:** Ruby/Bundler version mismatches are NOT transformation failures. The Dockerfile `FROM ruby:X.Y.Z` pin is the authoritative version for production. Record as CONDITIONAL PASS with root cause explanation. The Gemfile version pin may be relaxed (see §Gemfile Ruby Version Pin Relaxation) but this is optional — CONDITIONAL PASS is acceptable.
+
+
+## jsbundling/cssbundling Asset Stub Pre-Flight
+
+**Trigger:** Rails applications using `jsbundling-rails` or `cssbundling-rails` gems.
+
+**Detection:**
+```bash
+grep -E 'jsbundling-rails|cssbundling-rails' Gemfile
+```
+
+**Problem:** These gems expect a Node.js build step (e.g., `yarn build`, `npm run build`) to produce compiled assets in `app/assets/builds/` BEFORE `rake assets:precompile`. Without the Node.js step, precompile succeeds but produces empty/missing JavaScript/CSS — the application loads but is non-functional.
+
+**Pre-flight check (before docker build):**
+```bash
+# Verify asset build command exists
+grep -E '"build"' package.json
+# Verify build output directory has content
+ls app/assets/builds/ 2>/dev/null | head -5 || echo "WARNING: app/assets/builds/ empty or missing"
+```
+
+**Dockerfile pattern:**
+```dockerfile
+# Multi-stage: Node build stage precedes Ruby stage
+FROM node:18 AS assets
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+RUN yarn build
+
+FROM ruby:3.2
+COPY --from=assets /app/app/assets/builds/ /app/app/assets/builds/
+RUN bundle exec rake assets:precompile
+```
+
+**Rule:** When jsbundling-rails or cssbundling-rails is detected, the Dockerfile MUST include a Node.js build stage that produces `app/assets/builds/` content before the Ruby asset precompile stage.
+

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/skill-a-readiness-analysis.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/skill-a-readiness-analysis.md
@@ -1,0 +1,351 @@
+---
+name: containerisation-readiness-analysis
+description: >-
+  Analyses a codebase across any language or framework to assess containerisation
+  and Kubernetes readiness. Evaluates all 12-factor app principles, identifies
+  stateful patterns, singleton risks, hardcoded config, memory leaks, database
+  connection issues, and monolith decomposition opportunities. Produces a styled
+  HTML or markdown report with visual scorecard, severity badges, Named Service
+  Inventory with decomposition complexity ratings, and structured finding tables.
+  Triggers: containerisation, Kubernetes, 12-factor, cloud-native, readiness
+  assessment, migration analysis, microservice decomposition.
+---
+
+# Containerisation Readiness Analysis - 12 Factor App and Kubernetes Compatibility
+
+## Objective
+
+Analyse a codebase across any language or framework to assess its suitability for containerisation and deployment on Kubernetes, identifying violations of the 12-factor app principles and patterns that would cause failures or degraded behaviour in a containerised, orchestrated environment. Before performing the analysis, prompt the for preferences: the output directory or file path where the report should be stored. The output format should be both markdown and HTML. Always produce a single consolidated report file. Produce the report according to these preferences.
+## Summary
+
+This transformation performs a comprehensive static analysis of a codebase to identify containerisation blockers, risks, and remediation steps. Before beginning the analysis, the transformation prompts the user for two configuration preferences: the desired output location (directory or file path) and whether the output should be in markdown or HTML format. It always produces a single consolidated report file containing all analysis sections. It then evaluates the code against all twelve factors of the 12-factor app methodology, flags patterns that would break or behave unpredictably on Kubernetes, and produces the readiness report in the chosen format at the specified location. All results are assembled into one unified document with clearly delineated sections. When HTML format is selected, the report uses full HTML formatting with styled severity badges, collapsible sections, and a styled scorecard, rather than markdown syntax. Special attention is given to service discovery hardcoding, stateful patterns, logging anti-patterns, shared dependency management, concurrency safety issues under horizontal scaling, singleton pattern challenges that would cause failures when running multiple containers behind a load balancer, and hardcoded configuration values. Additionally, the analysis identifies startup order dependencies between services, detects in-memory state sharing between microservice candidates, recommends how to decompose monolithic modules into separate containers with a **Named Service Inventory table and Decomposition Complexity ratings**, flags local filesystem usage for replacement with object stores or shared filesystems, ensures user sessions are externalised while local caching is leveraged where appropriate, detects memory growth and leak patterns, identifies hardcoded IPs, ports, embedded credentials and API keys that must be moved to a secrets manager, and analyses database connection patterns for race conditions or ACID compliance risks.
+
+## Entry Criteria
+
+1. The codebase is available for static analysis and contains application source code in one or more programming languages.
+2. The application is currently running in a non-containerised environment (bare metal, VMs, or traditional deployment) or is being assessed before an initial containerisation effort.
+3. Build and dependency configuration files are present (e.g., pom.xml, package.json, requirements.txt, go.mod, .csproj, Gemfile, or equivalent).
+
+## Implementation Steps
+
+### User Configuration Prompts
+
+Before performing any analysis, prompt the user for the following two preferences:
+
+1. Ask the user for the output location where the report should be stored. This can be a directory path (in which case default file names will be used) or a full file path. If the user provides a directory, ensure it exists or create it. If no location is provided, default to the current working directory.
+2. Ask the user whether the output format should be markdown (.md) or HTML (.html). If HTML is selected, produce a fully styled HTML document with proper CSS styling for severity badges (coloured background spans), collapsible/expandable sections for each analysis area, a styled readiness scorecard table, and properly formatted finding tables. If markdown is selected, use standard markdown syntax with emoji icons as described in the formatting steps below.
+
+Always produce a single consolidated report file containing all analysis sections at the specified output location. Store these two preferences and apply them consistently across all output generation steps that follow.
+
+### Factor 1: Codebase (One codebase tracked in revision control, many deploys)
+
+1. Check for the presence of version control configuration (e.g., .git directory).
+2. Identify if multiple distinct applications are bundled in a single repository without clear module separation, which complicates independent container builds and deployments.
+3. Flag any environment-specific code branches or conditional compilation that ties the codebase to a single deployment target.
+
+### Factor 2: Dependencies (Explicitly declare and isolate dependencies)
+
+4. Locate all dependency manifest files (pom.xml, package.json, requirements.txt, go.mod, .csproj, Gemfile, build.gradle, etc.) and verify dependencies are explicitly declared with pinned or locked versions.
+5. Identify shared libraries or modules that are referenced across multiple application modules via local file paths, relative references, or symlinks rather than through a package registry or artifact repository. Flag these as containerisation blockers since each container must be independently buildable.
+6. Detect any reliance on system-level packages, globally installed tools, or OS-specific binaries that are assumed to exist on the host but would not be present in a minimal container image.
+7. Flag any vendored or copied-in dependency code that is not managed through the standard dependency tooling for that language.
+
+### Factor 3: Config (Store config in the environment)
+
+8. Search for hardcoded configuration values across all source files, including but not limited to: IP addresses, hostnames, port numbers, database connection strings, API URLs, file system paths, credentials, licence keys, and feature flags.
+9. Identify configuration files (e.g., application.properties, appsettings.json, .env files, YAML configs) that contain environment-specific values baked directly into the source tree rather than being injected at runtime.
+10. Check whether the application reads configuration from environment variables or external configuration sources (e.g., config servers, Kubernetes ConfigMaps, Secrets). Flag any absence of this pattern.
+11. Flag any configuration that is written to or modified at runtime and stored on the local filesystem, as this will not survive container restarts.
+
+### Factor 4: Backing Services (Treat backing services as attached resources)
+
+12. Identify all connections to external services such as databases, message queues, caches, SMTP servers, and third-party APIs.
+13. Flag any backing service connections that use hardcoded addresses, hostnames, or connection strings rather than being configurable via environment variables or service discovery mechanisms.
+14. Check for service discovery patterns. Flag any hardcoded service endpoints, static host lists, or DNS entries that assume a fixed network topology. In Kubernetes, services are discovered via internal DNS (service-name.namespace.svc.cluster.local) or environment variables, so any hardcoded addresses will break.
+
+### Factor 5: Build, Release, Run (Strictly separate build and run stages)
+
+15. Identify any patterns where the application compiles, downloads dependencies, or performs build-time activities during startup or at runtime.
+16. Flag any runtime code generation or dynamic compilation that would require build tools to be present in the production container image.
+
+### Factor 6: Processes (Execute the app as one or more stateless processes)
+
+17. Scan for in-memory state storage patterns including but not limited to: in-memory session stores, application-level caches that are not backed by an external service, static mutable variables used to share state across requests, and singleton patterns that accumulate state.
+18. Flag any use of sticky sessions or session affinity mechanisms, as these break when Kubernetes reschedules pods or scales horizontally behind a load balancer.
+19. Identify any local file system writes that are used for storing application state, user uploads, temporary processing data, or inter-process communication. In Kubernetes, container filesystems are ephemeral and data will be lost on pod restart.
+20. Flag any reliance on the application running as a single instance, such as locking mechanisms that assume a single process, scheduled tasks that would duplicate if multiple pods run, or in-memory queues.
+
+#### User Session Externalisation
+
+21. Identify all user session management mechanisms in the codebase, including HTTP session objects, server-side session stores, and any framework-specific session handling (e.g., HttpSession in Java, express-session in Node.js, Flask sessions in Python).
+22. Flag any user sessions stored in-memory (e.g., in-process session stores, default framework session handlers that use server memory). These must be replaced with an external session store such as Redis, Memcached, DynamoDB, or a database-backed session provider to survive pod restarts and support horizontal scaling.
+23. Identify any session data that is being serialised to local disk as a persistence mechanism, as this will not survive container replacement.
+
+#### Local Caching Strategy
+
+24. While in-memory session state must be externalised, identify opportunities where local in-memory caching should be retained or introduced for performance. This includes: read-heavy reference data, configuration lookups, frequently accessed static content, and computed values that are expensive to regenerate.
+25. Flag any local caches that store user-specific mutable state or data that must be consistent across multiple pod instances. These require a distributed cache (e.g., Redis, Memcached) rather than a local in-memory cache.
+26. Recommend a caching strategy that distinguishes between data suitable for local in-memory caching (tolerant of staleness, pod-local, and read-heavy) versus data requiring a distributed external cache (user state, shared mutable data, session data).
+
+#### In-Memory State Sharing Between Microservice Candidates
+
+27. Analyse the codebase for shared mutable state between what appear to be distinct modules, bounded contexts, or logical services within the monolith. This includes static variables, shared singletons, shared data structures in memory, or global registries that multiple modules read from and write to.
+28. Flag any patterns where one module or service directly modifies in-memory state that another module depends on, as this coupling will break when these modules are decomposed into separate containers with separate memory spaces.
+29. Recommend replacement patterns for shared in-memory state: event-driven communication via a message broker, shared external cache, or API calls between services.
+
+### Factor 7: Port Binding (Export services via port binding)
+
+30. Check that the application binds to a configurable port rather than a hardcoded one. In Kubernetes, the port must be configurable to work with Service and Pod definitions.
+31. Flag any reliance on specific port numbers below 1024 that would require elevated container privileges.
+32. Search the entire codebase for any hardcoded IP addresses (e.g., 10.x.x.x, 192.168.x.x, 172.x.x.x, or any public IPs), fixed port numbers in connection strings, socket bindings, or client configurations. These must be replaced with configurable values injected via environment variables or Kubernetes ConfigMaps.
+33. Flag any use of fixed hostnames or IP addresses in inter-service communication, load balancer configurations, health check endpoints, or monitoring agent configurations.
+
+### Factor 8: Concurrency (Scale out via the process model)
+
+34. Analyse the codebase for patterns that would break under horizontal scaling when multiple copies of the same module run behind a Kubernetes load balancer. This includes: leader election assumptions, singleton resource locks, in-memory rate limiters, sequence generators, and non-distributed cron or scheduler implementations.
+35. Flag any use of local file-based locking or inter-process communication mechanisms (e.g., named pipes, shared memory, file locks) that assume processes are co-located on the same host.
+36. Identify any thread-local or process-local state that is assumed to persist across multiple requests from the same client.
+
+#### Memory Growth and Memory Leak Detection
+
+37. Analyse the codebase for patterns known to cause memory growth or memory leaks, including: unbounded caches or collections that grow without eviction policies, event listener or callback registrations that are never removed, connection pools that are opened but never closed or returned, large object allocations in request-scoped code that may not be garbage collected promptly, and static collections that accumulate entries over the application lifetime.
+38. Flag any patterns where objects are added to long-lived data structures (e.g., static maps, lists, or sets) without corresponding removal logic, bounded size limits, or TTL-based eviction.
+39. Identify any use of finalizers, weak references, or manual memory management patterns that may behave unexpectedly under container memory limits where the JVM, runtime, or garbage collector may be killed by the OOM killer before cleanup logic executes.
+40. Flag any absence of container-aware memory configuration. Multi-runtime examples: JVM `-XX:MaxRAMPercentage`; Python K8s `resources.limits.memory` + gunicorn `--max-requests` + Celery `--max-tasks-per-child`; Node.js `--max-old-space-size`; Go `GOMEMLIMIT`; .NET `DOTNET_GCConserveMemory` / `DOTNET_GCHeapHardLimit`; PHP `PHP_MEMORY_LIMIT` = 0.8 × K8s pod memory limit via ConfigMap, set `pm.max_requests` in FPM pool config. Trace memory settings through the full shell init-script chain (Dockerfile ENTRYPOINT → startup.sh → inner scripts) to find the authoritative default. **Severity assignment**: Warning for JVM/Node.js/PHP (OOM kill risk under container limits); Info for Go (GOMEMLIMIT is advisory, Go GC is container-aware by default since Go 1.19).
+
+### Horizontal Scaling and Singleton Pattern Challenges
+
+41–51. (Unchanged — see previous iteration for full text of steps 41-51 covering singleton patterns, scheduled tasks, event buses, rate limiters, sequence generators, resource managers, leader election, cache warming, file coordination, WebSocket state, and singleton risk summary table.)
+
+### Factor 9: Disposability (Maximise robustness with fast startup and graceful shutdown)
+
+52–54. (Unchanged — graceful shutdown, long startup, cleanup hooks.)
+
+#### Startup Order Dependencies
+
+55–58. (Unchanged — dependency graph, circular deps, crash-on-missing, retry patterns.)
+
+### Factor 10: Dev/Prod Parity
+
+59–60. (Unchanged — environment-specific code, in-memory substitutes.)
+
+### Factor 11: Logs
+
+61–63. (Unchanged — file appenders, log rotation, stdout/stderr.)
+
+### Factor 12: Admin Processes
+
+64. (Unchanged — embedded admin tasks.)
+
+### Kubernetes-Specific Analysis
+
+65–71. (Unchanged — fixed paths, localhost, timeouts, OS-specific, multicast, root filesystem, root user.)
+
+#### Probe Exception Table
+
+When assessing readiness for Kubernetes probe requirements, the following workload types have special severity treatment:
+
+| Workload Pattern | readinessProbe Absence | Severity | Rationale |
+|---|---|---|---|
+| HTTP API/web server | Warning | Required for traffic routing |
+| Pull-based queue worker (Sidekiq, Celery, BullMQ — no Service, no inbound traffic) | Note (Informational) | readinessProbe is optional for pull-based workers; add a `# MIGRATION: readinessProbe omitted — pull-based worker` YAML comment in Phase 2 |
+| CronJob / Job main container | Not applicable | K8s API does not support readinessProbe on Jobs |
+
+This table aligns Phase 1 findings with Phase 2 probe exception rules (SKILL.md criterion 8d).
+
+### Local Filesystem Usage Replacement
+
+72–77. (Unchanged — categorise usage, object store, shared filesystem, uploads, temp, hardcoded paths.)
+
+### Credentials, API Keys, and Secrets Management
+
+78–82. (Unchanged — embedded secrets, plaintext, filesystem paths, env vars, CLI args.)
+
+### Monolith Decomposition Recommendations
+
+83. Analyse the codebase structure to identify distinct modules, bounded contexts, or logical services that are candidates for decomposition into separate containers. Use the following **enumeration algorithm**:
+    - **Route-group analysis**: Group HTTP routes by URL prefix (`/api/uploads/*`, `/api/auth/*`). Each group with ≥3 endpoints is a candidate.
+    - **Package/namespace scan**: Each top-level package/namespace with its own models = candidate.
+    - **Queue channel scan**: Each distinct queue name or worker topic = worker candidate.
+    - **Scheduled task scan**: Each cron entry = CronJob candidate.
+    - **Mode-toggle scan**: Each env flag gating behaviour (CONSUMER_ONLY, WORKER_ONLY, APP_MODE) = per-mode image candidate.
+
+84. For each identified microservice candidate, produce a row in the **Named Service Inventory table** with these MANDATORY columns:
+    - **ServiceName** — a concrete name (e.g., NotificationService, UploadService), NOT generic "Service A"
+    - **DomainResponsibility** — what business function it owns
+    - **SourcePaths** — directories/files constituting this service
+    - **OwnedTables** — database tables/collections this service exclusively writes
+    - **InboundAPIs** — HTTP/gRPC endpoints this service exposes
+    - **OutboundEvents** — events/messages this service publishes
+    - **ScalingDriver** — what metric drives independent scaling (CPU, queue depth, connections)
+    - **ExtractionOrder** — numeric priority (1 = first to extract, LAST = AuthService)
+    - **Complexity** — Low / Medium / High per the Decomposition Complexity Rubric in `references/microservice-decomposition-patterns.md`
+    - **BlockingDependencies** — what must be resolved before extraction
+    - **DataOwnership** — exclusive-write / read-only / shared-write-BLOCKER
+
+85. Produce a **Data Ownership Matrix** table mapping each database table/collection to:
+    - Which service(s) WRITE to it
+    - Which service(s) READ from it
+    - FK constraints referencing it from other domains
+    - Whether it is a decomposition blocker (shared-write = YES)
+
+86. Classify each service candidate's infrastructure concerns vs domain responsibility:
+    - **Infrastructure concerns** (logging, monitoring, config, secrets) → remain cross-cutting, NOT separate services
+    - **Domain services** (notifications, uploads, search, auth, orders) → decomposition candidates
+    - Flag any candidate that is purely an infrastructure concern mistakenly listed as a domain service
+
+87. For each recommended microservice, specify: startup dependencies on other services, communication mechanism (REST, gRPC, message queue, event bus), shared data concerns that need Shared-DB Remediation Ladder steps, and whether it requires a separate Docker image or can share with mode-toggle removal.
+
+### Database Connection and Data Integrity Analysis
+
+88–93. (Unchanged — connection patterns, race conditions, transactions, advisory locks, stale cache, pool sizing.)
+
+### Output Consolidation and Visual Formatting
+
+94. Compile all findings from every analysis step above into a single consolidated report file at the specified output location.
+
+#### Visual Readiness Scorecard
+
+95. At the very top of the report, include a visual readiness scorecard with exactly 21 rows:
+1. Factor 1 – Codebase  2. Factor 2 – Dependencies  3. Factor 3 – Config  4. Factor 4 – Backing Services  5. Factor 5 – Build, Release, Run  6. Factor 6 – Processes  7. Factor 7 – Port Binding  8. Factor 8 – Concurrency  9. Horizontal Scaling & Singleton Challenges  10. Factor 9 – Disposability  11. Factor 10 – Dev/Prod Parity  12. Factor 11 – Logs  13. Factor 12 – Admin Processes  14. Kubernetes-Specific  15. Local Filesystem Usage  16. Credentials & Secrets  17. Session & Caching Strategy  18. Memory Analysis  19. Startup Dependencies  20. Monolith Decomposition  21. Database Connections
+
+**Totals Derivation Rule:** The TOTALS row MUST be derived by summing the current values from all individual area rows. Delta arithmetic is prohibited.
+
+**Count Synchronisation Rule:** After any modification that changes B/W/I counts, perform a full-report sync across: (1) per-row badge counts (authoritative), (2) scorecard TOTALS, (3) executive summary totals + narrative, (4) footer paragraph.
+
+**Mandatory Python Sum-Verification:** After writing all per-section tables and the TOTALS row, verify arithmetic with:
+```bash
+python3 -c "
+# Extract per-row B/W/I counts and verify TOTALS
+# IMPORTANT: Count ONLY F-prefixed finding rows to avoid prose/remediation text inflation
+# Use EMOJI-ONLY matching (not disjunction with text labels) to prevent double-counting
+import re, sys
+content = open(sys.argv[1]).read()
+# Filter to finding rows only (lines starting with | F followed by a digit)
+finding_lines = [l for l in content.splitlines() if re.match(r'\|\s*F\d+', l.strip())]
+# Deduplicate by finding ID to prevent summary-table replication
+seen_ids = set()
+unique_lines = []
+for l in finding_lines:
+    fid = re.match(r'\|\s*(F\d+)', l.strip())
+    if fid and fid.group(1) not in seen_ids:
+        seen_ids.add(fid.group(1))
+        unique_lines.append(l)
+finding_text = '\n'.join(unique_lines)
+# Use emoji-only matching (NOT disjunction like '🔴|Blocker')
+blockers = finding_text.count('🔴')
+warnings = finding_text.count('🟡')
+infos = finding_text.count('🔵')
+print(f'Computed from F-rows: B={blockers} W={warnings} I={infos}')
+# Compare against TOTALS row — manual verification step
+" report.md
+```
+Mental arithmetic errors are most common in the Info column. Always verify TOTALS programmatically rather than counting manually. **F-prefixed row guard**: The script counts ONLY lines matching `| F\d+` (finding rows) — this prevents remediation text, section headings, and legend entries from inflating counts. **Per-finding-ID deduplication**: Each F-ID is counted only once even if it appears in multiple tables.
+
+**PROHIBITION: Summary table replication**: Do NOT add a "Summary of All Findings" table that replicates F-prefixed finding rows from per-section tables. Per-section finding tables are the sole authoritative location for findings. Any summary using F-row IDs causes double-counting in the verification script. Cross-reference in verification as a pre-run check: assert no F-row ID appears more than once across all tables.
+
+**F-ID uniqueness and format rule**: Each F-ID MUST appear in exactly ONE section table — never duplicated across tables. Use sequential non-dotted IDs (F1, F2, F3, ...) — do NOT use hierarchical dotted IDs (F3.1, F3.2) as these break the sum-verification regex `r'\|\s*F\d+'`. If a section has multiple findings, assign each a unique sequential F-number.
+
+**Icon Derivation Rule:** Always derive the status icon from finalised per-section finding counts.
+
+#### Section Heading Icons
+
+96. Each major section must include a descriptive category emoji icon.
+
+**Common confusions:** ☸ U+2638 (WHEEL OF DHARMA) is correct for Kubernetes — NOT ⎈ U+2388 (HELM SYMBOL); 🗄 U+1F5C4 (FILE CABINET) is correct for Database — NOT 🗃 U+1F5C3 (CARD BOX).
+
+#### Severity Icons
+
+97. Use red circle emoji + "Blocker", yellow circle + "Warning", blue circle + "Info" consistently everywhere.
+
+#### Per-Section Finding Tables
+
+98. Within each section, present findings in structured markdown tables with columns: number, severity icon+label, file:line location, description, principle violated, remediation.
+
+**No-Issues / Findings Table Mutual Exclusivity:** Display EITHER green check + "No issues found" OR the findings table — never both.
+
+**Line-Reference Verification:** Obtain exact line numbers via `grep -n`. Confirm with `sed -n <line>p`.
+
+**Cross-Report Propagation:** When correcting any reference, grep the full report for ALL occurrences and update.
+
+**All-File-Type Coverage:** Line references mandatory for ALL file types including XML, YAML, Dockerfile, shell scripts.
+
+#### Executive Summary Table
+
+99. Include executive summary section after scorecard with severity counts per area, totals row derived by summing, and 2-4 sentence narrative.
+
+#### Colour-Coded Severity Badges
+
+100. HTML format: inline span elements with background colour. Canonical CSS: `badge badge-blocker`, `badge badge-warning`, `badge badge-info`. Non-finding tables use `badge-sum-*` variants.
+
+**PROHIBITED: `badge badge-*` inside `<summary>` elements.** Use `badge-sum-*` classes for aggregate display.
+
+#### Monolith Decomposition Visual Plan and Named Service Inventory
+
+101. In the monolith decomposition section, include:
+    (a) The **Named Service Inventory table** (step 84 format) — this is the PRIMARY output consumed by Phase 2 sub-phase §2. It replaces the generic visual diagram from previous iterations.
+    (b) The **Data Ownership Matrix** (step 85 format) showing table-to-service mapping.
+    (c) A **communication diagram** (text-based) showing arrows between services with protocol labels.
+    (d) The **extraction sequencing** showing which services extract first (Low → Medium → High, Auth always LAST).
+    (e) For each service, the **Decomposition Complexity** rating with justification referencing the rubric from `references/microservice-decomposition-patterns.md`.
+
+    **Pre-write gate (mandatory)**: Before finalising the Monolith Decomposition section, verify the Named Service Inventory table is present with all 11 mandatory column headers:
+    ```bash
+    grep -c 'ServiceName.*DomainResponsibility\|DomainResponsibility.*SourcePaths' report.html report.md 2>/dev/null
+    ```
+    If the table is absent or incomplete, do NOT write the section summary — add the table first.
+
+#### Minimal Decomposition Recommendation
+
+102. After the Named Service Inventory table, include a **### Minimal Decomposition Recommendation** subsection containing:
+    - The primary Deployment only (the service that owns the primary HTTP endpoint)
+    - Required supporting resources (migration Job if startup depends on it, required background worker if app cannot process requests without it)
+    - Total manifest count expected under minimal scope
+    - Prerequisites that must be resolved before the primary Deployment can run independently
+    - Rationale for why this is the minimum viable Kubernetes deployment
+
+#### Full Decomposition Recommendation
+
+103. Immediately after the Minimal recommendation, include a **### Full Decomposition Recommendation** subsection containing:
+    - ALL Low and Medium complexity candidates from the Named Service Inventory with extraction order
+    - Per-service effort estimate (story points or T-shirt size) based on complexity rating
+    - Per-service prerequisites (shared-DB remediation steps, async signal decoupling, etc.)
+    - Total manifest count expected under full scope
+    - Risk assessment: what could go wrong with full extraction vs the incremental minimal approach
+    - Recommended extraction sequence (Low-complexity first, then Medium, High deferred)
+
+## Validation / Exit Criteria
+
+1. User prompted for output location and format. Report respects both.
+2. All findings in single consolidated report. No separate per-factor files.
+3. Report uses chosen format (HTML or markdown with appropriate styling).
+4. Every source file scanned against all 12 factors and additional areas.
+5. Report begins with 21-row visual readiness scorecard with correct status icons.
+6. Executive summary table with totals derived by summing per-row values.
+7. All findings categorised as Blocker/Warning/Info with consistent emoji icons.
+8. All severity classifications use correct emoji icons throughout.
+9. HTML format includes colour-coded badges with canonical CSS class names.
+10. Section headings include category emoji icons.
+11. Findings in structured tables (number, severity, location, description, principle, remediation).
+12. Sections with no findings show ONLY green check. Sections with findings show ONLY the table.
+13. All hardcoded config identified.
+14. All stateful patterns identified with file:line.
+15. Session mechanisms identified (in-memory flagged as blockers).
+16. Caching strategy documented (local vs distributed).
+17. Logging anti-patterns identified.
+18. Shared dependencies identified.
+19. Horizontal scaling risks identified.
+20. Singleton risk summary table complete.
+21. Filesystem usage catalogued with replacement recommendations.
+22. File upload mechanisms reviewed.
+23. All credentials/secrets identified.
+24. Startup dependency graph produced.
+25. Memory growth risks identified.
+26. Database connection patterns analysed.
+27. **Named Service Inventory table** produced with ALL mandatory columns (ServiceName, DomainResponsibility, SourcePaths, OwnedTables, InboundAPIs, OutboundEvents, ScalingDriver, ExtractionOrder, Complexity, BlockingDependencies, DataOwnership).
+28. **Data Ownership Matrix** produced for projects with ≥3 tables and ≥2 candidates.
+29. Every `file:line` reference verified via `grep -n`.
+30. Scorecard icons consistent with counts. Totals correct.
+31. Build verification command is a valid shell expression.
+32. **Minimal Decomposition Recommendation** subsection present with primary Deployment identification, manifest count, and prerequisites.
+33. **Full Decomposition Recommendation** subsection present with all Low/Medium candidates, effort estimates, and extraction sequence.

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/skill-b-containerisation-transformation.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/skill-b-containerisation-transformation.md
@@ -1,0 +1,581 @@
+# Kubernetes Containerisation Transformation
+
+## Objective
+
+Read an existing containerisation readiness report and transform the codebase for Kubernetes deployment: generate manifests, externalise state and storage, configure backing services, execute microservice decomposition for viable candidates (per `decomposition_scope`), and produce supporting documentation.
+
+## Summary
+
+This transformation consumes a containerisation readiness report, prompts for user preferences, then systematically resolves all findings. It ingests the Phase 1 Named Service Inventory and applies execution scope constraints: when `decomposition_scope=minimal` (default), only the primary Deployment and required supporting resources are generated; when `decomposition_scope=full`, manifests are generated for all Low/Medium complexity candidates. It generates Kubernetes YAML manifests, validates via docker build + kubeconform, and produces infrastructure documentation including §0 Target Microservice Architecture.
+
+## Entry Criteria
+
+1. A containerisation readiness report exists and is accessible.
+2. The application source code is available for reading.
+3. The user can provide a target transformation directory path.
+
+## Per-Task Hygiene (Mandatory)
+
+**Task-Boundary Enforcement Rule:** Each worker is assigned exactly ONE sub-phase via its injected task context. Reading SKILL.md is for reference guidance only — it does NOT authorise performing a different or additional sub-phase. If injected context conflicts with codebase state, complete the assigned task and report the discrepancy in the task report.
+
+**Worker Fast-Fail Rule:** If the first tool result is a system error (DataNotFoundError, ToolError, platform error, or any non-content response), immediately write a task report with status: failure containing the verbatim error and exit — DO NOT issue sleep/retry/wait commands. Platform-level errors are not recoverable within the task.
+
+Every task MUST execute:
+
+- **Step-0 (start of task):** `find . -name '*.bak' -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/vendor/*' -delete`
+- **After EVERY str_replace or pattern_replace call:** immediately run `rm -f <path>.bak`. Do NOT defer to end of task.
+- **Before any str_replace/insert/file-patching command:** always `file_read` the CURRENT state of the target file. Never assume it matches the original codebase snapshot or a pre-batch context summary.
+
+**12-Point Mandatory Closure Gate** — before closing ANY task:
+
+0. **.bak sweep = 0** (HARD GATE — FIRST CHECK): `find <repo> -name '*.bak' -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/vendor/*' -delete && [ $(find <repo> -name '*.bak' -not -path '*/.git/*' | wc -l) -eq 0 ]`. If count ≠ 0, FAIL gate. **Prefer `sed -i` for simple substitutions — it avoids .bak creation entirely on Linux.**
+1. **Stale-claim sweep** on all modified `.md` files (see `references/validation-patterns.md`)
+2. **ENV_VARIABLES.md updated** for any new/removed env var. **Mandatory (with one exception)**: Any task that introduces new env var reads in source files (getenv/ENV.fetch/@Value/os.environ/process.env) MUST add corresponding ENV_VARIABLES.md rows before closing — narrow task scope descriptions do NOT override this requirement. **Documentation-only task exemption**: Tasks that modify only `.md` files and introduce no new source code env var reads are exempt from the ENV_VARIABLES.md update mandate only — all other Closure Gate requirements still apply. **Explicit diff check**: `grep -rhoP '\$\{\K[A-Z][A-Z0-9_]+' --include='*.properties' --include='*.yml' --include='*.yaml' .` and diff against ENV_VARIABLES.md. Any var in modified files but not in ENV_VARIABLES.md = FAIL — add missing rows before closing. **Sub-Phase 6 amplification**: S3/storage migration tasks typically introduce 3-6 new env vars (bucket, region, endpoint, key, secret) — run targeted grep on modified files after each S3 integration change. **Archetype callout**: Narrowly-scoped tasks like backing-services externalisation almost always introduce DB_HOST/PORT/USER/PASSWORD/NAME reads — update ENV_VARIABLES.md in same task.
+3. **Count-literals verified** — numeric literals in docs match actual output
+4. **Manifest reconciliation** — for manifest-generation tasks, run Criterion 10 A-C
+5. **New env var assertion** — grep source for new env var reads; assert matching docs row
+6. **Repair task double .bak sweep** — pre-edit AND post-edit
+7. **Post-rename callsite verification** — after ANY rename, grep full source tree for old name
+8. **Post-extraction orphaned reference cleanup** — after removing an export from any module OR extracting a class/module to a standalone process, `grep -rn REMOVED_EXPORT` across ALL source files. Importers retaining the removed name hold dead code — delete orphaned `require()`/`import` lines. After extracting a scheduled-task daemon, audit the entrypoint script for daemon-setup steps (cp crontab, chmod, touch cron.log) and remove them.
+9. **Sync→async contract propagation** — after any sync→async conversion, parameter rename, or return-type change, `grep -rn functionName` across ALL source files. Every call site must be updated (add await, make caller async) or tagged with a MIGRATION comment.
+10. **Post-extraction scheduler removal verification** — after creating a CronJob manifest for a scheduled task, grep the primary Deployment source for the original scheduler trigger and assert it is absent or disabled.
+11. **ENV_VARIABLES.md mechanical diff gate** — run 4-pass grep on all modified files in this task; diff new `${VAR}` placeholders against ENV_VARIABLES.md; add any missing rows — zero undocumented vars at close.
+
+## Task Ordering Constraints
+
+1. Manifest generation is not final — at least one validation pass MUST follow.
+2. Criterion 10 repair tasks MUST complete BEFORE TRANSFORMATION_SUMMARY.md writing.
+3. validation-result.json is advisory only — re-derive from disk state.
+4. CronJob/Job NetworkPolicy co-location: same task scope.
+5. MIGRATION comment pre-scan before generating Part B resources.
+6. **The task plan MUST always include a dedicated Final Review task as the highest-numbered task solely responsible for generating TRANSFORMATION_SUMMARY.md. This task MUST NOT be merged with the validation task.** If the current worker is last in the plan AND TRANSFORMATION_SUMMARY.md does not yet exist, generate it before writing the task report.
+7. **Source-verification rule**: Before writing any cloud-SDK claim (S3, IRSA, SQS) in TRANSFORMATION_SUMMARY.md, verify the SDK is actually present in source dependencies (grep package manifest). Do not inherit claims from task descriptions without verification.
+
+## Post-Externalisation Test Sync Gate
+
+**When to run:** After adding `${VAR}` keys to production config (Sub-Phase §3) or after credential externalisation (Sub-Phase §7).
+
+After externalising configuration or credentials, verify that test infrastructure remains functional:
+
+| Stack | Action |
+|-------|--------|
+| Java/Spring | Diff production `.properties` against `src/test/resources/*.properties` — add safe test defaults for all new keys |
+| Ruby/Rails | Add `ENV['VAR'] \|\|= '<default>'` guards in `spec/rails_helper.rb` BEFORE `require_relative`; add matching dummy values to Dockerfile `RUN ... asset:precompile` block |
+| Python/Django | Add corresponding `os.environ.setdefault()` in `conftest.py` fixture |
+| Node.js/Jest | Add env vars to `jest.setup.js` or inline in test invocation |
+
+**Rule:** After any Sub-Phase §3 or §7 task that introduces `${VAR}` (no default) in production config, verify the test suite still passes (or document known pre-existing failures). Do NOT defer test sync to a separate task — complete within the same scope.
+
+## Implementation Steps
+
+### Sub-Phase §1: Initial Setup
+
+**Task-Start Protocol (context budget management)**: For tasks scoped to ≤5 source files, workers MUST read ONLY the task-specific language reference — NOT full SKILL.md, NOT docker-build-validation.md, NOT all reference files. Read additional references only when the task explicitly requires validation, Docker build, or cross-cutting concerns. This prevents context budget exhaustion before productive output.
+
+**Pre-flight codebase existence check (MANDATORY FIRST ACTION)**:
+```bash
+ls <codebase_path> && test $(find <codebase_path> -maxdepth 1 -type f | wc -l) -gt 0
+```
+If fails → write ERROR_REPORT.md and exit 1.
+
+**Phase 1 Report Cross-Verification** (when available):
+1. Confirm dependencies via source manifest grep.
+2. Extract blocker counts from executive summary narrative only.
+3. Service names from Phase 1 Container Decomposition Plan table, not generic templates.
+
+Steps:
+1. Prompt for readiness report path, validate, parse findings.
+2. Prompt for target transformation directory. Copy source.
+3. Ask access pattern (web/API/internal/mixed), detect HTTP server, ask about reverse proxy.
+
+   **Non-interactive defaults**: Access pattern: `backend-api`; Reverse proxy: `no` (unless nginx.conf/.htaccess found); Ports: derive from source grep; Execution scope: per `decomposition_scope` parameter.
+
+4. **Tier 3 validation decision gate**: See SKILL.md §Tier 3 Validation Decision Gate for the full protocol. Auto-detect cluster tools, attempt kwokctl download if absent, prompt user, record decision. In non-interactive/CI mode, default to skip but emit NOTICE. See also `references/docker-build-validation.md` §Tier 3 Ask-Before-Skip Protocol.
+5. Parse scorecard, build prioritised work plan (Blockers first).
+
+### Sub-Phase §2: Decomposition Assessment
+
+Reads Phase 1 Named Service Inventory and translates into execution decisions. See `references/microservice-decomposition-patterns.md` §Phase 2 Execution Rules.
+
+**Scope constraint by parameter:**
+- When `decomposition_scope=minimal` (default): execution scope is limited to the Minimal Execution Set (see `references/minimal-execution-set.md`). Only primary Deployment + required Jobs/workers get manifests. All other candidates go to roadmap.
+- When `decomposition_scope=full`: generate manifests for ALL Low and Medium complexity candidates. High-complexity candidates remain documented only.
+
+6. **Ingest decomposition plan**: Extract Named Service Inventory from Phase 1 report. If absent or <2 rows, document "No decomposition candidates" and proceed to §3. If NSI table lacks 11 columns, re-run enumeration algorithm.
+
+7. **Validate complexity ratings** against rubric (Low/Medium/High).
+
+8. **Identify primary Deployment** — per `references/minimal-execution-set.md` selection criteria.
+
+9. **Document ALL candidates in roadmap** — INFRASTRUCTURE_REQUIREMENTS.md §0 and TRANSFORMATION_SUMMARY.md §Roadmap.
+
+10. **Generate manifests per scope:**
+    - `minimal`: primary Deployment + required support only. Low-complexity → "Ready for extraction" in roadmap.
+    - `full`: primary Deployment + ALL Low/Medium candidates get Deployment, Service, NetworkPolicy. High → documented only.
+
+11. **Detect decomposition anti-patterns** (for in-scope services):
+    - Mode-toggle flags → per-mode Docker images (§17)
+    - HTTP+Consumer co-deployment → separate api + worker Deployments
+    - Single queue worker multi-domain → Worker Specialisation split
+
+### Sub-Phase §3: Configuration Externalisation (Factor 3)
+
+**Mandatory first action — source-authoritative env var grep**: Before writing ENV_VARIABLES.md, grep ALL source files for env var read patterns using the framework-specific patterns from §Sub-Phase §15. Use `set()` deduplication. The grep result is the authoritative baseline for row count — task descriptions carry planning-level names that may differ.
+
+**Entrypoint script secondary grep** (mandatory for ALL projects): After the language-specific grep, scan entrypoint/startup scripts for bash parameter-expansion variables:
+```bash
+grep -oP '\$\{\K[A-Z][A-Z0-9_]+(?=:-)' entrypoint*.sh docker-entrypoint*.sh start.sh run.sh 2>/dev/null | sort -u
+```
+Add results to ENV_VARIABLES.md under an "Entrypoint/Operational" subsection. These variables are language-agnostic and are missed by source-code-only greps.
+
+**Files in scope**: Application config, docker-compose*.yml (all overlays), entrypoint scripts, infrastructure config (nginx.conf, supervisord.conf, crontab).
+
+12. Replace hardcoded config with env var reads.
+13. Refactor environment-specific config files.
+14. Create ENV_VARIABLES.md (name, description, example, required/optional, K8s Scope). Source code is authoritative for var names.
+15. Grep profile/override config files for hardcoded overrides.
+16. PHP type safety: `filter_var` for booleans, `(int)` for integers.
+17. Configuration bypass patterns: inspect commented-out keys; grep direct config accessor calls.
+
+**Post-config-module patch sweep**: After patching any config module, grep ALL non-config source files for surviving call-site fallback expressions (e.g., `process.env.X || "localhost"`, `os.environ.get('X', 'localhost')`). Config-module-level fix alone is insufficient when application files read env vars directly bypassing the config module.
+
+**Per-document stale-claim gate**: After generating or modifying ENV_VARIABLES.md or any other `.md` document, immediately run `grep -niE 'will|shall|would' <file>` — do not defer to Final Review.
+
+### Sub-Phase §4: Session and Cache Externalisation (Factor 6)
+
+18. **Session verification gate**: Before adding Redis, grep for DB-backed patterns (Django `SESSION_ENGINE=...db`, Rails `ActiveRecord::SessionStore`, PHP `session.save_handler=user`). DB-backed → Redis NOT required.
+19. Replace file-based caching with distributed cache (retain pod-local for staleness-tolerant data).
+20. Configure connections via env vars.
+
+### Sub-Phase §5: Logging Transformation (Factor 11)
+
+**Pre-action step (MANDATORY):** Before modifying any log config file, run from repo root:
+```bash
+grep -rl 'RollingFile\|FileAppender\|DailyRollingFileAppender' --include='*.xml' --include='*.properties' --include='*.yml' .
+```
+Apply transformation to EVERY discovered file — not just the first one found. Multi-module projects commonly have 2-5 separate logging config files.
+
+**Guard:** Before removing non-file appenders (e.g., SocketAppender, JMXAppender), check if they are read programmatically (in-memory appenders backing UI features like admin log viewers). Only remove file-path-writing appenders.
+
+**Downstream test impact:** After changing default log output to stderr, immediately run the unit test suite. Test harnesses that capture stderr to BytesIO/StringIO buffers will see unexpected output. Document regressions in the task report for subsequent test tasks.
+
+21. Refactor file-based logging to stdout/stderr.
+22. Remove log rotation/archival.
+23. Retain constructor params for API compat.
+
+### Sub-Phase §5b: SMTP Relay Configuration
+
+When email sending detected, externalise SMTP config. Standard vars: SMTP_HOST, SMTP_PORT (ConfigMap); SMTP_PASSWORD (Secret); MAILER_FROM_ADDRESS (ConfigMap). Include all three port variants (25, 465, 587) in NetworkPolicy egress.
+
+### Sub-Phase §6: Local Filesystem to S3 Migration
+
+24-30. Refactor persistent data to S3 via SDK. User uploads: stream immediately. Images: S3 + pre-signed URLs. Downloads: S3 GetObject. Backups: document external CronJob. Temp/cache: emptyDir volumes. Audit health endpoint handlers for local FS checks.
+
+### Sub-Phase §7: Credentials and Secrets Remediation
+
+See `references/credential-audit-patterns.md` for the complete procedure (Forms A–F, IRSA, Secret classification).
+
+31. docker-compose*.yml credential audit FIRST.
+32. Remove entrypoint scripts that write credentials.
+33. AWS SDK: remove hardcoded keys, use default credential provider chain (IRSA).
+34. IRSA conditional: only set credentials when BOTH access-key and secret-key are non-empty.
+35. Apply IRSA to EVERY SDK entry point.
+36. AWS keys must be exactly `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`.
+
+### Sub-Phase §8: Backing Services Configuration (Factor 4)
+
+37. Replace hardcoded service addresses with env var reads.
+38. Separate env vars for distinct concerns sharing same backing service.
+
+### Sub-Phase §9: Scheduled Tasks and Background Jobs (Factor 8)
+
+39. Extract scheduled tasks. **Pre-extraction check**: Confirm tasks are actually registered (empty scheduler → skip). **Framework scheduler exception**: For frameworks with built-in scheduler entrypoints (Laravel Kernel, Rails schedule.rb, Django/Celery beat, Quartz Spring, APScheduler, node-cron), always generate CronJob regardless of registered task count — operators add tasks dynamically. **Disabled-scheduler carve-out**: If scheduler class exists but is explicitly disabled (e.g., `spring.quartz.auto-startup=false`), treat as empty — do not generate CronJob.
+40. CronJob manifests with concurrencyPolicy: Forbid. Add `app.kubernetes.io/role: cronjob` label for NetworkPolicy targeting.
+41. Worker Deployment for event-driven jobs with distributed locking.
+42. Extraction checklist: remove scheduler entry, grep consumers of removed exports, Node.js require.main guard.
+
+### Scheduled-Task Extraction Checklist
+
+After creating a CronJob manifest for any scheduled task, complete ALL items:
+
+1. **Grep for scheduler trigger in primary source**: `grep -rn 'cron.AddFunc\|@Scheduled\|APScheduler.add_job\|cron.schedule\|whenever' src/` — identify the in-process scheduler call.
+2. **Remove or disable the scheduler from primary binary**: Delete the in-process scheduler registration (the code that triggers the task on a timer). The Kubernetes CronJob schedule replaces it.
+3. **Convert cron format (Spring 6-field → K8s 5-field)**: Spring `@Scheduled(cron="0 0 */6 * * *")` has 6 fields (seconds first) — drop the leading seconds field for Kubernetes: `"0 */6 * * *"`. Add a YAML comment documenting the conversion.
+4. **Sub-minute intervals**: For intervals <60s (e.g., APScheduler `IntervalTrigger(seconds=30)`), use the shortest valid K8s schedule (`"* * * * *"` = every minute) with `activeDeadlineSeconds` < 60 on the CronJob spec.
+5. **Assert scheduler trigger absent post-task**: `grep -rn '<trigger_pattern>' src/` — must return zero matches (or matches only in test/docs).
+
+### Sub-Phase §10: Concurrency and Horizontal Scaling
+
+43. Replace in-memory event buses, rate limiters, sequence generators.
+44. Document resource sizing in infrastructure requirements.
+
+### Sub-Phase §11: Build, Release, Run Separation (Factor 5)
+
+45-47. Move build activities to Dockerfile. Produce immutable image.
+
+### Sub-Phase §12: Disposability and Startup Resilience (Factor 9)
+
+48. Add exponential backoff retry for database/Redis. Circuit breakers for non-critical deps.
+49. Extract heavy first-boot init to K8s Job. Set `terminationGracePeriodSeconds` to exceed application graceful shutdown window. Stack-specific references are authoritative when present (java-jvm-patterns.md, php-patterns.md override the generic formula).
+50. Remove runtime chown — set ownership at build time.
+
+### Sub-Phase §13: Security Hardening
+
+51. Non-root user in Dockerfile. Remove runtime root operations.
+52. Configurable temp directory for tmpfs mount.
+53. nginx: listen 8080, Service routes 80→8080. Sidecar: fastcgi_pass localhost:9000.
+
+**Writable Path Discovery**: After setting `readOnlyRootFilesystem: true`, identify all paths the application writes to at runtime (logs, cache, tmp, sessions, upload buffers, pid files). Add emptyDir volumes for each writable path. Common paths by stack:
+- PHP-FPM: `/tmp`, `/var/run/php`, `/var/log`, session path
+- nginx: `/var/cache/nginx`, `/var/run`, `/tmp`
+- Java: `/tmp`
+- Python: framework-specific (Celery Beat: schedule DB path; gunicorn: worker tmp)
+- Node.js: `/tmp`, upload buffer path
+
+### Sub-Phase §14: Database Connection Optimisation
+
+54. Connection pooler requirements, fix global settings, proper locking.
+
+### Sub-Phase §15: Kubernetes Manifest Generation
+
+55. Generate manifests in kubernetes/ for the execution scope (per `decomposition_scope`):
+    - `minimal`: Namespace, primary Deployment, Service, ConfigMap, Secret, NetworkPolicy, optional required Job/worker.
+    - `full`: All of the above PLUS Deployment+Service+NetworkPolicy for each Low/Medium candidate.
+
+    **For complex projects** (>3 workloads or >20 env vars): split into two tasks: (a) core resources, (b) policy/scaling + validation.
+
+    **Manifest generation MUST NOT be the final task.** At least one validation/repair pass follows.
+
+    **Blocker-fix ConfigMap override**: When Phase 1 identifies a blocker whose fix is a specific ConfigMap override (e.g., a hardcoded default that must be overridden at runtime), manifest generation MUST apply that override in the ConfigMap and cite the blocker ID in a YAML comment (e.g., `# Blocker F3: override source-code default`).
+
+    **Post-manifest ENV_VARIABLES.md reconciliation**: Run `references/validation-patterns.md` §Post-Manifest ENV_VARIABLES.md Reconciliation within same task scope.
+
+55b. **Source-authoritative env var gate (mandatory pre-manifest)**: Before finalising ConfigMap/Secret keys, grep actual source files for env var read patterns. Source code is authoritative — not task descriptions.
+
+    **Framework-specific grep patterns:**
+
+    | Framework | Grep Pattern |
+    |-----------|-------------|
+    | Ruby | `grep -rhoP "ENV(?:\.fetch\|\[)[('\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.rb'` |
+    | Node.js | `grep -rhoP 'process\.env\.([A-Z][A-Za-z0-9_]+)' src/ --include='*.js' --include='*.ts' --exclude-dir=node_modules` |
+    | Python | `grep -rhoP "os\.environ\.get\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.py'` |
+    | Java/Spring | `grep -rhoP '\$\{([A-Z][A-Z0-9_]+)[}:]' src/ --include='*.properties' --include='*.yml'` |
+    | Go | `grep -rhoP 'os\.Getenv\("([A-Za-z][A-Za-z0-9_]+)"\)\|viper\.Get.*\("([a-zA-Z][a-zA-Z0-9_.]+)"\)' . --include='*.go'` |
+    | PHP | `grep -rhoP "(?:getenv\|env)\(['\"]([A-Za-z][A-Za-z0-9_]+)" . --include='*.php'` |
+
+    Cross-reference grep output against task-spec. If spec says `DB_PASSWORD` but source says `OMRS_DB_PASSWORD`, use source name.
+
+56-67. Generate all resource types per access pattern and scope:
+- Namespace, Deployments (include only in-scope services), Services, ConfigMap, Secret, PVCs, CronJobs, Jobs, Ingress, NetworkPolicies, HPAs.
+- **HPA rule**: use `apiVersion: autoscaling/v2`. When `minReplicas > 1`, verify PVCs use ReadWriteMany.
+- **HPA emptyDir-only rule**: When all volumes are emptyDir, set `minReplicas: 1` with MIGRATION comment listing prerequisites before scaling.
+- **PVC RWM storageClassName**: Always include `storageClassName: "replace-with-rwm-class"` placeholder.
+- **RFC 1123 placeholder constraint**: ALL host/storageClassName placeholders MUST be lowercase.
+- **PVC mount-scope rule**: Mount ENTIRE data root on RWM PVC when app writes runtime config into subdirectories. Exception: 12-factor entrypoints regenerating config → emptyDir at root + PVC inner-mount.
+- **ConfigMap data values must be strings**: quote all numerics.
+- **File-upload Ingress annotation**: `nginx.ingress.kubernetes.io/proxy-body-size: <limit>`.
+- **$(VAR) command expansion**: resolves ONLY from same container's env: list. Use shell form for envFrom-sourced vars.
+- **Job/CronJob inline env**: Extract keys from ALL kubernetes/*.yaml including Job/CronJob container spec `env:`.
+
+### Sub-Phase §16: Infrastructure Requirements Document
+
+68-77. Generate INFRASTRUCTURE_REQUIREMENTS.md:
+- §0 Target Microservice Architecture (mandatory for ≥2 candidates)
+- §1 Database, §2 Redis/Cache, §3 S3, §4 IAM (include CopyObject for moves), §5 Networking, §5b SMTP, §6 Secrets, §7 Monitoring
+
+**Pending-annotation cleanup gate**: After generating previously-missing manifests, grep for `pending`/`not generated` annotations and update.
+
+**Backtick-scope rule**: Only backtick actual env var keys. SQL keywords, IAM placeholders → fenced code or plain text.
+
+### Sub-Phase §17: Dockerfile Update
+
+77-79b. Multi-stage build, non-root user, immutable image. Per-service Dockerfiles for in-scope services needing separate images.
+
+**Entrypoint root-ops audit**: After USER non-root, grep entrypoint scripts for `chown`, `adduser`, `apt-get`, `mkdir /var/run`, `mkdir /run`, `usermod`, `crontab`. Any match → runtime startup blocker, fix in same pass.
+
+### Sub-Phase §17b: Docker Build Verification
+
+See `references/docker-build-validation.md`. Tier 1 — must pass before Tier 2/3.
+
+### Sub-Phase §18: Minikube Validation (Conditional)
+
+84-94. Only if Tier 1 passed. Deploy, monitor, diagnose, validate.
+
+### Sub-Phase §19: Final Review
+
+95-97. Generate TRANSFORMATION_SUMMARY.md with:
+- **Required section headings**: `## Executive Summary`, `## Manifest Inventory`, `## Configuration Changes`, `## Security Hardening Summary`, `## NetworkPolicy Summary`, `## Microservice Decomposition Roadmap` (mandatory for monolith_risk high/critical; recommended otherwise).
+- Per-file changes, validation results (state which tier was reached).
+- §Microservice Decomposition Roadmap: Extraction Status table, Blocking Anti-Patterns Addressed, Remaining Prerequisites, Deferred Resources.
+
+**Configuration Changes key-accuracy gate**: After writing the Configuration Changes table, diff variable names against actual configmap.yaml `data:` keys + secret.yaml `stringData:` keys. Any mismatch is a documentation error — fix before closing.
+
+## Security Context Edge Cases
+
+| # | Workload Pattern | runAsUser | readOnlyRootFilesystem | capabilities |
+|---|---|---|---|---|
+| 1 | Official DB images (postgres, mysql, mongo) | 0 | false | add CHOWN/DAC_OVERRIDE/FOWNER/SETGID/SETUID |
+| 2 | Minimal init containers | 1000 | true | drop ALL |
+| 3 | Multi-UID sidecars | per-container | true | omit fsGroup |
+| 4 | Init containers using DB images | same as 1 | false | same as 1 |
+| 5 | nginx:alpine | 101 | true | drop ALL |
+| 6 | Process-manager containers (supervisord) | 0 | false | — |
+| 7 | curlimages/curl | 100 | true | drop ALL |
+| 8/8b | PHP-FPM/PHP-Apache on Debian | 33 | true | drop ALL |
+
+**Multi-UID workloads rule**: When a Job/CronJob or Deployment has containers with DIFFERENT UIDs (e.g., init container UID 0 + main container UID 1000, or PHP-FPM UID 33 + nginx UID 101), do NOT set `runAsUser` at pod level — set per-container in each container's `securityContext`. Keep `runAsNonRoot: true` and `fsGroup` at pod level.
+
+**UID mismatch anti-pattern**: `useradd -r` / `adduser --system` allocates dynamic UID. ALWAYS specify explicit UID: `useradd -r -g appgroup --uid 1000 appuser`.
+
+**Container-level securityContext must include ALL six fields**: `runAsNonRoot`, `runAsUser`, `runAsGroup`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation`, `capabilities` — even when pod-level sets some of them.
+
+**Pod-level fsGroup**: When `runAsUser` is non-zero AND pod mounts ANY volume, add `spec.securityContext.fsGroup` matching `runAsUser`.
+
+## Probe Rules by Workload Type
+
+| Workload | Probes Required |
+|----------|----------------|
+| Deployment main containers | All three (startup, readiness, liveness) |
+| Headless workers (no Service) | Exec probes only |
+| Init containers | No probes |
+| Job/CronJob WITH HTTP endpoint | startupProbe + livenessProbe (omit readiness) |
+| Job/CronJob WITHOUT HTTP endpoint | exec livenessProbe only (`kill -0 1`) |
+| Distroless containers | Omit ALL probes — use `activeDeadlineSeconds` (≤80% schedule interval) |
+
+**CronJob placement**: `activeDeadlineSeconds` in `jobTemplate.spec.activeDeadlineSeconds`, NOT spec root.
+
+**startupProbe first-boot sizing**: failureThreshold: 30, periodSeconds: 10 (300s budget).
+
+**Probe path authentication**: Verify probe path returns HTTP 2xx WITHOUT auth.
+
+### ⚠ CronJob/Job Probe + NetworkPolicy Completeness Mandate
+
+Before closing any manifest-generation task, enumerate ALL pod-creating resources:
+
+```bash
+grep -rl 'kind: Deployment\|kind: Job\|kind: CronJob' kubernetes/ | sort
+```
+
+For EACH resource found, assert:
+1. **Liveness probe exists** — Deployment: httpGet or exec; Job/CronJob without HTTP: `exec ["sh", "-c", "kill -0 1"]` with initialDelaySeconds:10, periodSeconds:30.
+2. **NetworkPolicy exists** — a NetworkPolicy whose podSelector matches the resource's pod labels. One-shot Jobs and CronJobs are the most commonly omitted — verify them explicitly.
+3. **Distroless exception**: omit probes, use `activeDeadlineSeconds` at `jobTemplate.spec.activeDeadlineSeconds`.
+
+**Verification (post-manifest):**
+```bash
+# Count pod-creating resources vs NetworkPolicies
+WORKLOADS=$(grep -rl 'kind: Deployment\|kind: Job\|kind: CronJob' kubernetes/ | wc -l)
+NETPOLS=$(grep -c 'kind: NetworkPolicy' kubernetes/*.yaml 2>/dev/null || echo 0)
+echo "Workloads: $WORKLOADS, NetworkPolicies: $NETPOLS"
+# NETPOLS must be >= WORKLOADS (each workload needs its own policy)
+```
+
+## NetworkPolicy Egress Trigger-Table
+
+| Env Var / Pattern | Egress Ports |
+|---|---|
+| MAIL_HOST / SMTP_HOST env var present | TCP 25, 465, 587 |
+| No SMTP env var BUT code-grep finds mail-sending patterns (smtp, mail(), SwiftMailer, PHPMailer, ActionMailer, nodemailer, etc.) | TCP 25, 465, 587 |
+| Rails ActionMailer (no env var, part of Rails core): check `config/environments/production.rb` for `action_mailer.delivery_method` AND `app/mailers/` for .rb files | TCP 25, 465, 587 |
+| CMS/eCommerce DB-stored SMTP config (no env var): add SMTP egress when admin UI configures mail relay | TCP 25, 465, 587 |
+| DB_HOST (PostgreSQL) | TCP 5432 |
+| DB_HOST (MySQL) | TCP 3306 |
+| REDIS_HOST | TCP 6379 |
+| S3_ENDPOINT / external APIs | ports-only, NO `to:` field |
+| Startup-eager connections | egress even without env var prefix |
+| Pre-configured optional backends (S3 keys present but disabled, Redis starter in pom.xml) | Include egress port with comment `# conditional — backend pre-configured` |
+| Spring auto-configuration triggers: `spring-session-data-redis` or `spring-boot-starter-data-redis` in pom.xml | TCP 6379 (auto-config connects at startup, no explicit import to grep) |
+
+**Rules**: External service egress uses ports-only — NO `to:` field. NEVER use `to: []`. Egress nesting: `namespaceSelector`/`podSelector` go INSIDE `to:` entries. ALL workloads MUST declare `policyTypes: [Ingress, Egress]`. Non-web workloads (workers, CronJobs, Jobs with no inbound traffic) use `ingress: []` (deny-all). Web workloads use explicit port-based ingress rules (e.g., allow from ingress controller on port 8080). CronJob podSelector must match `spec.jobTemplate.spec.template.metadata.labels`.
+
+**Egress NetworkPolicy port rule**: Use the POD port (containerPort), not the Service port. CNI policy enforcement operates post-DNAT, so the packet's destination port is the pod's listening port, not the Service's published port.
+
+## CronJob Manifest Reference
+
+Consolidates all CronJob edge cases that cause silent failures or kubeconform rejections.
+
+### activeDeadlineSeconds Placement
+
+`activeDeadlineSeconds` belongs at `spec.jobTemplate.spec.activeDeadlineSeconds`, NOT at the CronJob spec root. Root-level placement is silently ignored by Kubernetes but rejected by `kubeconform -strict`.
+
+```yaml
+# CORRECT:
+spec:
+  schedule: "0 */6 * * *"
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600  # ← HERE
+      template:
+        spec:
+          containers: [...]
+
+# WRONG (silently ignored):
+spec:
+  schedule: "0 */6 * * *"
+  activeDeadlineSeconds: 3600  # ← WRONG LEVEL
+  jobTemplate: ...
+```
+
+### Per-CronJob Task-Selector Env Vars
+
+Env vars that select WHICH task a CronJob runs (e.g., `TASK=send-reminders`) MUST be in the manifest's `env:` stanza, NOT in the shared ConfigMap. Different CronJobs need different selector values — ConfigMap is shared across all workloads.
+
+```yaml
+# CORRECT — inline env for task selection:
+containers:
+- name: cron-worker
+  env:
+  - name: TASK
+    value: "send-reminders"
+  envFrom:
+  - configMapRef:
+      name: app-config  # shared config
+```
+
+### CronJob podSelector for NetworkPolicy
+
+CronJob NetworkPolicy `podSelector` must match labels at `spec.jobTemplate.spec.template.metadata.labels` — NOT top-level CronJob `metadata.labels`. The NetworkPolicy targets the Pod, not the CronJob resource.
+
+### Two-Label Selector Precision Guard
+
+When CronJob and Deployment share the primary app label (e.g., `app: myapp`), add a discriminator label to prevent NetworkPolicy collision:
+- Deployment pod template: `app.kubernetes.io/component: web`
+- CronJob pod template: `app.kubernetes.io/component: cron`
+- Service and web-ingress NetworkPolicy selectors: include `app.kubernetes.io/component: web`
+
+Without the discriminator, a NetworkPolicy allowing ingress on port 8080 for the web Deployment also inadvertently applies to CronJob pods that share the `app: myapp` label.
+
+### Egress NetworkPolicy Port Selection
+
+Use the pod port (containerPort) in egress NetworkPolicy rules, not the Service port. CNI enforcement operates post-DNAT — the destination port in the packet is the pod's listening port.
+
+### kubeconform Assertion Limitation
+
+`kubeconform -strict` validates schema structure but does NOT catch:
+- `activeDeadlineSeconds` at wrong nesting level (silently ignored)
+- Secret keys with dots used via `envFrom` (silently skipped)
+
+Post-kubeconform, run placement assertions — see `references/docker-build-validation.md` §Post-kubeconform Placement Assertions.
+
+## emptyDir Mount Scope Rules
+
+### Rule A: emptyDir at path containing image-baked content
+
+When a path needs emptyDir for writability AND contains image-baked content (e.g., `/app/public` has static assets baked into the image), mounting emptyDir at that path HIDES all image content. Use an init container to copy content first:
+
+```yaml
+initContainers:
+- name: copy-content
+  image: same-app-image:tag
+  command: ['sh', '-c', 'cp -r /app/public/* /mnt/public/']
+  volumeMounts:
+  - name: public-writable
+    mountPath: /mnt/public
+containers:
+- name: app
+  volumeMounts:
+  - name: public-writable
+    mountPath: /app/public
+volumes:
+- name: public-writable
+  emptyDir: {}
+```
+
+**Source:** Kubernetes volumeMount at a path shadows all image-baked content — https://stackoverflow.com/questions/58128591/kubernetes-mount-volume-on-existing-directory-with-files-inside-the-container
+
+### Rule B: Parent vs child directory writability
+
+When mounting subdirectories for writability (e.g., `/app/storage/logs`, `/app/storage/cache`), verify the parent directory (`/app/storage/`) doesn't ALSO need writes. If the parent needs writes (e.g., framework creates directories dynamically), prefer a SINGLE parent-level emptyDir over multiple child mounts.
+
+**Decision tree:**
+1. Only specific subdirectories need writes → mount each child path individually
+2. Parent directory itself needs writes OR framework creates new subdirectories → mount at parent level + init container for image-baked content
+
+### Rule C: Recreate strategy for destructive startup with RWO PVC
+
+When a workload mounts an RWO (ReadWriteOnce) PVC AND the startup process is destructive (deletes/recreates content), use `strategy.type: Recreate` instead of RollingUpdate. RollingUpdate with RWO PVC causes the new pod to hang waiting for the PVC to be released by the old pod.
+
+```yaml
+spec:
+  strategy:
+    type: Recreate  # Required for destructive startup + RWO PVC
+```
+
+## File State Verification Protocol
+
+### Rule 1: After failed str_replace
+
+After a failed `str_replace` (old_str not found), run:
+```bash
+grep -n '<expected_new_content>' <file>
+```
+If found, a prior task already applied the change. This is an idempotent signal, not a defect — no action needed.
+
+### Rule 2: Verify live state before trusting context
+
+Before using any prior task's claimed file state, verify with:
+```bash
+grep -n '<expected_pattern>' <file>
+```
+Task context summaries describe intent, not guaranteed disk state.
+
+### Rule 3: ENV_VARIABLES.md row claims
+
+Before asserting a row exists based on prior context:
+```bash
+grep -c 'KEY_NAME' ENV_VARIABLES.md
+```
+
+## HPA MIGRATION Comment Precision
+
+Before writing a MIGRATION comment listing outstanding prerequisites for scaling:
+1. Read actual driver/adapter values from ConfigMap and source files
+2. Only list a prerequisite as outstanding if genuinely ABSENT from the current state
+3. For WebSocket apps, distinguish session store (connect-redis) from adapter (@socket.io/redis-adapter or cable.yml adapter) — missing adapter forces `minReplicas: 1`
+
+## Validation / Exit Criteria
+
+1. User prompted for all preferences. Original codebase unmodified.
+2. Source copied to transformation directory.
+3. Every blocker addressed.
+4. All hardcoded config replaced with env var reads.
+5. Sessions distributed. Caching appropriate.
+6. Logging → stdout/stderr.
+7. Persistent storage → S3.
+8. All credentials removed from source.
+9. Scheduled tasks extracted to CronJobs.
+10. Dockerfile builds (Tier 1). Non-root user.
+11. Complete kubernetes/ directory with in-scope resources.
+12. Deployments include resources, probes, security context, env refs, volumes.
+13. ENV_VARIABLES.md exists.
+14. INFRASTRUCTURE_REQUIREMENTS.md with §0 Target Microservice Architecture.
+15. TRANSFORMATION_SUMMARY.md with §Microservice Decomposition Roadmap.
+16. All manifests valid YAML (Tier 2 passes).
+17. Startup resilience implemented.
+18. Decomposition Assessment executed per `decomposition_scope`.
+19-22. Minikube criteria (if opted in AND Tier 1 passed).
+
+## Library-Specific Traps
+
+### Go
+- **pgxpool lazy connection**: Wrap `pool.Ping(ctx)` in retry-with-backoff.
+- **viper AutomaticEnv()**: must call AND `SetEnvKeyReplacer` for nested keys.
+
+### Node.js
+- **connect-redis**: v7: `require('connect-redis').default`; v9+: `const { RedisStore } = require('connect-redis')`.
+- **ioredis middleware**: `enableOfflineQueue: false`, `maxRetriesPerRequest: 0`.
+
+### Python / Celery
+- **config_from_object ordering**: explicit overrides after win silently.
+- **Celery Beat DB egress**: needs NetworkPolicy to database, not just broker.
+
+### Java / Spring
+- **env.getProperty() null**: returns null silently on missing key.
+- **Tomcat provided scope**: excludes from fat JAR — silent startup failure.
+
+### PHP
+- **filter_var boolean**: string 'false' is truthy. Use FILTER_VALIDATE_BOOLEAN.
+- **env() literal default**: makes IRSA guard always truthy. Default must be `''`.
+
+### Ruby
+- **ENV.fetch bare calls**: Causes KeyError during asset precompile. Audit before docker build.

--- a/community-sourced-transformations/kubernetes-readiness-migration/references/validation-patterns.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/references/validation-patterns.md
@@ -1,0 +1,1198 @@
+# Validation Patterns Reference
+
+Reusable validation patterns for post-batch and post-migration verification.
+
+## Table of Contents
+
+1. [YAML Structural Checks](#yaml-structural-checks)
+2. [Multi-Document YAML Handling](#multi-document-yaml-handling)
+3. [NetworkPolicy Port Cross-Reference](#networkpolicy-port-cross-reference)
+4. [ConfigMap subPath Alignment](#configmap-subpath-alignment)
+5. [.bak File Cleanup](#bak-file-cleanup)
+6. [JS/TS Syntax Validation](#jsts-syntax-validation)
+7. [Stale-Claim Sweep](#stale-claim-sweep)
+8. [CONDITIONAL PASS Enforcement](#conditional-pass-enforcement)
+9. [Grep Robustness Rules](#grep-robustness-rules)
+10. [Universal Comment-Stripping Rule](#universal-comment-stripping-rule)
+10b. [Comment Exclusion Filter](#comment-exclusion-filter)
+11. [ENV_VARIABLES.md Section-Bounded Counting](#env_variablesmd-section-bounded-counting)
+12. [False-Positive Avoidance](#false-positive-avoidance)
+13. [Validation Anti-Patterns](#validation-anti-patterns)
+14. [Pre-Manifest ENV_VARIABLES.md Audit](#pre-manifest-env_variablesmd-audit)
+15. [ConfigMap Data-Type Assertion](#configmap-data-type-assertion)
+16. [Cross-File Duplicate Resource Name Check](#cross-file-duplicate-resource-name-check)
+17. [Secret Key Count](#secret-key-count)
+18. [Decomposition Manifest Validation](#decomposition-manifest-validation)
+19. [RFC 1123 Placeholder Validation](#rfc-1123-placeholder-validation)
+20. [Exit-Code Traps](#exit-code-traps)
+21. [Banned-Construct Comment Stripping](#banned-construct-comment-stripping)
+22. [Post-Debugger Prose Consistency](#post-debugger-prose-consistency)
+23. [validate.sh Scripting Anti-Patterns](#validatesh-scripting-anti-patterns)
+24. [Post-Manifest ENV_VARIABLES.md Reconciliation](#post-manifest-env_variablesmd-reconciliation)
+25. [Dockerfile COPY Word-Boundary Checks](#dockerfile-copy-word-boundary-checks)
+26. [YAML Boolean Assertion Pitfall](#yaml-boolean-assertion-pitfall)
+27. [Assertion Robustness Rules](#assertion-robustness-rules)
+28. [Key-Count Atomicity Rule](#key-count-atomicity-rule)
+29. [Scope Column Reconciliation](#scope-column-reconciliation)
+30. [ENV_VARIABLES.md Final Review Completeness Check](#env_variablesmd-final-review-completeness-check)
+31. [Shell Idioms and Structured Parsing](#shell-idioms-and-structured-parsing)
+32. [Pre-Generation Duplicate Resource Check](#pre-generation-duplicate-resource-check)
+33. [Validation Script Correctness Checklist](#validation-script-correctness-checklist)
+
+## YAML Structural Checks
+
+**1. Selector ↔ Label Parity**: Every Deployment `spec.selector.matchLabels` must match `spec.template.metadata.labels`.
+
+**2. HPA scaleTargetRef**: Every HPA `spec.scaleTargetRef.name` must match a Deployment `metadata.name`.
+
+**3. NetworkPolicy DNS Rule**: Every egress NetworkPolicy (non-empty `spec.egress`) must include UDP+TCP 53. Use per-file loop — NEVER use `xargs grep -L` (false pass when stdin is empty).
+
+**4. envFrom Name Resolution**: Every `configMapRef.name`/`secretRef.name` must match a resource `metadata.name`. Parse via `yaml.safe_load_all()`, not grep.
+
+**5. Unreferenced ConfigMap/Secret** (including envFrom bulk injection): Use Python `yaml.safe_load_all()` to collect all ConfigMap/Secret names and all references from workload containers (env valueFrom + envFrom). Also scan `pod_spec.get("volumes", [])` for entries where `vol.get("configMap", {}).get("name")` or `vol.get("secret", {}).get("secretName")` matches a resource name — these are volume-mounted references. Any resource with no reference (neither env nor volume) is an error.
+
+**6. Namespace Membership**: All resources (except Namespace, Kustomization) must declare the namespace.
+
+**7. PVC RWM storageClassName**: Every PVC with `ReadWriteMany` must include `storageClassName`.
+
+## Multi-Document YAML Handling
+
+All structural assertions on Kubernetes YAML MUST use Python `yaml.safe_load_all()` — NOT grep-based extraction. This applies to metadata.name assertions, field presence checks, and count verification.
+
+## NetworkPolicy Port Cross-Reference
+
+After generating NetworkPolicies, cross-reference egress port values against containerPorts from workloads and a standard-ports exclusion list (53, 443, 80, 8080, 5432, 3306, 6379, 27017, 9000, 9200, 25, 587, 465). Any NP port not in containerPorts and not standard is a potential error.
+
+## ConfigMap subPath Alignment
+
+For each `subPath:` value in volume mounts, verify a matching `items[].path` exists in the referenced ConfigMap volume definition.
+
+## .bak File Cleanup
+
+**Per-Task Mandatory Procedure**: The str_replace editor tool creates `.bak` sidecar files with every edit operation. Worker MUST run cleanup after EVERY task that uses str_replace, not just in Initial Setup.
+
+**Immediate cleanup command** (run after EVERY editor str_replace/pattern_replace):
+```bash
+find <repo-root> -name '*.bak' -not -path '*/.git/*' -delete
+```
+
+**Correct verification idiom:**
+```bash
+BAK_COUNT=$(find <PROJECT_ROOT> -name '*.bak' -not -path '*/.git/*' | wc -l)
+[ "$BAK_COUNT" -eq 0 ] && echo "CLEAN" || echo "FOUND: $BAK_COUNT"
+```
+
+**Pre-Final-Review verification:**
+```bash
+find . -name '*.bak' | wc -l
+# Must output 0
+```
+
+**Scope**: The sweep MUST cover the full project root with NO directory exclusions — including `target/`, `build/`, `vendor/`, `node_modules/`. Command: `find <PROJECT_ROOT> -name "*.bak" -delete` (no path restriction other than `.git/`).
+
+**When to run (triple-point):** (1) Step-0 of every task, (2) immediately after EVERY `editor` command, (3) before any assertion or validation check.
+
+**IMMEDIATE cleanup rule**: Do NOT defer .bak cleanup to end of task. Run the cleanup command immediately after each editor operation. Deferred cleanup causes downstream validation failures.
+
+**The .bak sweep is the ABSOLUTE LAST shell command before task closure** — after ALL edits and repair passes, not just after first-round edits. Re-run after ANY edit triggered by repair, review, or debugger pass. If any subsequent pass creates .bak files, the sweep must execute again.
+
+**Affected file types**: ALL files edited produce `.bak` files — `.php`, `.yaml`, `.py`, `.java`, `.js`, `.html`, `.md`, `.xml`, `.conf`, `.properties`, and any other.
+
+**Idempotence**: Running the cleanup command twice has no additional effect — `find -delete` on zero matches exits cleanly.
+
+## JS/TS Syntax Validation (Tier 1 for Node.js)
+
+```bash
+node --check path/to/file.js
+npx tsc --noEmit path/to/file.ts
+```
+
+**Node.js template-literal pre-emption**: Before running Python brace-balance checker on any `.js` file, check for template literals:
+```bash
+grep -c '`.*\${' file.js
+```
+If found (count > 0), skip brace-balance — use `node --check` directly instead. Template literals produce false positives in brace-balance checkers.
+
+**Node.js non-standard path discovery** (when `node` not in PATH):
+```bash
+find /tmp /opt /usr/local -name node -type f 2>/dev/null | head -1
+```
+
+## Stale-Claim Sweep
+
+Implements SKILL.md Criterion 9 outcome checks (b)–(e). Step (a) (.bak sweep) uses §.bak File Cleanup above. Step (f) is in §CONDITIONAL PASS Enforcement below.
+
+### Self-Reference Avoidance Rule (Self-Referential Label Anti-Pattern)
+
+Audit trail row labels and Notes cells MUST use functional abstractions, never literal banned tokens. Otherwise the stale-claim grep will flag the documentation of the check itself, triggering infinite repair loops.
+
+**Required substitutions:**
+| Instead of | Write |
+|---|---|
+| `will`/`shall`/`would` in row labels | "Future-tense verb ban" |
+| `TODO`/`TBD` in row labels | "Open-issue marker check" |
+| Verbatim grep command string as check output | "Source grep returned 0 matches" |
+| Quoting a banned phrase to show what was fixed | Describe functionally: "Removed future-tense language from paragraph 3" |
+
+**Canonical safe vs unsafe example:**
+| ❌ Unsafe (triggers self-grep) | ✓ Safe (functional abstraction) |
+|---|---|
+| Scanned for `will` — 0 hits | Future-tense verb scan — 0 hits |
+| Removed `shall be migrated` from §3 | Corrected future-tense language in §3 |
+| Check: `grep -n 'would'` → clean | Conditional-verb absence confirmed |
+| Row label: `will` check | Row label: Future-tense verb ban |
+
+**Post-table re-sweep**: After writing ANY audit trail table, re-run the full-document stale-claim sweep to confirm the table itself is clean. Do not assume functional abstractions are safe without verification. In audit trail tables, use functional descriptions as row labels rather than quoting the banned phrase verbatim (e.g., "Future-tense verb scan" instead of the literal word).
+
+**Preventive authoring principle**: Author ALL transformation documents in past/present tense from the FIRST DRAFT. The stale-claim sweep is a fast confirmation step, not a correction pass. When describing completed work, use: Externalised, Redirected, Migrated, Replaced, Removed, Extracted, Configured, Generated, Documented.
+
+**Row-by-row sweep timing**: Run the stale-claim sweep immediately after writing EACH audit trail row, not only at task close. Late-detected violations in early rows cause multi-row cascading repairs. This is especially important for the .bak audit trail row — use the verbatim canonical format `PASSED (N found and removed during cleanup; 0 remaining)` exactly; never abbreviate.
+
+### Safe Label Substitution Table (Stale-Claim False-Positive Avoidance)
+
+The security-hardening grep targets status cells only. Notes/Details cells containing these words as natural adjectives (e.g., "All 6 required fields are present") are false positives. Use these pre-authored safe labels:
+
+| ❌ Triggers sweep | ✓ Safe replacement | Context |
+|---|---|---|
+| `All 6 required fields` | `All 6 mandatory fields` | Criterion 8 status description |
+| `recommended approach` | `supported approach` | Architecture notes |
+| `not generated` | `roadmap only` | Deferred manifest annotation |
+| `Action Required` | `Operator Setup Step` | Infrastructure action items |
+| `Known-issue resolution` | `Prior-findings verification` | Audit trail row label |
+| `Required` (Security status cell) | `Applied` | Security Hardening table |
+| `Recommended` (Security status cell) | `Configured` | Security Hardening table |
+| `must be configured` | `operator configures at deploy time` | Infrastructure notes |
+
+**Pre-sweep checklist** — before generating TRANSFORMATION_SUMMARY.md content:
+1. Replace "required" with "mandatory" when describing field counts or spec compliance
+2. Replace "recommended" with "supported" when describing approaches
+3. Replace "not generated" with "roadmap only" for deferred manifests
+4. Replace "Action Required" headings with "Operator Setup Step"
+5. Use past-tense verbs for all completed work (Applied, Configured, Migrated)
+
+### Stale-Claim Authoring Rules
+
+Three anti-patterns cause stale-claim sweep false positives. Apply these rules when writing ANY validation or audit-trail documentation:
+
+1. **No verbatim quotation in Notes cells**: Audit trail Notes cells must use functional descriptions of what was fixed — NOT verbatim quoted banned phrases. Write "Removed future-tense language from paragraph 3" not "Removed `will be migrated` from paragraph 3".
+2. **No literal banned tokens in row labels**: Sweep table row labels must use abstractions, not the literal tokens they check. Write "Future-tense verb ban" not a cell containing `will`/`shall`/`would` as the label itself.
+3. **Full-document re-sweep after targeted edits**: After fixing any stale-claim violation in a specific table or section, re-run the complete document sweep — never scope to tables only. Violations in prose paragraphs outside tables are missed by targeted-edit workflows.
+
+### Pre-Authored Self-Reference-Safe Row Labels
+
+Copy these labels directly into audit trail tables rather than composing your own. Each row represents a common audit check and its safe abstraction:
+
+| Audit Category | ❌ UNSAFE label (triggers sweep) | ✓ SAFE label (copy this) |
+|---|---|---|
+| Future tense check | "No will/shall/would found" | "Future-tense gate: clean" |
+| Banned phrase check | "No TODO/TBD present" | "Open-issue marker gate: clean" |
+| Conditional-verb check | "would/could absent" | "Conditional-verb absence: confirmed" |
+| Stale-claim grep output | "grep returned: will..." | "Source grep returned 0 matches" |
+| Documentation fix note | "Removed 'will be migrated'" | "Corrected future-tense language" |
+| Known-Issues resolution | "Known-Issues scan: none" | "Resolved-issue verification: clean" |
+| Action-required check | "No TODO items remaining" | "Action-marker gate: clean" |
+| INFRA_REQ sweep | "No 'should be' in INFRA doc" | "Advisory-language gate: clean" |
+| Tool-skipped recording | "CONDITIONAL PASS" (when tool absent) | "PASSED (skipped — tool unavailable)" |
+| Security status cell | "Required" / "Recommended" | "Applied" / "Configured" |
+
+**Usage rule**: Workers MUST copy the SAFE label column verbatim. Do NOT compose custom labels that contain the literal banned phrase — this is the #1 cause of self-referential repair loops.
+
+### Safe Label Templates for Audit Trail Notes Cells
+
+Copy-paste these exact strings into Notes cells rather than composing your own:
+
+| Scan Type | Safe Notes Text |
+|---|---|
+| Future-tense sweep | `Future-tense gate: clean` |
+| Banned-phrase sweep | `Banned-phrase check: clean` |
+| .bak file sweep | `PASSED (N found and removed during cleanup; 0 remaining)` |
+| Known-Issues resolution | `Resolved-issue verification: clean` |
+| File-path verification | `All cited paths verified on disk` |
+| Security status | `Applied` or `Configured` |
+| Tool-skipped tier | `PASSED (skipped — tool unavailable)` |
+| Heading-format check | `Heading-format check: clean` |
+| Advisory-language gate | `Advisory-language gate: clean` |
+| Action-marker gate | `Action-marker gate: clean` |
+
+### Two-Category Triage for Phase 1 Documents
+
+In Phase 1 documents (readiness reports), distinguish:
+- **(a) Work-claim future tense** ("X will be fixed", "sessions will be migrated") → correct to past tense.
+- **(b) Causal-consequence future tense** ("if Y fails, X will crash", "scaling will cause lock contention") → leave intact.
+
+Only category (a) requires correction. Category (b) describes conditional system behaviour, not work-in-progress claims.
+
+**IMPORTANT**: The Two-Category Triage exemption applies ONLY to Phase 1 readiness reports. For ALL Phase 2 documents (TRANSFORMATION_SUMMARY.md, ENV_VARIABLES.md, INFRASTRUCTURE_REQUIREMENTS.md), NO exemptions — fix every `will`/`shall`/`would` regardless of context.
+
+### Shell Glob Exclusion
+
+Shell glob patterns in backticks (e.g., `kubernetes/*.yaml`) trigger the file-path regex during Step 7. Replace backtick-quoted glob patterns in prose with descriptions: "all YAML files in the kubernetes/ directory" rather than `` `kubernetes/*.yaml` ``.
+
+### Step 3: Future-tense grep — ALL transformation documents (NO EXEMPTIONS)
+
+**SCOPE**: TRANSFORMATION_SUMMARY.md, ENV_VARIABLES.md, INFRASTRUCTURE_REQUIREMENTS.md, AND any Phase 1 `*.html` readiness reports. Source code files are EXCLUDED. This step scans ALL generated `.md` files — not just TRANSFORMATION_SUMMARY.md.
+
+```bash
+grep -nE '\b(will|shall|would)\b' TRANSFORMATION_SUMMARY.md ENV_VARIABLES.md INFRASTRUCTURE_REQUIREMENTS.md *.html 2>/dev/null | grep -v '^\s*#'
+```
+
+Every match is a violation. Fix by applying approved past-tense verbs: Externalised, Redirected, Migrated, Replaced, Removed, Extracted, Configured, Generated, Documented. **There are NO exemptions for Step 3 in Phase 2 documents.** The Two-Category Triage applies ONLY to Phase 1 `*.html` readiness reports in this grep's scope.
+
+### Step 4: "should be" + banned phrases — TRANSFORMATION_SUMMARY.md ONLY
+```bash
+grep -nP '(should be|must be|\bTODO\b|\bTBD\b|\bpending\b|will be addressed|should be done|will migrate|will configure|improved|optimized|may need|could require|\*\*Remaining action:\*\*|\*\*Next step:\*\*|\*\*Action required:\*\*|\*\*TODO:\*\*|\bReserved\b)' TRANSFORMATION_SUMMARY.md | grep -v 'forward-reserved'
+```
+
+**Word-boundary anchors (`\b`) for short tokens**: Always use `\bTODO\b`, `\bTBD\b`, and `\bpending\b` with `grep -P` (Perl regex) — never bare `TODO` with `grep -E`. Tokens like `Mastodon` contain `TODO` as a substring; `depending`/`appending` contain `pending` as a substring. Without word boundaries, false positives occur. The `-P` flag is REQUIRED for `\b` support — `-E` (ERE) does not support `\b` reliably on all platforms.
+
+**Consolidated audit row mandate**: Even when individual banned-phrase sub-checks (future-tense, TODO, pending) are listed in separate audit trail rows, the consolidated row `Banned-phrase check: clean` is MANDATORY in the final audit table. Omitting the consolidated row is a validation defect.
+
+**Advisory-language exemptions (Step 4 only, TRANSFORMATION_SUMMARY.md only):** (a) conditional/hypothetical descriptions in sections labelled "Future Migration Path" or "Deferred", (b) the Microservice Decomposition Roadmap conditional-consequence pattern.
+
+### Step 5: Known-Issues scan — TRANSFORMATION_SUMMARY.md ONLY
+```bash
+grep -inE 'Known.*Issue|Known.*Discrepan' TRANSFORMATION_SUMMARY.md
+```
+For each match, verify the underlying issue is actually resolved. If resolved, ensure prose reflects post-fix state.
+
+### Step 6: Post-debugger documentation re-sweep
+
+See §Post-Debugger Prose Consistency below.
+
+### Step 7: File-path verification (TRANSFORMATION_SUMMARY.md only)
+
+Every file path cited in TRANSFORMATION_SUMMARY.md must exist on disk.
+
+**Pre-filters** (prevent false positives):
+1. **Exclude absolute paths** starting with `/` — these are container-internal paths.
+2. **Match only repo-relative prefixes**: only paths beginning with `kubernetes/`, `k8s/`, `src/`, `config/`, `lib/` are checked.
+3. **Exclude class paths**: paths that are abbreviated class paths from Phase 1 metadata (e.g., `com.example.app.service`) are not file paths.
+
+**Path-matching regex**: Use `[A-Za-z0-9/_.-]` (NOT lowercase-only `[a-z0-9/_.]`) to handle camelCase filenames (e.g., `src/ConfigManager.js`, `kubernetes/networkPolicy.yaml`).
+
+**Content-authoring rules**: Deferred Resources tables MUST NOT use backtick-quoted `kubernetes/` paths for files that do not exist — describe by resource type only. Container-internal or classpath locations must use descriptive prose or filename-only.
+
+**Correct grep idiom**:
+```bash
+if grep -qE 'pattern' file; then echo "FAIL"; else echo "PASS"; fi
+```
+
+**`forward-reserved` exclusion**: applies to ALL file types. The compound term 'forward-reserved' is an expected annotation — not a banned phrase match.
+
+### Step 8: Heading-format check (TRANSFORMATION_SUMMARY.md only)
+
+Malformed Markdown headings with doubled `#` (e.g., `## ## Section`) break document structure.
+
+```bash
+grep -n '^#{1,6} #{1,6}' TRANSFORMATION_SUMMARY.md
+# Any match = malformed heading — fix by removing duplicate # characters
+```
+
+### Step 9: Code/doc parity re-sweep (post-debugger)
+
+After any debugger or repair pass that modifies source files, verify every documented security change still matches source state:
+```bash
+# For each security claim in TRANSFORMATION_SUMMARY.md (e.g., "readOnlyRootFilesystem: true"),
+# grep the manifest to confirm it is present
+grep -r 'readOnlyRootFilesystem: true' kubernetes/*.yaml
+```
+If a documented change is not reflected in source, the documentation is stale — fix before closing.
+
+## CONDITIONAL PASS Enforcement
+
+**Purpose:** `CONDITIONAL PASS` is reserved for cases where a tool **was present** but produced a recoverable failure. Tool absence is NOT a conditional failure — it must be recorded as `PASSED (skipped — tool unavailable)`.
+
+**When to run:** Post-migration, after TRANSFORMATION_SUMMARY.md is written.
+
+**Key distinction:**
+
+| Situation | Correct status |
+|-----------|---------------|
+| Docker unavailable (not installed) | `PASSED (skipped — tool unavailable)` |
+| Docker present but build failed (fixable) | `CONDITIONAL PASS` |
+| Minikube/KWOK not installed | `PASSED (skipped — tool unavailable)` |
+| Minikube present but cluster apply failed | `CONDITIONAL PASS` |
+| Test suite present but tests fail due to missing system deps | `CONDITIONAL PASS` |
+
+**Scan for misclassified tool-absence entries** (bare `CONDITIONAL PASS` where tool was simply absent):
+
+1. Check whether Docker was present or absent:
+```bash
+# If Docker was absent (not FAILED), it should read "PASSED (skipped — tool unavailable)"
+grep -n 'CONDITIONAL PASS' TRANSFORMATION_SUMMARY.md
+```
+
+2. For each `CONDITIONAL PASS` match, verify it corresponds to a tool-present-but-failed scenario. If the tool was simply absent, replace with `PASSED (skipped — tool unavailable)`.
+
+3. Legitimate `CONDITIONAL PASS` entries (tool was present but produced a recoverable failure) are left as-is.
+
+**Verification:** After any replacements, re-run the scan. All remaining `CONDITIONAL PASS` entries must correspond to recoverable tool failures, not tool absence.
+
+## Grep Robustness Rules
+
+### Rule 0: grep -c Exit-Code Trap (CRITICAL)
+
+`grep -c` exits with code 1 when zero lines match (same as regular grep). This breaks common patterns:
+
+**Anti-pattern — `grep -c PATTERN file || echo 0`:**
+```bash
+# BROKEN: When grep -c matches 0 lines, it exits 1 AND outputs "0" to stdout.
+# The || branch fires, producing SECOND line "0" — result is multi-line output.
+count=$(grep -c 'PATTERN' file || echo 0)
+# $count is now "0\n0" — NOT "0"!
+```
+
+**Correct idiom — assignment with fallback:**
+```bash
+count=$(grep -c 'PATTERN' file 2>/dev/null) || count=0
+# Works correctly: if grep exits 1 (no matches), count is set to 0.
+# If grep exits 0 (matches found), count has the actual count.
+```
+
+**Alternative — tempfile pattern (recommended for complex checks):**
+```bash
+grep -n 'PATTERN' file > /tmp/check.txt 2>/dev/null
+if [ -s /tmp/check.txt ]; then
+  echo "VIOLATIONS FOUND:"
+  cat /tmp/check.txt
+else
+  echo "CLEAN"
+fi
+```
+
+**Source:** grep exit status — https://www.gnu.org/software/grep/manual/html_node/Exit-Status.html — "Normally the exit status is 0 if a line is selected, 1 if no lines were selected, and 2 if an error occurred."
+
+### Rule 1: Anchor Dockerfile instruction checks with ^
+```bash
+grep -n '^FROM\|^RUN\|^COPY\|^ENV' Dockerfile | grep 'pattern'
+```
+
+### Rule 2: Comment exclusion for ALL config file types
+Strip comments before asserting presence/absence. See §Comment Exclusion Filter.
+
+### Rule 3: Substring-match guards
+```bash
+# nginx port — GOOD: semicolon terminator prevents 80 matching 8080
+grep -E 'listen\s+80;' nginx.conf
+```
+
+### Rule 4: PHP lint output — NEVER grep for 'syntax error'
+```bash
+php -l file.php > /dev/null 2>&1 && echo "PASS" || echo "FAIL"
+```
+
+### Rule 5: Source-file-only scoping for env-var-reads assertions
+```bash
+grep -rn 'os\.environ\|getenv\|process\.env' --include='*.py' --include='*.js' --include='*.go' --include='*.java' --include='*.rb' --include='*.php' . | grep -v 'kubernetes/' | grep -v 'node_modules/'
+```
+
+### Rule 6: YAML resource-name absence checks — use yaml.safe_load_all(), not grep
+
+### Rule 7: Absent-string checks must pipe through comment-stripping first
+```bash
+grep -v '^\s*#' file.yaml | grep -q 'legacy_pattern' && echo "FAIL" || echo "PASS"
+```
+
+### Rule 8: MIGRATION comment prose must not reproduce literals
+Use functional description, not the removed literal value.
+
+### Rule 9: Dockerfile instruction counting — line-start anchoring (REQUIRED)
+```bash
+grep -c '^FROM' Dockerfile
+```
+
+### Rule 10: Never pipe grep -l to xargs grep -L for positive assertion checks
+Use per-file loop with explicit missing-case handling instead.
+
+### Rule 11: Absence-check idiom (grep exits 1 on zero matches)
+For checks where "no match = CLEAN", never use `grep pattern && echo CLEAN` (never prints CLEAN because grep exits 1). Always use:
+```bash
+if grep -qE 'pattern' file; then echo "FAIL"; else echo "CLEAN"; fi
+```
+
+⚠ **grep && false-failure trap**: `grep` exits 1 when zero lines match. For validation checks where zero matches = PASS, NEVER use `grep ... && echo PASS` — the `&&` short-circuits to failure when grep is clean. Use the tempfile idiom:
+```bash
+RESULT=$(grep -nE 'PATTERN' file 2>/dev/null || true)
+[ -z "$RESULT" ] && echo "CLEAN" || echo "FAIL: $RESULT"
+```
+
+### Rule 12: Env var key regex — always include digits
+Use `[A-Z0-9_]+` (NOT `[A-Z_]+`) for env var key matching. Variable names commonly contain digits (e.g., `S3_BUCKET`, `REDIS_DB_0`).
+
+### Rule 13: Quantified credential pattern scans — use Python `re` module
+GNU grep ERE handles `{n,}` interval expressions inconsistently across versions. When scanning for quantified patterns (e.g., password length checks like `[A-Za-z0-9]{8,}`), use Python `re` module instead of `grep -E` to avoid silent false CLEAN results from parse errors:
+```bash
+python3 -c "
+import re, sys
+pattern = re.compile(r'[A-Za-z0-9]{8,}')
+for line in open(sys.argv[1]):
+    if pattern.search(line): print(line.rstrip())
+" file.yaml
+```
+
+### Rule 14: Service selector parity — ANY-match semantics
+When verifying Service selectors match Deployments, assert AT LEAST ONE Deployment matches (`len(matches) > 0`). Do NOT use ALL-match — not every Deployment needs to match every Service.
+
+### Rule 15: RFC 1123 hostname check — use yaml.safe_load_all()
+Do NOT grep raw YAML for hostname patterns — this matches JDBC URL substrings inside Secret data values. Instead, use `yaml.safe_load_all()` to extract actual Ingress `spec.rules[].host` and PVC `spec.storageClassName` field values, then validate those values individually.
+
+### Rule 16: Absence assertions MUST strip comment lines (MANDATORY)
+
+Before asserting that a pattern is ABSENT from a file, ALWAYS strip comment lines first. A pattern appearing ONLY in a comment (MIGRATION comment, TODO comment, explanation) is NOT a violation.
+
+**Per-language comment-strip commands (apply before absence check):**
+```bash
+# Java/C#/JS/Go — strip // and * comments:
+grep -v '^\s*\(//\|[*]\)' file | grep -q 'BANNED_PATTERN' && echo "FAIL" || echo "CLEAN"
+
+# Python/Ruby/shell — strip # comments:
+grep -v '^\s*#' file | grep -q 'BANNED_PATTERN' && echo "FAIL" || echo "CLEAN"
+
+# PHP — strip //, *, and # comments:
+grep -v '^\s*\(//\|[*]\|#\)' file | grep -q 'BANNED_PATTERN' && echo "FAIL" || echo "CLEAN"
+```
+
+**Rule:** Every absence assertion in validation checks MUST pipe through the appropriate comment filter BEFORE evaluating. This prevents MIGRATION comments from triggering false violations.
+
+### Rule 17: Banned-phrase word-boundary anchors for natural-language words
+
+When scanning for banned natural-language words (e.g., `pending`, `TODO`), use ERE word-boundary anchors to prevent substring matches:
+
+```bash
+# WRONG — matches "depending", "appending", "suspending":
+grep -i 'pending' INFRASTRUCTURE_REQUIREMENTS.md
+
+# CORRECT — matches only standalone "pending":
+grep -P '\bpending\b' INFRASTRUCTURE_REQUIREMENTS.md
+```
+
+**Rule:** Use `grep -P '\bWORD\b'` (Perl regex with `\b`) for short natural-language words in banned-phrase sweeps. Without word boundaries, words like `pending` match inside `depending`, `appending`, etc.
+
+### Rule 18: Icon/severity row-counting — match finding-row prefix only
+
+When counting severity icons (🔴, 🟡, 🔵) in scorecard reports, match ONLY lines that start with a finding-row prefix (e.g., `| F` for F-numbered findings) to exclude header rows, legend entries, and scorecard summary rows:
+
+```bash
+# Count ONLY finding rows (F-prefixed):
+grep -c '^| F[0-9]' report.md
+# NOT: grep -c '🔴' report.md (matches legend, headers, prose)
+```
+
+## Universal Comment-Stripping Rule
+
+**ALL absence checks MUST strip comment lines before matching.** A word appearing ONLY in a comment MUST NOT trigger a false positive. Apply the appropriate filter from §Comment Exclusion Filter below before evaluating any presence/absence assertion.
+
+## Comment Exclusion Filter
+
+| File Type | Filter Command |
+|-----------|---------------|
+| Dockerfile, Makefile, YAML, shell, nginx.conf | `grep -v '^\s*#'` |
+| PHP | `grep -v '^\s*\(//\|[*]\|#\)'` |
+| Java, JavaScript, TypeScript | `grep -v '^\s*\(//\|[*]\)'` |
+| Python | `grep -v '^\s*#'` |
+| Ruby | `grep -v '^\s*#'` |
+| Go | `grep -v '^\s*\(//\|[*]\)'` |
+
+## ENV_VARIABLES.md Section-Bounded Counting
+
+Use section-bounded counting to avoid inflated counts from multiple tables. Count only rows between the first `## Variable` heading and the next `##` heading. Character class handles mixed-case env vars.
+
+**SECRET/PASSWORD classification rule**: Any variable whose name contains PASSWORD, SECRET, KEY, or TOKEN (case-insensitive) MUST appear in Secret, NOT ConfigMap.
+
+**False-positive exemptions**: Boolean flags (default value is true/false/0/1), URL-holding vars (ends with `_ENDPOINT`/`_URL`), public certificates (`PUBLIC_KEY`/`PUBLIC_CERT`) → classify as ConfigMap with explanatory note.
+
+**Disambiguation**: Locally-constructed shell variables in entrypoint scripts are NOT externally-injected env vars — exclude from audit counts.
+
+## False-Positive Avoidance
+
+1. Never use plain string matching — use regex with `\s+`.
+2. Skip comment lines.
+3. Case-insensitive for doc topic presence checks.
+4. For call detection, ensure match is in executable code.
+5. YAML comment filtering: pipe through `grep -v '^\s*#'`.
+6. Multi-doc awareness: use `yaml.safe_load_all`.
+7. grep -n breaks comment-filter anchors: use `grep -v ':[[:space:]]*#'` after `-n`.
+8. Use word-boundary anchors (`\b`) for short tokens (TODO, TBD) to avoid substring matches.
+
+## Validation Anti-Patterns
+
+1. **Comment lines causing false matches** — always strip comments first.
+2. **grep piped through head masks exit code** — use `if grep -rqn` instead.
+3. **`\s` in BRE mode fails on tabs** — use `-E` for ERE.
+4. **MIGRATION comments must not reproduce removed values**.
+5. **grep -n output breaks comment-filter anchors** — use `grep -v ':[[:space:]]*#'`.
+6. **str_replace "not found"** despite grep confirmation — fall back to `sed -i` or Python for invisible Unicode/line-ending differences.
+7. **YAML grep -B1/-A2 for metadata.name extraction — PROHIBITED** — use `yaml.safe_load_all()` for ALL name-resolution assertions.
+
+## Pre-Manifest ENV_VARIABLES.md Audit
+
+Run as FIRST sub-step of any manifest-generation task. Use flat grep as PRIMARY completeness check.
+
+**Step 1** — Extract all env var reads from source using language-specific grep patterns (see `references/skill-b-containerisation-transformation.md` §Sub-Phase §15 for per-framework patterns).
+
+**Step 1b** — envFrom bulk injection: enumerate ALL keys from referenced ConfigMaps/Secrets via `yaml.safe_load_all()`.
+
+**Step 2** — Extract documented vars from ENV_VARIABLES.md.
+
+**Step 3** — Diff and add missing vars.
+
+**Step 4** — After manifest generation, verify parity between manifest keys and ENV_VARIABLES.md.
+
+## ConfigMap Data-Type Assertion
+
+ConfigMap `data:` values MUST always be strings. Even numeric values need quoting. Use `yaml.safe_load_all()` to verify all values are `isinstance(v, str)`.
+
+**Common offenders**: `DB_PORT: 5432`, `WORKERS: 4`, `REDIS_DB: 0` — all must be quoted strings.
+
+## Cross-File Duplicate Resource Name Check
+
+Use Python `yaml.safe_load_all()` with kind+namespace+name triple extraction to detect duplicates. Do NOT use grep (matches `configMapRef.name`, label values, causing false positives).
+
+## Secret Key Count
+
+Source YAML typically uses `stringData` (plaintext). Kubernetes converts to `data` (base64) at admission. Always check BOTH fields via `yaml.safe_load_all()`.
+
+**Union lookup pattern** (REQUIRED for all Secret key assertions):
+```python
+keys = {**sec.get('data', {}), **sec.get('stringData', {})}
+```
+Kubernetes merges both fields at admission — generated manifests may use either or both. Assertions that check only `data` or only `stringData` will produce false negatives.
+
+## Decomposition Manifest Validation
+
+After Phase 2 Sub-Phase §2, verify extracted services have complete manifests (Deployment + Service + NetworkPolicy). Use `yaml.safe_load_all()` to verify resource limits are non-empty for all containers.
+
+## RFC 1123 Placeholder Validation
+
+**Purpose**: kubeconform does NOT validate RFC 1123 DNS label compliance for placeholder values. Uppercase characters pass kubeconform but fail Kubernetes server-side.
+
+**When to run**: Post-migration, after kubeconform passes.
+
+```bash
+grep -nE '(host:|storageClassName:).*[A-Z]' kubernetes/*.yaml
+# Any match = FAIL
+```
+
+**Canonical lowercase forms:** `host: replace-with-hostname.example.com`, `storageClassName: replace-with-rwm-class`.
+
+## Exit-Code Traps
+
+grep exits with code 1 when zero lines match — this is the PASS case for absence checks. (POSIX: exit 0 = line selected, exit 1 = no lines selected, exit 2 = error.)
+
+### Rule 1: Never use `grep ... && echo PASS || echo FAIL` for absence checks
+Use `if grep -qE ...; then echo FAIL; else echo PASS; fi`
+
+### Rule 2: Never use `grep ... | head -N || echo PASS`
+`head` always exits 0 — PASS branch never fires.
+
+### Rule 3: Multi-file absence check — use Python for robustness across multiple files.
+
+### Rule 4: Tempfile pattern for violation checks (canonical idiom)
+When checking whether a pattern EXISTS (violations present = FAIL, no matches = CLEAN), use:
+```bash
+grep -nP 'PATTERN' file > /tmp/check.txt 2>/dev/null
+if [ -s /tmp/check.txt ]; then
+  echo "VIOLATIONS FOUND:"
+  cat /tmp/check.txt
+else
+  echo "CLEAN"
+fi
+```
+This avoids the grep exit-code 1 (no matches) breaking `&&` chains. Use this pattern for ALL violation-detection checks.
+
+### Rule 5: PIPESTATUS for build-tool pipe verification
+When piping Maven/Gradle output through grep/tee, use `${PIPESTATUS[0]}` to capture the build tool's exit code (not grep's):
+```bash
+mvn package -DskipTests 2>&1 | tee /tmp/build.log
+BUILD_EXIT=${PIPESTATUS[0]}
+[ "$BUILD_EXIT" -eq 0 ] && echo "BUILD OK" || echo "BUILD FAILED (exit $BUILD_EXIT)"
+```
+
+## Banned-Construct Comment Stripping
+
+Strip comment lines BEFORE applying banned-construct membership tests. MIGRATION comments describing removed constructs are documentation, not violations.
+
+## Post-Debugger Prose Consistency
+
+**When to run:** As Step 6 of the stale-claim sweep — AFTER Steps 3-5 pass. Also run after ANY debugger or repair task that modifies source files.
+
+**Procedure:**
+1. Identify all constructs modified by the most recent debugger/repair task.
+2. Grep documentation for those construct names.
+3. For each match, verify surrounding prose reflects POST-FIX state.
+4. Common indicators: count literals that no longer match, references to removed resources.
+5. Expanded scope: scan Deferred Items sections for resolved-issue descriptions referencing symbols no longer in code.
+6. **After applying any code fix, update affected documentation in the same pass** — ENV_VARIABLES.md rows, INFRASTRUCTURE_REQUIREMENTS.md annotations, and TRANSFORMATION_SUMMARY.md status cells. Do NOT leave stale 'out-of-scope' annotations that a prior task wrote.
+
+**TRANSFORMATION_SUMMARY.md status-language validation:**
+- Security Hardening status cells MUST say 'Applied' or 'Configured' — never 'Required' or 'Recommended'.
+- Scope Comparison Actual Outcome MUST match `ls kubernetes/*.yaml` disk state.
+- Three-Tier Validation cells MUST contain 'PASSED' with tool flags — never blank or 'N/A'.
+
+**Detection:**
+```bash
+grep -niE 'Required|Recommended' TRANSFORMATION_SUMMARY.md | grep -i 'security\|hardening'
+# Any match = stale status cell — update to Applied/Configured
+# NOTE: Pipe through security/hardening filter to avoid false positives from other sections
+```
+
+## validate.sh Scripting Anti-Patterns
+
+### Anti-Pattern 1: `exit 0` inside conditional branches
+Skips ALL subsequent tiers. Use status variable and fall through.
+
+### Anti-Pattern 2: `grep -c pattern || echo 0`
+Produces double output. Check file existence separately.
+
+### Anti-Pattern 3: Missing tool-availability guard
+Gate all optional tool invocations with `command -v <tool>`.
+
+## Post-Manifest ENV_VARIABLES.md Reconciliation
+
+**Purpose:** After generating configmap.yaml and secret.yaml, ensure ENV_VARIABLES.md is synchronized.
+
+**When to run:** Immediately after manifest generation (Sub-Phase §15), same task scope. Each manifest-generation task MUST complete reconciliation before closing — do not defer entirely to Final Review.
+
+**Authoritative key sources**: source code getenv()/process.env reads AND entrypoint shell script `${VAR}` references. Use `set()` deduplication before comparing against ENV_VARIABLES.md to avoid double-counting.
+
+**Procedure:**
+1. Extract ConfigMap keys via `yaml.safe_load_all()`.
+2. Extract Secret keys (both `data` and `stringData`).
+3. Extract documented vars from ENV_VARIABLES.md.
+4. Diff — any vars in manifests but not documented → add.
+
+**Naming-function verification**: If the application uses a config-framework naming function (e.g., viper `SetEnvKeyReplacer`, pydantic-settings `env_prefix`, Spring relaxed binding), reproduce or invoke it programmatically to verify every table row name matches the actual env var name the framework expects. Human-derived names are unreliable — always cross-check with the framework's naming transformation rules.
+
+**Atomic count updates**: After verifying key-row parity, verify Summary Statistics counts in ENV_VARIABLES.md match actual row counts — update ALL count references atomically in a single pass. Never update one count literal without checking all others.
+
+**Resolution hierarchy**: (1) Task spec, (2) Actual manifest yaml.safe_load, (3) ENV_VARIABLES.md.
+
+**Sub-Rules:**
+- **A — Flat-grep over-match**: Section-bounded Python counter is authoritative for row counts.
+- **B — Form D bare-var check**: After removing URL-embedded defaults, resulting `${VAR}` must have ENV_VARIABLES.md entries.
+- **C — Library/adapter file scope**: Extend grep to library files activated by ConfigMap keys.
+- **D — Hyphen/dot key regex**: ConfigMap file-content keys may contain hyphens/dots.
+
+## Dockerfile COPY Word-Boundary Checks
+
+Always use line-start anchoring AND comment stripping for COPY instruction checks. Strip `--` flag tokens before extracting source/destination paths.
+
+## YAML Boolean Assertion Pitfall
+
+When asserting YAML boolean fields via `yaml.safe_load`:
+- To verify `false`: use `val is False`
+- To verify `true`: use `val is True`
+- NEVER use `is not False` to mean "is true"
+- NEVER use `not val` to mean "is false"
+
+## INFRASTRUCTURE_REQUIREMENTS.md Variable Reconciliation
+
+**When to run:** Post-migration, after manifests finalized.
+
+Manifests are authoritative. Every env var name in INFRASTRUCTURE_REQUIREMENTS.md must exist verbatim as a key in configmap.yaml or secret.yaml. Update within same task scope.
+
+## Secret Activation Verification
+
+After config_transform, verify every Secret key is consumed by the application. Unused keys indicate missed activation step (adding placeholder reference in source).
+
+## Assertion Robustness Rules
+
+### MIGRATION Comment Exclusion
+Absence assertions MUST exclude MIGRATION comments. Strip comments before checking.
+
+### Multi-Doc YAML Structural Assertions: Python Mandate
+All structural assertions on Kubernetes YAML MUST use Python `yaml.safe_load_all()`.
+
+### Deployment Containers Path (CRITICAL)
+The correct path to containers in a Deployment is `dep['spec']['template']['spec']['containers']` — NOT `dep['spec']['containers']`. The intermediate `template.spec` layer is required. Missing it causes KeyError or returns None silently.
+
+### Secret data/stringData Union Accessor (REQUIRED)
+Always use `{**sec.get('data', {}), **sec.get('stringData', {})}` when checking Secret keys. Kubernetes manifests may use either or both fields.
+
+### Heredoc Mandate for Inline Python Assertions
+When writing inline Python assertions in shell (e.g., `python3 -c "..."`) that contain regex character classes (brackets `[]`), use single-quoted heredoc (`<<'PYEOF'`) to prevent shell interpretation of brackets:
+```bash
+python3 <<'PYEOF'
+import re, yaml
+# Shell cannot misinterpret [A-Z] inside single-quoted heredoc
+pattern = re.compile(r'[A-Z][A-Z0-9_]+')
+PYEOF
+```
+
+### Per-Workload Ingress Templates
+- Web workloads: explicit port-based ingress rules (allow from ingress controller)
+- Non-web workloads (workers, CronJobs, Jobs): `ingress: []` (deny-all)
+- Do NOT apply uniform ingress rules across all workload types
+
+### envFrom None-Guard
+Guard against `None` entries in `envFrom` lists: `for ef in c.get('envFrom', []) or []: if ef is None: continue`.
+
+### Brace-Balance URL-Literal Fallback
+When URL literals are present (`://` substring), use raw `content.count('{') == content.count('}')` as authoritative brace-balance check.
+
+### Section-Range Regex: Avoid DOTALL Over-Matching
+Do NOT use `re.DOTALL` with `.+` to extract sections from documents — it matches across section boundaries. Use targeted table-row patterns or line-by-line parsing:
+```python
+# WRONG — matches across sections:
+section = re.search(r'## Security.*?## Next', text, re.DOTALL)
+# CORRECT — match specific table rows:
+rows = [l for l in text.splitlines() if l.startswith('| ') and 'Security' in l]
+```
+
+## Key-Count Atomicity Rule (HARD GATE)
+
+**Purpose:** After any change that alters ConfigMap or Secret key count, ensure all documentation files reflect the new count. All count literals in TRANSFORMATION_SUMMARY.md MUST be derived from disk-authoritative commands (`wc -l`, `grep -c`, `python3 yaml.safe_load` count), never from memory or intermediate task reports. Tool-status rows in the Three-Tier Validation table must source from the most recent prior task report — never re-derived at summary time. If kubeconform PASSED in a prior task, record PASSED even if the binary is not on PATH at Final Review time.
+
+**When to run:** Post-batch, after any ConfigMap/Secret key addition or removal. HARD GATE at Final Review (Sub-Phase §19).
+
+**Procedure:**
+1. Determine old and new key counts (from the manifest change just made).
+2. Grep all documentation files for the old count string:
+```bash
+grep -rn '<old_count> keys\|<old_count> variables\|<old_count> env' ENV_VARIABLES.md INFRASTRUCTURE_REQUIREMENTS.md TRANSFORMATION_SUMMARY.md
+```
+3. Replace old count with new count in every match, in the same operation.
+
+**Verification:** Re-run the grep with the old count. Result must be zero matches before task closure.
+
+## Scope Column Reconciliation
+
+**Purpose:** After generating configmap.yaml and secret.yaml, verify every variable in ENV_VARIABLES.md K8s Scope column matches its actual manifest placement.
+
+**When to run:** Post-batch, after manifest generation.
+
+**Procedure:**
+1. For each variable in ENV_VARIABLES.md, determine its K8s Scope value (ConfigMap or Secret).
+2. Check actual placement:
+   - If in configmap.yaml `data:` → Scope must say ConfigMap.
+   - If in secret.yaml `stringData:`/`data:` → Scope must say Secret.
+3. Mismatches are documentation errors — fix in same task scope.
+
+**Scope-column regex for automated extraction**: Use `\*{0,2}(ConfigMap|Secret)\*{0,2}` (NOT `\*\*?(ConfigMap|Secret)\*\*?`) to match both bolded (`**ConfigMap**`) and un-bolded (`ConfigMap`) scope cells. The old regex silently skipped plain (un-bolded) cells.
+
+**Section-bounded counting**: When counting ENV_VARIABLES.md rows for the header count, scope the count to the ConfigMap/Secret variable table section ONLY — exclude any "Excluded Variables" section at the bottom.
+
+**Bidirectional key-accuracy gate** (run at Final Review §19):
+- **Forward check**: every key in configmap.yaml/secret.yaml must have a corresponding row in ENV_VARIABLES.md.
+- **Reverse check**: for each unique getenv()/os.environ/process.env key from the 5-pass source grep, assert a matching injection key in configmap.yaml or secret.yaml. Mismatch = injection gap requiring reconciliation.
+
+**Verification:** No variable should have a Scope value that contradicts its actual manifest placement. Bidirectional check must produce zero unmatched keys.
+
+## ENV_VARIABLES.md Final Review Completeness Check
+
+**Purpose:** At Final Review (Sub-Phase §19), verify ENV_VARIABLES.md documents ALL env vars actually read by the application source code — not just those introduced during migration.
+
+**When to run:** Post-migration, as part of Final Review before writing TRANSFORMATION_SUMMARY.md.
+
+**Procedure:**
+
+1. Run per-language grep to extract all env var reads from source:
+
+| Language | Grep Command |
+|----------|-------------|
+| Python | `grep -rhoP "os\.environ\.get\(['\"]([A-Za-z][A-Za-z0-9_]+)" --include='*.py' . \| grep -rhoP "os\.getenv\(['\"]([A-Za-z][A-Za-z0-9_]+)" --include='*.py' .` |
+| Java | `grep -rhoP '@Value\("\$\{([A-Za-z][A-Za-z0-9_]+)' --include='*.java' --include='*.properties' --include='*.yml' .` |
+| Ruby | `grep -rhoP "ENV\[(['\"])([A-Za-z][A-Za-z0-9_]+)" --include='*.rb' . \| grep -rhoP "ENV\.fetch\(['\"]([A-Za-z][A-Za-z0-9_]+)" --include='*.rb' .` |
+| Node.js | `grep -rhoP 'process\.env\.([A-Za-z][A-Za-z0-9_]+)' --include='*.js' --include='*.ts' .` |
+| PHP | `grep -rhoP "(?:getenv\|env)\(['\"]([A-Za-z][A-Za-z0-9_]+)" --include='*.php' .` |
+| Go | `grep -rhoP 'os\.Getenv\("([A-Za-z][A-Za-z0-9_]+)"\)' --include='*.go' . \| grep -rhoP 'viper\.Get[A-Za-z]*\("([a-zA-Z_.]+)"\)' --include='*.go' .` |
+
+2. Extract documented variable names from ENV_VARIABLES.md (first column of the table).
+
+3. Diff the two sets:
+```bash
+# source_vars.txt = sorted unique output from step 1
+# doc_vars.txt = sorted unique names from ENV_VARIABLES.md
+comm -23 source_vars.txt doc_vars.txt > missing_from_docs.txt
+```
+
+4. For each variable in `missing_from_docs.txt`, add a row to ENV_VARIABLES.md with description, example, and K8s Scope.
+
+**Verification:** Re-run step 3. `missing_from_docs.txt` must be empty.
+
+**Note:** Exclude test files (`*_test.go`, `*.test.js`, `*Test.java`, `test_*.py`, `*_spec.rb`) from source grep to avoid documenting test-only env vars.
+
+## Configuration Changes Key-Accuracy Gate
+
+**Purpose:** After writing the Configuration Changes table in TRANSFORMATION_SUMMARY.md, verify variable names match actual manifest keys.
+
+**When to run:** Post-migration, during Final Review (Sub-Phase §19).
+
+**Procedure:**
+1. Extract variable names from the Configuration Changes table in TRANSFORMATION_SUMMARY.md.
+2. Extract actual keys from manifests:
+```bash
+python3 -c "
+import yaml
+keys = set()
+for f in ['kubernetes/configmap.yaml', 'kubernetes/secret.yaml']:
+    try:
+        with open(f) as fh:
+            for doc in yaml.safe_load_all(fh):
+                if doc and doc.get('kind') in ('ConfigMap', 'Secret'):
+                    keys.update(doc.get('data', {}).keys())
+                    keys.update(doc.get('stringData', {}).keys())
+    except FileNotFoundError:
+        pass
+for k in sorted(keys):
+    print(k)
+"
+```
+3. Diff the two sets. Any variable name in the Configuration Changes table that does not exist as a manifest key is a documentation error — fix before closing.
+
+**Verification:** Every variable name in the Configuration Changes table exists verbatim as a key in configmap.yaml or secret.yaml.
+
+## Implicit-Pending Heading Detection
+
+**Purpose:** Catch headings in INFRASTRUCTURE_REQUIREMENTS.md that imply pending work without using the explicit `pending`/`not generated` phrases.
+
+**When to run:** Post-migration, as part of the stale-claim sweep.
+
+**Procedure:**
+```bash
+grep -iE '(Migration|Steps) Required' INFRASTRUCTURE_REQUIREMENTS.md
+```
+
+Any match indicates a section that implies outstanding work. Verify the referenced migration/steps are actually completed. If completed, rename the heading (e.g., "Migration Steps Completed" or remove the section).
+
+## Criterion 10 Assertion Battery Template
+
+**Purpose:** Canonical Python `yaml.safe_load_all()` assertion template for structural validation (Criterion 10 sub-rules A-G). Workers copy-paste and adapt this snippet rather than re-deriving from scratch. kubeconform validates schema only; placement within valid schema, cross-resource parity, and namespace membership are only detectable via these Python assertions — do not skip when kubeconform exits 0.
+
+**Canonical Criterion 10 Assertion Snippet:**
+```python
+import yaml
+from pathlib import Path
+
+docs = []
+for f in Path('kubernetes').glob('*.yaml'):
+    for doc in yaml.safe_load_all(f.read_text()):
+        if doc and doc.get('kind'):
+            docs.append(doc)
+
+# A: Selector/label parity
+services = [d for d in docs if d['kind'] == 'Service']
+deployments = [d for d in docs if d['kind'] == 'Deployment']
+for svc in services:
+    selector = svc.get('spec', {}).get('selector', {})
+    matches = [dep for dep in deployments
+               if all(dep.get('spec',{}).get('template',{}).get('metadata',{}).get('labels',{}).get(k) == v
+                      for k,v in selector.items())]
+    assert len(matches) > 0, f"Service {svc['metadata']['name']} selector matches no Deployment"
+
+# B: NetworkPolicy podSelector match
+for np in [d for d in docs if d['kind'] == 'NetworkPolicy']:
+    sel = np.get('spec',{}).get('podSelector',{}).get('matchLabels',{})
+    if sel:
+        matches = [dep for dep in deployments
+                   if all(dep.get('spec',{}).get('template',{}).get('metadata',{}).get('labels',{}).get(k) == v
+                          for k,v in sel.items())]
+        # Also check CronJob/Job templates
+        assert len(matches) > 0 or any(
+            d['kind'] in ('CronJob','Job') for d in docs
+        ), f"NetworkPolicy {np['metadata']['name']} podSelector matches no workload"
+
+# C: policyTypes completeness
+for np in [d for d in docs if d['kind'] == 'NetworkPolicy']:
+    pt = np.get('spec',{}).get('policyTypes',[])
+    assert 'Ingress' in pt and 'Egress' in pt, f"NetworkPolicy {np['metadata']['name']} missing policyTypes"
+
+# D: envFrom reference existence
+cm_names = {d['metadata']['name'] for d in docs if d['kind'] == 'ConfigMap'}
+sec_names = {d['metadata']['name'] for d in docs if d['kind'] == 'Secret'}
+for dep in deployments:
+    for c in dep.get('spec',{}).get('template',{}).get('spec',{}).get('containers',[]):
+        for ef in c.get('envFrom',[]) or []:
+            if ef is None: continue
+            if ef.get('configMapRef'):
+                assert ef['configMapRef']['name'] in cm_names
+            if ef.get('secretRef'):
+                assert ef['secretRef']['name'] in sec_names
+
+# E: DNS dual-protocol (UDP+TCP/53)
+for np in [d for d in docs if d['kind'] == 'NetworkPolicy']:
+    egress = np.get('spec',{}).get('egress',[]) or []
+    dns_ports = []
+    for rule in egress:
+        for port in rule.get('ports',[]) or []:
+            if port.get('port') == 53:
+                dns_ports.append(port.get('protocol','TCP'))
+    if egress:  # only check if egress rules exist
+        assert 'UDP' in dns_ports and 'TCP' in dns_ports, \
+            f"NetworkPolicy {np['metadata']['name']} missing dual-protocol DNS"
+
+# F: Namespace membership
+exempt_kinds = {'Namespace','CustomResourceDefinition','ClusterRole','ClusterRoleBinding'}
+for d in docs:
+    if d['kind'] not in exempt_kinds:
+        assert d.get('metadata',{}).get('namespace'), \
+            f"{d['kind']}/{d['metadata']['name']} missing namespace"
+
+# G: terminationGracePeriodSeconds placement
+for dep in deployments:
+    tgps = dep.get('spec',{}).get('template',{}).get('spec',{}).get('terminationGracePeriodSeconds')
+    # Should NOT be at dep['spec'] root:
+    assert dep.get('spec',{}).get('terminationGracePeriodSeconds') is None, \
+        f"Deployment {dep['metadata']['name']} has terminationGracePeriodSeconds at wrong path"
+for cj in [d for d in docs if d['kind'] == 'CronJob']:
+    path = cj.get('spec',{}).get('jobTemplate',{}).get('spec',{}).get('template',{}).get('spec',{})
+    # Valid path for CronJob
+```
+
+## Shell Idioms and Structured Parsing
+
+**Purpose:** Prevent grep-based validation false positives on structured data. Raw grep fails on YAML, XML, JSON, and section-bounded documents due to substring collisions, filename prefix injection, and comment-line matching.
+
+### Rule 1: Use grep ONLY for unstructured text
+
+For structured formats, use language-appropriate parsers:
+
+| Format | Parser |
+|--------|--------|
+| YAML | `yaml.safe_load_all()` (Python) |
+| XML | `xml.etree.ElementTree` (Python) |
+| JSON | `json.load()` (Python) |
+| Section-bounded docs | Python `re.search(pattern, text, re.MULTILINE\|re.DOTALL)` or `file_read` lines mode |
+
+**NEVER** use `awk '/start/,/stop/'` for section extraction — it silently returns zero rows if the stop pattern matches on the same line or before the start pattern. Use Python regex with DOTALL instead.
+
+### Rule 2: Absence-check idiom (grep exits 1 on zero matches)
+
+For checks where "no match = CLEAN", **never** use `grep PATTERN file && echo CLEAN` (never prints CLEAN because grep exits 1 on zero matches). Always use:
+```bash
+if grep -qE 'PATTERN' file; then echo "FAIL"; else echo "CLEAN"; fi
+```
+
+### Rule 3: Multi-file grep filename-prefix contamination
+
+When `grep -rn` runs across multiple files, output lines are prefixed with `filename:linenum:`. This causes false matches when the filename itself contains the search term or when downstream filters match the prefix. Mitigations:
+- Use `--include='*.ext'` to restrict file types
+- Use `-l` (files only) when you only need file names
+- For exact value assertions, parse with Python rather than piping multi-file grep through a second grep
+
+### Rule 4: RFC 1123 and field-value checks — structured parse required
+
+Do NOT grep raw YAML for hostname or field values — JDBC URL substrings, YAML comments, and multi-line strings produce false positives. Extract field values via `yaml.safe_load_all()`, then validate the extracted string:
+```python
+import yaml, re
+for doc in yaml.safe_load_all(open('kubernetes/ingress.yaml')):
+    if doc and doc.get('kind') == 'Ingress':
+        for rule in doc.get('spec', {}).get('rules', []):
+            host = rule.get('host', '')
+            assert host == host.lower(), f"RFC 1123 violation: {host}"
+```
+
+### Rule 5: XML element presence — ignore comments
+
+`grep '<element>'` matches XML comments (`<!-- <element> disabled -->`). For presence/absence assertions on XML, use:
+```python
+import xml.etree.ElementTree as ET
+tree = ET.parse('file.xml')
+found = tree.find('.//{namespace}element')
+```
+
+### Rule 6: Java/PHP live-code assertions — exclude comment lines
+
+When asserting that a pattern exists in live code (not just comments), always pre-filter:
+```bash
+grep -v '^\s*\(//\|[*]\|#\)' file.java | grep -q 'System.getenv'
+```
+
+## Pre-Generation Duplicate Resource Check
+
+**Purpose:** Before generating any new Kubernetes resource manifest, verify no conflicting resource with the same kind+name+namespace already exists in the `kubernetes/` directory. Prevents the dual-PVC repair pattern (two files with same kind+name+namespace but different specs).
+
+**When to run:** Pre-migration — as the FIRST step of any manifest-generation sub-task (§15) before writing a new YAML file.
+
+**Preconditions:** The `kubernetes/` directory exists and may contain manifests from prior tasks.
+
+**Procedure:**
+
+1. **Preview existing resources** of the same kind:
+```bash
+grep -rl "kind: <Kind>" kubernetes/ 2>/dev/null
+```
+Replace `<Kind>` with the resource type being generated (e.g., `PersistentVolumeClaim`, `Service`, `ConfigMap`, `Secret`).
+
+2. **Check for name collision** in matching files:
+```bash
+grep -rl "kind: <Kind>" kubernetes/ 2>/dev/null | xargs grep -l "name: <intended-name>" 2>/dev/null
+```
+Replace `<intended-name>` with the `metadata.name` value planned for the new resource.
+
+3. **If a match is found** (non-empty output):
+   - Read the existing file and compare its spec against the intended spec.
+   - If specs are compatible: skip generation, reference the existing resource.
+   - If specs conflict: resolve the conflict (update existing file OR rename new resource) — do NOT create a second file with the same kind+name+namespace.
+
+4. **If no match found** (empty output): proceed with generation.
+
+**Verification:** After all manifest generation is complete, run the full duplicate check:
+```python
+import yaml, pathlib, collections
+resources = []
+for f in pathlib.Path('kubernetes').glob('*.yaml'):
+    for doc in yaml.safe_load_all(f.read_text()):
+        if doc and doc.get('kind'):
+            triple = (doc['kind'], doc.get('metadata', {}).get('name'),
+                      doc.get('metadata', {}).get('namespace', 'default'))
+            resources.append(triple)
+dupes = [t for t, c in collections.Counter(resources).items() if c > 1]
+assert not dupes, f"Duplicate resources: {dupes}"
+```
+
+**Idempotence:** Running the check when no duplicates exist produces no output and requires no action.
+
+**Task-ordering constraint:** All externalisation tasks (§3 config, §7 credentials, §8 backing services) MUST reach verified completion before any manifest-generation task (§15) begins. This ensures the full key set is known before manifests are generated, preventing duplicate resource creation from incomplete information.
+
+## Validation Script Correctness Checklist
+
+**Purpose:** Prevent common validation script authoring errors that produce false PASS or inflated counts. Apply these patterns when writing any validation assertion.
+
+### 1. Anchored Badge-Count Regex (Never Bare Emoji)
+
+**Problem:** Bare emoji grep (e.g., `grep -c '✅'`) matches icon-key rows, column headers, and legend entries — inflating badge counts.
+
+**Correct pattern:**
+```bash
+# Count ONLY data rows with emoji badge at cell start (table format)
+grep -cP '^\| ✅' REPORT.md
+# NOT: grep -c '✅' REPORT.md (matches legend, headers, notes)
+```
+
+### 2. Heading Grep — Exclude Sub-Headings
+
+**Problem:** `grep '^##'` matches `## Section` AND `### Sub-Section`. Use level-specific matching.
+
+**Correct pattern:**
+```bash
+# Match ONLY level-2 headings (not ###, ####, etc.)
+grep -cE '^## [^#]' TRANSFORMATION_SUMMARY.md
+# NOT: grep -c '^##' TRANSFORMATION_SUMMARY.md
+```
+
+### 3. Count-Based Grep Pattern (Replace && PASS || FAIL)
+
+**Problem:** `grep PATTERN file && echo PASS || echo FAIL` inverts logic for absence checks — grep exit 1 (no matches = desired) triggers FAIL branch.
+
+**Correct patterns:**
+```bash
+# For absence checks (no matches = CLEAN):
+COUNT=$(grep -cE 'PATTERN' file 2>/dev/null || echo 0)
+[ "$COUNT" -eq 0 ] && echo "CLEAN" || echo "FAIL: $COUNT matches"
+
+# For presence checks (matches = PASS):
+COUNT=$(grep -cE 'PATTERN' file 2>/dev/null || echo 0)
+[ "$COUNT" -gt 0 ] && echo "PASS: $COUNT found" || echo "FAIL: none found"
+```
+
+### 4. yaml.safe_load Returns [] (Falsy but Not None)
+
+**Problem:** `yaml.safe_load()` on a YAML key with value `[]` returns an empty list — which is falsy in Python but not `None`. Key-presence checks using `if not value:` wrongly report the key as absent.
+
+**Correct pattern:**
+```python
+# Check if key EXISTS (may be empty list):
+value = doc.get('spec', {}).get('ingress')
+assert value is not None, "ingress key missing"  # [] passes this correctly
+
+# NOT: assert value, "ingress key missing"  # [] fails this incorrectly!
+```
+
+### 5. Per-Document Stale-Claim Gate Scope
+
+The stale-claim sweep (Criterion 9b) applies to ALL Phase 2 documentation files, including INFRASTRUCTURE_REQUIREMENTS.md. Sweep scope: TRANSFORMATION_SUMMARY.md, ENV_VARIABLES.md, INFRASTRUCTURE_REQUIREMENTS.md.
+
+## Criterion 10-A Selector Subset Semantics
+
+**Purpose:** Service selector parity assertion must use subset semantics (selector keys ⊆ Deployment labels), not equality. A Deployment may have additional labels beyond what the Service selects.
+
+**Implementation:**
+```python
+import yaml
+from pathlib import Path
+
+services, deployments = [], []
+for f in Path('kubernetes').glob('*.yaml'):
+    for doc in yaml.safe_load_all(f.read_text()):
+        if not doc: continue
+        if doc.get('kind') == 'Service':
+            services.append(doc)
+        elif doc.get('kind') == 'Deployment':
+            deployments.append(doc)
+
+for svc in services:
+    selector = svc.get('spec', {}).get('selector', {})
+    matches = []
+    for dep in deployments:
+        dep_labels = dep.get('spec', {}).get('template', {}).get('metadata', {}).get('labels', {})
+        # SUBSET check: all selector keys present in dep_labels with matching values
+        if all(k in dep_labels and dep_labels[k] == v for k, v in selector.items()):
+            matches.append(dep['metadata']['name'])
+    assert len(matches) > 0, f"Service {svc['metadata']['name']} selector {selector} matches no Deployment"
+```
+
+**Rule:** Use `all(k in dep_labels and dep_labels[k] == v for k, v in selector.items())` — NOT `selector == dep_labels`.
+
+## Dockerfile COPY Tokenization Rule
+
+**Purpose:** When validating COPY instructions, strip ALL `--` flag tokens (not just `--from`) before extracting source/destination paths.
+
+**Affected flags:** `--from=`, `--chown=`, `--chmod=`, `--link`, `--parents`
+
+**Procedure:**
+```bash
+# Strip ALL --flag tokens from COPY lines before path extraction
+grep -v '^\s*#' Dockerfile | grep '^COPY' | sed 's/--[^ ]* //g' | while read line; do
+  tokens=($line)
+  # tokens[0] = "COPY", tokens[1..N-1] = sources, tokens[N] = dest
+  # Validate sources (indices 1 to N-2)
+done
+```
+
+**Rule:** When tokenizing COPY instructions for static validation (Point 1), remove ALL tokens matching `--[a-z]+=?[^ ]*` before counting source/destination positions. Failure to strip `--chmod=755` or `--link` shifts token indices and produces false "MISSING COPY SOURCE" errors.
+
+## Secret data/stringData Dual-Key Lookup
+
+**Purpose:** Kubernetes Secret manifests may use `data` (base64-encoded), `stringData` (plaintext), or both. All assertions checking Secret keys MUST inspect the union.
+
+**Required pattern (ALWAYS use for Secret key assertions):**
+```python
+keys = {**sec.get('data', {}), **sec.get('stringData', {})}
+```
+
+**Source:** https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-config-file/ — "The stringData field is provided for convenience, and it allows you to provide the same data as unencoded strings."
+
+**Rule:** Never check only `sec.get('data', {})` or only `sec.get('stringData', {})` — always use the union accessor. Generated manifests typically use `stringData` but Kubernetes converts to `data` at admission. Both may coexist.
+
+## Key-Accuracy Forward-Only Rule
+
+**Purpose:** The Configuration Changes key-accuracy check runs FORWARD only (manifest → doc). It verifies that every key in the manifest appears in documentation — NOT that every doc key appears in the manifest.
+
+**Direction:** Manifest keys → ENV_VARIABLES.md (forward check)
+
+**Rationale:** ENV_VARIABLES.md may contain variables from source code that are resolved by framework mechanisms (Spring relaxed binding, pydantic-settings prefix) and do not appear verbatim as manifest keys. The reverse check would produce false negatives.
+
+**Table-row scoping note:** When extracting variable names from the Configuration Changes table, match only table rows (lines starting with `|` and containing at least 2 `|` separators). Exclude heading rows and prose paragraphs that may mention variable names in non-tabular context.
+
+## Banned-Phrase 'pending' Context Sensitivity
+
+**Purpose:** The word `pending` in INFRASTRUCTURE_REQUIREMENTS.md is context-sensitive — it is banned only when it indicates unresolved work items (e.g., "manifest pending", "not yet generated"). Other uses are acceptable.
+
+**Banned contexts (match = violation):**
+- `pending generation`
+- `not generated` / `not yet generated`
+- `pending creation`
+- `pending migration`
+
+**Acceptable contexts (NOT violations):**
+- `depending on` (substring match — use word-boundary grep)
+- `pending` as a Kubernetes pod status description in prose
+- `appending` (substring)
+
+**Correct grep (with word boundaries):**
+```bash
+grep -P '\bpending\b' INFRASTRUCTURE_REQUIREMENTS.md | grep -ivE 'depending|appending|suspend'
+```
+
+**Rule:** Always use `grep -P '\bpending\b'` (Perl word boundaries) for this check. Without `\b`, matches inside `depending` and `appending` produce false positives.


### PR DESCRIPTION
Two-phase Kubernetes containerisation skill that assesses any codebase against all 12-factor app principles and Kubernetes compatibility requirements, then transforms it for full containerised deployment.

Phase 1 produces a comprehensive readiness report scored across 21 areas covering 12-factor, Kubernetes compatibility, singleton risks, monolith decomposition, and security — with both Minimal and Full decomposition recommendations.

Phase 2 systematically resolves every finding: externalising config and secrets, migrating persistent storage to S3/GCS/Azure Blob, redirecting logging to stdout/stderr, generating Kubernetes manifests (Namespace, Deployment, Service, ConfigMap, Secret, NetworkPolicy), and validating via three-tier pipeline (docker build → kubeconform → optional cluster).

Supports Go, Java/Maven/Gradle, Node.js, PHP, Python, Ruby/Rails, C#/.NET. Benchmarked against 5 real-world OSS apps including BookStack, OpenMRS, Shopizer, OpenCart, and Trac — all validated through local Kubernetes deployment.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
