### PR TITLE
feat: add metrics + knowledge items UI, migrate create flow to SKILL.md

### DIFF
--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -85,7 +85,7 @@ UI → /orchestrate (submit) → Lambda (async) → AgentCore
 
   Step 4: Read selected files from S3 (up to 400K chars / ~100K tokens)
   Step 5: Generate definition (Bedrock with full source code context)
-    → Uploads transformation_definition.md to S3
+    → Uploads SKILL.md (ATX skill format) to S3
   Step 6: Publish (Batch job: atx custom def publish)
     → status.json written to S3
 

--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -9,7 +9,7 @@ AI-powered code transformation platform built on Amazon Bedrock AgentCore and AW
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  UI (React + CloudFront)                                     │
-│  Tabs: Transformations | Execute | Create Custom | CSV Batch | Jobs │
+│  Tabs: Transformations | Execute | Create Custom | CSV Batch | Jobs | Metrics | Knowledge | Chat │
 └──────────────────────┬───────────────────────────────────────┘
                        │
               POST /orchestrate
@@ -127,6 +127,30 @@ Rows without transformation: orchestrator follows find → create → execute ch
   → execute_transform_agent runs the transformation
 ```
 
+### Metrics
+```
+UI Metrics tab → /orchestrate (direct, op: metrics) → Lambda metrics.py
+  → CloudWatch ListMetrics + GetMetricData on AWS/TransformCustom namespace
+  → Aggregates totals, byTransformation, byRepository, per-execution detail
+  → Batch ListJobs for job-status counts
+No AI/AgentCore involved — deterministic CloudWatch query. Ported from
+scaled-execution-containers get_metrics.py. The dashboard (Chart.js) reads
+type=all + type=transform_detail and derives execution status from the
+TransformationExecutionCompleted metric (not the raw ExecutionStatus dimension).
+```
+
+### Knowledge Items
+```
+UI Knowledge tab → /orchestrate (direct, op: knowledge_items) → Lambda knowledge_items.py
+  Read (cache):   kiAction=get      → S3 cache (instant)
+  Refresh:        kiAction=submit   → Batch job (atx custom def list-ki --json)
+                  kiAction=poll     → scrape job logs → write S3 cache → return items
+  Write:          kiAction=update-ki-status | delete-ki | update-ki-config | export-ki-markdown
+                  → Batch job (atx custom def ...)
+Knowledge items are generated DISABLED by ATX after a run; the UI lists them
+cache-first and only triggers the Batch refresh on an explicit "Pull from registry".
+```
+
 ## Components
 
 | Component | Path | Purpose |
@@ -137,7 +161,9 @@ Rows without transformation: orchestrator follows find → create → execute ch
 | Create tool | `orchestrator/tools/createtransform.py` | Analyze source, generate definition, publish |
 | Memory | `orchestrator/tools/memory_*.py` | AgentCore short-term memory |
 | Async Lambda | `api/lambda/async_invoke_agent.py` | Submit/poll/direct bridge |
-| UI | `ui/src/` | React app (5 tabs) |
+| Metrics | `api/lambda/metrics.py` | CloudWatch AWS/TransformCustom metrics (direct op) |
+| Knowledge Items | `api/lambda/knowledge_items.py` | List/enable/disable/delete/export KIs (direct op) |
+| UI | `ui/src/` | React app (8 tabs) |
 | Infrastructure | `cdk/` | Batch, S3, VPC, CloudFront, AgentCore |
 | SAM Layer | `sam/` | AgentCore deploy Lambda + API (Option A) |
 | Container | `../scaled-execution-containers/container/` | ATX CLI Docker image (shared) |
@@ -165,9 +191,11 @@ Rows without transformation: orchestrator follows find → create → execute ch
 │   ├── Dockerfile              # Container image for CDK deployment
 │   └── requirements.txt
 ├── api/lambda/                 # Async bridge Lambda
-│   └── async_invoke_agent.py
-├── ui/                         # React frontend (5 tabs)
-│   └── src/components/         # TransformationList, Form, CreateCustom, CsvUpload, JobTracker
+│   ├── async_invoke_agent.py
+│   ├── metrics.py              # CloudWatch metrics (op: metrics)
+│   └── knowledge_items.py      # Knowledge items (op: knowledge_items)
+├── ui/                         # React frontend (8 tabs)
+│   └── src/components/         # TransformationList, Form, CreateCustom, CsvUpload, JobTracker, Metrics, KnowledgeItems, Chat
 ├── cdk/                        # CDK stacks (Container, Infrastructure, AgentCore, UI)
 │   └── lib/
 │       ├── container-stack.ts      # ECR + Docker image (builds from ../../../scaled-execution-containers/container/)

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -291,6 +291,7 @@ Create via the "Create Custom" tab. Published to the ATX registry via `atx custo
 | **Jobs** | Track job status, view results |
 | **Metrics** | CloudWatch dashboard for the `AWS/TransformCustom` namespace (Chart.js) |
 | **Knowledge** | Review/enable/disable/delete knowledge items per transformation |
+| **Chat** | Conversational interface to the orchestrator |
 
 ---
 
@@ -310,7 +311,7 @@ Create via the "Create Custom" tab. Published to the ATX registry via `atx custo
 │   ├── template.yaml           # SAM resources
 │   ├── deploy_agentcore.py     # Deploy Lambda (SDK-based)
 │   └── deploy.sh               # One-command SAM deploy
-├── ui/                         # React frontend (7 tabs)
+├── ui/                         # React frontend (8 tabs)
 │   └── src/components/
 ├── cdk/                        # CDK stacks
 │   └── lib/

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -286,9 +286,11 @@ Create via the "Create Custom" tab. Published to the ATX registry via `atx custo
 |-----|---------|
 | **Transformations** | Browse AWS-managed + published custom transforms |
 | **Execute** | Run a single transformation on a repository |
-| **Create Custom** | Define and publish custom transformations |
+| **Create Custom** | Define and publish custom transformations (SKILL.md format) |
 | **CSV Batch** | Upload CSV to process multiple repos |
 | **Jobs** | Track job status, view results |
+| **Metrics** | CloudWatch dashboard for the `AWS/TransformCustom` namespace (Chart.js) |
+| **Knowledge** | Review/enable/disable/delete knowledge items per transformation |
 
 ---
 
@@ -301,12 +303,14 @@ Create via the "Create Custom" tab. Published to the ATX registry via `atx custo
 │   ├── Dockerfile              # Container image for CDK deployment
 │   └── requirements.txt
 ├── api/lambda/
-│   └── async_invoke_agent.py   # Async bridge (submit/poll/direct)
+│   ├── async_invoke_agent.py   # Async bridge (submit/poll/direct)
+│   ├── metrics.py              # CloudWatch AWS/TransformCustom metrics (op: metrics)
+│   └── knowledge_items.py      # Knowledge item ops (op: knowledge_items)
 ├── sam/                        # SAM template for AgentCore + API (Option A)
 │   ├── template.yaml           # SAM resources
 │   ├── deploy_agentcore.py     # Deploy Lambda (SDK-based)
 │   └── deploy.sh               # One-command SAM deploy
-├── ui/                         # React frontend (5 tabs)
+├── ui/                         # React frontend (7 tabs)
 │   └── src/components/
 ├── cdk/                        # CDK stacks
 │   └── lib/

--- a/agentic-atx-platform/api/lambda/async_invoke_agent.py
+++ b/agentic-atx-platform/api/lambda/async_invoke_agent.py
@@ -240,6 +240,28 @@ def _handle_direct(body):
         except Exception as e:
             return cors_response(500, json.dumps({'error': str(e)}))
 
+    elif op == 'metrics':
+        try:
+            from metrics import get_metrics
+            # Accept either a nested `params` object or flat keys on the body.
+            params = body.get('params') or {
+                k: body[k] for k in ('type', 'period', 'startDate', 'endDate', 'jobId')
+                if k in body
+            }
+            return cors_response(200, json.dumps(get_metrics(params)))
+        except ValueError as e:
+            return cors_response(400, json.dumps({'error': str(e)}))
+        except Exception as e:
+            return cors_response(500, json.dumps({'error': str(e)}))
+
+    elif op == 'knowledge_items':
+        try:
+            from knowledge_items import handle as _handle_ki
+            status_code, payload = _handle_ki(body)
+            return cors_response(status_code, json.dumps(payload))
+        except Exception as e:
+            return cors_response(500, json.dumps({'error': str(e)}))
+
     elif op in ('save_job', 'list_jobs', 'delete_job', 'update_job'):
         return _handle_jobs_ops(op, body)
 
@@ -254,7 +276,21 @@ def _handle_direct(body):
                 bucket = f"atx-source-code-{account}"
                 # Normalize name to lowercase-hyphenated (matches how create agent stores it)
                 normalized = def_name.lower().replace(' ', '-')
-                key = f"custom-definitions/{normalized}/transformation_definition.md"
+                # Prefer the new SKILL.md format; fall back to legacy transformation_definition.md
+                candidates = [
+                    f"custom-definitions/{normalized}/SKILL.md",
+                    f"custom-definitions/{normalized}/transformation_definition.md",
+                ]
+                key = ''
+                for cand in candidates:
+                    try:
+                        s3_client.head_object(Bucket=bucket, Key=cand)
+                        key = cand
+                        break
+                    except Exception:
+                        continue
+                if not key:
+                    key = candidates[0]  # report the expected new path if neither exists
             if not bucket or not key:
                 return cors_response(400, json.dumps({'error': 'Missing bucket/key or definition_name'}))
             obj = s3_client.get_object(Bucket=bucket, Key=key)
@@ -336,7 +372,7 @@ def _handle_direct(body):
         except Exception as e:
             return cors_response(500, json.dumps({'error': str(e)}))
 
-    return cors_response(400, json.dumps({'error': f'Unknown op: {op}. Use status, results, list_custom, check_publish, save_job, list_jobs, or delete_job'}))
+    return cors_response(400, json.dumps({'error': f'Unknown op: {op}. Use status, results, list_custom, check_publish, metrics, knowledge_items, save_job, list_jobs, or delete_job'}))
 
 
 def _handle_jobs_ops(op, body):

--- a/agentic-atx-platform/api/lambda/knowledge_items.py
+++ b/agentic-atx-platform/api/lambda/knowledge_items.py
@@ -1,0 +1,290 @@
+"""
+ATX knowledge item management.
+
+Ported from scaled-execution-containers/api/lambda/get_knowledge_items.py so the
+agentic platform can serve knowledge items through its own /orchestrate `direct` op
+instead of the IAM-authenticated REST API.
+
+Knowledge items (KIs) are reusable artifacts AWS Transform Custom learns during a
+transformation run (patterns, fixes, edge cases). They are generated DISABLED and
+only applied once a human enables them. Each KI: { id, status, title, description, fix }.
+
+Entry point: handle(body: dict) -> (status_code: int, response: dict)
+`body` carries an `op` already routed here; this reads `kiAction`:
+  - get        : read cached list from S3 (instant)            { transformationName }
+  - submit     : run list-ki/get-ki via Batch, return request_id { cliAction, transformationName, id? }
+  - poll       : read submit result by request_id              { request_id }
+  - delete-ki / update-ki-status / update-ki-config / export-ki-markdown : Batch write jobs
+"""
+import json
+import os
+import re
+import uuid
+from datetime import datetime
+
+import boto3
+
+batch = boto3.client('batch')
+s3 = boto3.client('s3')
+logs = boto3.client('logs')
+
+RESULT_BUCKET = os.environ.get('RESULT_BUCKET', os.environ.get('OUTPUT_BUCKET', ''))
+CACHE_PREFIX = 'knowledge-items/cache/'
+RESULT_PREFIX = 'knowledge-items/results/'
+
+_NAME_RE = re.compile(r'^[a-zA-Z0-9/_-]+$')
+_ID_RE = re.compile(r'^[a-zA-Z0-9_-]+$')
+
+
+def _job_queue():
+    return os.environ.get('JOB_QUEUE_NAME', os.environ.get('JOB_QUEUE', 'atx-job-queue'))
+
+
+def _job_definition():
+    return os.environ.get('JOB_DEFINITION_NAME', os.environ.get('JOB_DEFINITION', 'atx-transform-job'))
+
+
+def handle(body):
+    """Route a knowledge-items request. Returns (status_code, dict)."""
+    ki_action = body.get('kiAction', 'get')
+
+    if ki_action == 'get':
+        return _handle_get(body)
+    if ki_action == 'submit':
+        return _handle_submit(body)
+    if ki_action == 'poll':
+        return _handle_poll(body)
+    if ki_action in ('delete-ki', 'update-ki-status', 'update-ki-config', 'export-ki-markdown'):
+        return _handle_write(body)
+    return 400, {'error': 'Invalid kiAction. Use get, submit, poll, delete-ki, update-ki-status, update-ki-config, or export-ki-markdown'}
+
+
+# ── GET: read from S3 cache ──────────────────────────────────────────────────
+
+def _handle_get(body):
+    name = body.get('transformationName')
+    if not name:
+        return 400, {'error': 'Missing required field: transformationName'}
+
+    key = f'{CACHE_PREFIX}{name.replace("/", "_")}/list-ki.json'
+    try:
+        obj = s3.get_object(Bucket=RESULT_BUCKET, Key=key)
+        data = json.loads(obj['Body'].read().decode('utf-8'))
+        return 200, {'source': 'cache', 'transformationName': name, **data}
+    except s3.exceptions.NoSuchKey:
+        return 200, {
+            'source': 'cache',
+            'transformationName': name,
+            'knowledgeItems': [],
+            'message': f'No knowledge items cached for {name}. Submit a list-ki refresh to populate.',
+        }
+    except Exception as e:
+        return 500, {'error': str(e)}
+
+
+# ── POST: submit a read job ──────────────────────────────────────────────────
+
+def _handle_submit(body):
+    cli_action = body.get('cliAction', 'list-ki')
+    name = body.get('transformationName')
+
+    if cli_action not in ('list-ki', 'get-ki'):
+        return 400, {'error': 'cliAction must be list-ki or get-ki'}
+    if not name:
+        return 400, {'error': 'Missing required field: transformationName'}
+    if not _NAME_RE.match(name):
+        return 400, {'error': 'Invalid transformationName'}
+
+    ki_id = body.get('id')
+    if cli_action == 'get-ki':
+        if not ki_id:
+            return 400, {'error': 'Missing required field: id (for get-ki)'}
+        if not _ID_RE.match(ki_id):
+            return 400, {'error': 'Invalid id'}
+
+    request_id = str(uuid.uuid4())
+
+    cmd = f'atx custom def {cli_action} -n {name} --json'
+    if cli_action == 'get-ki' and ki_id:
+        cmd = f'atx custom def {cli_action} -n {name} --id {ki_id} --json'
+
+    cache_key = f'{CACHE_PREFIX}{name.replace("/", "_")}/{cli_action}'
+    if ki_id:
+        cache_key += f'-{ki_id}'
+    cache_key += '.json'
+
+    job_name = f'ki-{cli_action}-{name.replace("/", "-")}'[:128]
+    try:
+        response = batch.submit_job(
+            jobName=job_name,
+            jobQueue=_job_queue(),
+            jobDefinition=_job_definition(),
+            containerOverrides={
+                'command': ['--output', f'knowledge-items/{job_name}/', '--command', cmd],
+                'environment': [
+                    {'name': 'KI_REQUEST_ID', 'value': request_id},
+                    {'name': 'KI_RESULT_KEY', 'value': f'{RESULT_PREFIX}{request_id}.json'},
+                    {'name': 'KI_CACHE_KEY', 'value': cache_key},
+                ],
+            },
+        )
+    except Exception as e:
+        return 500, {'error': str(e)}
+
+    marker = {
+        'status': 'PROCESSING', 'cliAction': cli_action,
+        'transformationName': name, 'batchJobId': response['jobId'],
+    }
+    s3.put_object(
+        Bucket=RESULT_BUCKET, Key=f'{RESULT_PREFIX}{request_id}.json',
+        Body=json.dumps(marker).encode(), ContentType='application/json',
+    )
+
+    return 200, {
+        'status': 'SUBMITTED',
+        'request_id': request_id,
+        'batchJobId': response['jobId'],
+        'cliAction': cli_action,
+        'transformationName': name,
+    }
+
+
+def _handle_poll(body):
+    request_id = body.get('request_id', '')
+    if not request_id:
+        return 400, {'error': 'Missing required field: request_id'}
+
+    try:
+        obj = s3.get_object(Bucket=RESULT_BUCKET, Key=f'{RESULT_PREFIX}{request_id}.json')
+        result = json.loads(obj['Body'].read().decode('utf-8'))
+
+        if result.get('status') != 'PROCESSING':
+            return 200, result
+
+        batch_job_id = result.get('batchJobId', '')
+        if not batch_job_id:
+            return 200, result
+
+        resp = batch.describe_jobs(jobs=[batch_job_id])
+        if not resp.get('jobs'):
+            return 200, result
+
+        job = resp['jobs'][0]
+        job_status = job['status']
+
+        if job_status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING'):
+            return 200, result
+
+        if job_status == 'FAILED':
+            failed = {'status': 'FAILED', 'error': job.get('statusReason', 'Unknown error')}
+            _write_result(request_id, failed)
+            return 200, failed
+
+        # SUCCEEDED — scrape JSON from CloudWatch logs
+        log_stream = job.get('container', {}).get('logStreamName')
+        if not log_stream:
+            failed = {'status': 'FAILED', 'error': 'No log stream found for completed job'}
+            _write_result(request_id, failed)
+            return 200, failed
+
+        ki_data = _extract_json_from_logs(log_stream)
+        if not ki_data:
+            failed = {'status': 'FAILED', 'error': 'Could not extract knowledge items from job logs'}
+            _write_result(request_id, failed)
+            return 200, failed
+
+        t_name = result.get('transformationName', '')
+        cli_action = result.get('cliAction', 'list-ki')
+        if t_name:
+            cache_key = f'{CACHE_PREFIX}{t_name.replace("/", "_")}/{cli_action}.json'
+            s3.put_object(Bucket=RESULT_BUCKET, Key=cache_key,
+                          Body=json.dumps(ki_data).encode(), ContentType='application/json')
+
+        completed = {'status': 'COMPLETED', **ki_data}
+        _write_result(request_id, completed)
+        return 200, completed
+
+    except s3.exceptions.NoSuchKey:
+        return 200, {'status': 'NOT_FOUND'}
+    except Exception as e:
+        print(f'KI poll error: {e}')
+        return 200, {'status': 'PROCESSING'}
+
+
+def _write_result(request_id, data):
+    s3.put_object(Bucket=RESULT_BUCKET, Key=f'{RESULT_PREFIX}{request_id}.json',
+                  Body=json.dumps(data).encode(), ContentType='application/json')
+
+
+def _extract_json_from_logs(log_stream):
+    try:
+        resp = logs.get_log_events(
+            logGroupName='/aws/batch/atx-transform',
+            logStreamName=log_stream,
+            startFromHead=True,
+            limit=100,
+        )
+        for event in resp.get('events', []):
+            msg = event.get('message', '').strip()
+            if msg.startswith('{"transformationName"'):
+                return json.loads(msg)
+        return None
+    except Exception as e:
+        print(f'KI log extraction error: {e}')
+        return None
+
+
+# ── Write actions (delete / update / export) via Batch ───────────────────────
+
+def _handle_write(body):
+    action = body.get('kiAction')
+    name = body.get('transformationName')
+
+    if not name:
+        return 400, {'error': 'Missing required field: transformationName'}
+    if not _NAME_RE.match(name):
+        return 400, {'error': 'Invalid transformationName'}
+
+    cmd = f'atx custom def {action} -n {name}'
+
+    ki_id = body.get('id')
+    if action in ('delete-ki', 'update-ki-status'):
+        if not ki_id:
+            return 400, {'error': f'Missing required field: id (for {action})'}
+        if not _ID_RE.match(ki_id):
+            return 400, {'error': 'Invalid id'}
+        cmd += f' --id {ki_id}'
+
+    if action == 'update-ki-status':
+        status = body.get('status')
+        if status not in ('ENABLED', 'DISABLED'):
+            return 400, {'error': 'status must be ENABLED or DISABLED'}
+        cmd += f' --status {status}'
+
+    if action == 'update-ki-config':
+        auto = body.get('autoEnabled')
+        if auto not in ('TRUE', 'FALSE'):
+            return 400, {'error': 'autoEnabled must be TRUE or FALSE'}
+        cmd += f' --auto-enabled {auto}'
+
+    job_name = f'ki-{action}-{name.replace("/", "-")}'[:128]
+    try:
+        response = batch.submit_job(
+            jobName=job_name,
+            jobQueue=_job_queue(),
+            jobDefinition=_job_definition(),
+            containerOverrides={
+                'command': ['--output', f'knowledge-items/{job_name}/', '--command', cmd],
+            },
+        )
+    except Exception as e:
+        return 500, {'error': str(e)}
+
+    return 200, {
+        'batchJobId': response['jobId'],
+        'jobName': response['jobName'],
+        'action': action,
+        'transformationName': name,
+        'status': 'SUBMITTED',
+        'submittedAt': datetime.utcnow().isoformat() + 'Z',
+    }

--- a/agentic-atx-platform/api/lambda/metrics.py
+++ b/agentic-atx-platform/api/lambda/metrics.py
@@ -1,0 +1,508 @@
+"""
+CloudWatch metrics for ATX transformation jobs.
+
+Ported from scaled-execution-containers/api/lambda/get_metrics.py (PR #41) so the
+agentic platform can serve metrics through its own /orchestrate `direct` op instead
+of the IAM-authenticated REST API. The query logic is intentionally kept close to
+the source so improvements there can be re-synced with minimal diff.
+
+Entry point: get_metrics(params: dict) -> dict
+`params` mirrors the REST API's query string:
+  type:      jobs | transform | transform_detail | lambda | api | all | job_list | job_detail
+  period:    hours lookback (default 24, max 720)
+  startDate: ISO date (overrides period)
+  endDate:   ISO date (defaults to now when only startDate given)
+  jobId:     required when type=job_detail
+"""
+import os
+from datetime import datetime, timedelta
+
+import boto3
+
+batch = boto3.client('batch')
+cloudwatch = boto3.client('cloudwatch')
+
+VALID_TYPES = {'jobs', 'transform', 'transform_detail', 'lambda', 'api', 'all', 'job_list', 'job_detail'}
+
+
+def get_metrics(params):
+    """Return metrics for the given params dict. Raises ValueError on bad input."""
+    params = params or {}
+    metric_type = str(params.get('type', 'all')).lower()
+
+    if metric_type not in VALID_TYPES:
+        raise ValueError(f'Invalid type. Must be one of: {", ".join(sorted(VALID_TYPES))}')
+
+    # Date range: explicit startDate/endDate take priority over period
+    if params.get('startDate') and params.get('endDate'):
+        start_time = datetime.fromisoformat(str(params['startDate']).replace('Z', ''))
+        end_time = datetime.fromisoformat(str(params['endDate']).replace('Z', ''))
+    elif params.get('startDate'):
+        start_time = datetime.fromisoformat(str(params['startDate']).replace('Z', ''))
+        end_time = datetime.utcnow()
+    else:
+        period_hours = min(int(params.get('period', 24)), 720)
+        end_time = datetime.utcnow()
+        start_time = end_time - timedelta(hours=period_hours)
+
+    if metric_type == 'job_list':
+        return {'jobs': _get_job_list()}
+
+    if metric_type == 'job_detail':
+        job_id = params.get('jobId')
+        if not job_id:
+            raise ValueError('jobId parameter required for job_detail type')
+        return _get_job_detail(job_id)
+
+    if metric_type == 'transform_detail':
+        return {
+            'startTime': start_time.isoformat() + 'Z',
+            'endTime': end_time.isoformat() + 'Z',
+            'executions': _get_transform_executions(start_time, end_time),
+        }
+
+    fetch_all = metric_type == 'all'
+    result = {
+        'startTime': start_time.isoformat() + 'Z',
+        'endTime': end_time.isoformat() + 'Z',
+    }
+    if fetch_all or metric_type == 'jobs':
+        result['jobs'] = _get_job_counts()
+    if fetch_all or metric_type == 'transform':
+        result['transformCustom'] = _get_transform_custom_metrics(start_time, end_time)
+    if fetch_all or metric_type == 'lambda':
+        result['lambda'] = _get_lambda_metrics(start_time, end_time)
+    if fetch_all or metric_type == 'api':
+        result['api'] = _get_api_metrics(start_time, end_time)
+    return result
+
+
+def _get_job_list():
+    """List all Batch jobs across all statuses with IDs, names, timestamps."""
+    job_queue = os.environ.get('JOB_QUEUE_NAME', os.environ.get('JOB_QUEUE', 'atx-job-queue'))
+    all_jobs = []
+    for status in ['RUNNING', 'SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'SUCCEEDED', 'FAILED']:
+        try:
+            paginator_token = None
+            while True:
+                kwargs = {'jobQueue': job_queue, 'jobStatus': status, 'maxResults': 100}
+                if paginator_token:
+                    kwargs['nextToken'] = paginator_token
+                resp = batch.list_jobs(**kwargs)
+                for j in resp.get('jobSummaryList', []):
+                    all_jobs.append({
+                        'jobId': j['jobId'],
+                        'jobName': j['jobName'],
+                        'status': j['status'],
+                        'createdAt': _fmt_ts(j.get('createdAt')),
+                        'startedAt': _fmt_ts(j.get('startedAt')),
+                        'stoppedAt': _fmt_ts(j.get('stoppedAt')),
+                    })
+                paginator_token = resp.get('nextToken')
+                if not paginator_token:
+                    break
+        except Exception as e:
+            print(f"Error listing {status} jobs: {e}")
+    all_jobs.sort(key=lambda x: x.get('createdAt') or '', reverse=True)
+    return all_jobs
+
+
+def _get_job_detail(job_id):
+    """Get full detail for a single job: conversation ID, CloudWatch metrics, logs."""
+    logs_client = boto3.client('logs')
+    s3_client = boto3.client('s3')
+
+    resp = batch.describe_jobs(jobs=[job_id])
+    if not resp.get('jobs'):
+        return {'error': f'Job not found: {job_id}'}
+    job = resp['jobs'][0]
+
+    result = {
+        'jobId': job['jobId'],
+        'jobName': job['jobName'],
+        'status': job['status'],
+        'createdAt': _fmt_ts(job.get('createdAt')),
+        'startedAt': _fmt_ts(job.get('startedAt')),
+        'stoppedAt': _fmt_ts(job.get('stoppedAt')),
+        'duration': _calc_dur(job.get('startedAt'), job.get('stoppedAt')),
+        'command': job.get('container', {}).get('command', []),
+        'exitCode': job.get('container', {}).get('exitCode'),
+        'conversationId': None,
+        's3OutputPath': None,
+        'metrics': {},
+    }
+
+    log_stream = job.get('container', {}).get('logStreamName')
+    log_group = '/aws/batch/atx-transform'
+    conversation_id = None
+
+    if log_stream:
+        result['logStream'] = {'logGroup': log_group, 'logStreamName': log_stream}
+        try:
+            log_resp = logs_client.get_log_events(
+                logGroupName=log_group, logStreamName=log_stream,
+                limit=200, startFromHead=False,
+            )
+            import re
+            for ev in log_resp.get('events', []):
+                msg = ev.get('message', '')
+                m = re.search(r'/atx/custom/(\d{8}_\d{6}_[a-f0-9]+)/', msg)
+                if m:
+                    conversation_id = m.group(1)
+                    break
+        except Exception as e:
+            print(f"Error reading logs: {e}")
+
+    if not conversation_id:
+        s3_bucket = None
+        for v in job.get('container', {}).get('environment', []):
+            if v.get('name') == 'S3_BUCKET':
+                s3_bucket = v.get('value')
+        cmd = job.get('container', {}).get('command', [])
+        output_prefix = 'transformations/'
+        try:
+            idx = cmd.index('--output')
+            if idx + 1 < len(cmd):
+                output_prefix = cmd[idx + 1]
+        except (ValueError, IndexError):
+            pass
+        if s3_bucket:
+            try:
+                s3_resp = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=output_prefix, MaxKeys=5)
+                import re
+                for obj in s3_resp.get('Contents', []):
+                    m = re.search(r'/(\d{8}_\d{6}_[a-f0-9]+)/', obj['Key'])
+                    if m:
+                        conversation_id = m.group(1)
+                        break
+            except Exception as e:
+                print(f"Error listing S3: {e}")
+
+    result['conversationId'] = conversation_id
+    if conversation_id:
+        s3_bucket = None
+        for v in job.get('container', {}).get('environment', []):
+            if v.get('name') == 'S3_BUCKET':
+                s3_bucket = v.get('value')
+        cmd = job.get('container', {}).get('command', [])
+        output_prefix = 'transformations/'
+        try:
+            idx = cmd.index('--output')
+            if idx + 1 < len(cmd):
+                output_prefix = cmd[idx + 1]
+        except (ValueError, IndexError):
+            pass
+        if s3_bucket:
+            result['s3OutputPath'] = f"s3://{s3_bucket}/{output_prefix}{conversation_id}/"
+
+    start_ms = job.get('createdAt') or job.get('startedAt')
+    stop_ms = job.get('stoppedAt')
+    if start_ms:
+        m_start = datetime.utcfromtimestamp(start_ms / 1000) - timedelta(minutes=5)
+        m_end = datetime.utcfromtimestamp(stop_ms / 1000) + timedelta(minutes=5) if stop_ms else datetime.utcnow()
+
+        for fn in ['atx-trigger-job', 'atx-trigger-batch-jobs', 'atx-async-invoke-agent']:
+            inv = _get_stat('AWS/Lambda', 'Invocations', 'FunctionName', fn, m_start, m_end, 'Sum')
+            err = _get_stat('AWS/Lambda', 'Errors', 'FunctionName', fn, m_start, m_end, 'Sum')
+            dur = _get_stat('AWS/Lambda', 'Duration', 'FunctionName', fn, m_start, m_end, 'Average')
+            if inv:
+                result['metrics'].setdefault('lambda', {})[fn] = {
+                    'invocations': int(inv or 0), 'errors': int(err or 0),
+                    'avgDurationMs': round(dur, 1) if dur else None,
+                }
+
+        transform_metrics = _get_job_transform_metrics(job['jobName'], conversation_id, m_start, m_end)
+        if transform_metrics:
+            result['metrics']['transformCustom'] = transform_metrics
+
+        result['metrics']['batch'] = {
+            'vcpus': job.get('container', {}).get('vcpus'),
+            'memory': job.get('container', {}).get('memory'),
+            'attempts': len(job.get('attempts', [])),
+        }
+
+    return result
+
+
+def _get_job_transform_metrics(job_name, conversation_id, start_time, end_time):
+    """Get AWS/TransformCustom metrics that match this job."""
+    namespace = 'AWS/TransformCustom'
+    result = {}
+    try:
+        for metric_name in ['AgentExecutionMinutes', 'TransformationExecutionStarted', 'ConversationStarted']:
+            resp = cloudwatch.list_metrics(Namespace=namespace, MetricName=metric_name)
+            for m in resp.get('Metrics', []):
+                dims = {d['Name']: d['Value'] for d in m['Dimensions']}
+                t_name = dims.get('TransformationName', '')
+                if job_name and job_name in t_name or conversation_id and conversation_id in str(dims):
+                    val = _get_stat(namespace, metric_name, m['Dimensions'][0]['Name'],
+                                    m['Dimensions'][0]['Value'], start_time, end_time, 'Sum')
+                    if val:
+                        result[metric_name] = result.get(metric_name, 0) + val
+                        result.setdefault('dimensions', {})[t_name] = dims
+    except Exception as e:
+        print(f"Error getting job transform metrics: {e}")
+    return result
+
+
+def _fmt_ts(ts_ms):
+    if ts_ms:
+        return datetime.utcfromtimestamp(ts_ms / 1000).isoformat() + 'Z'
+    return None
+
+
+def _calc_dur(start_ms, end_ms):
+    if start_ms and end_ms:
+        return int((end_ms - start_ms) / 1000)
+    return None
+
+
+def _get_job_counts():
+    job_queue = os.environ.get('JOB_QUEUE_NAME', os.environ.get('JOB_QUEUE', 'atx-job-queue'))
+    counts = {}
+    for status in ['SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING', 'RUNNING', 'SUCCEEDED', 'FAILED']:
+        total = 0
+        try:
+            token = None
+            while True:
+                kwargs = {'jobQueue': job_queue, 'jobStatus': status, 'maxResults': 100}
+                if token:
+                    kwargs['nextToken'] = token
+                resp = batch.list_jobs(**kwargs)
+                total += len(resp.get('jobSummaryList', []))
+                token = resp.get('nextToken')
+                if not token:
+                    break
+        except Exception:
+            pass
+        counts[status] = total
+    return counts
+
+
+def _list_all_metrics(namespace):
+    """List all metrics in a namespace, handling pagination."""
+    all_metrics = []
+    token = None
+    while True:
+        kwargs = {'Namespace': namespace}
+        if token:
+            kwargs['NextToken'] = token
+        resp = cloudwatch.list_metrics(**kwargs)
+        all_metrics.extend(resp.get('Metrics', []))
+        token = resp.get('NextToken')
+        if not token:
+            break
+    return all_metrics
+
+
+def _get_transform_custom_metrics(start_time, end_time):
+    """Aggregate view: all TransformCustom metrics with dimension rollup."""
+    namespace = 'AWS/TransformCustom'
+    try:
+        all_cw = _list_all_metrics(namespace)
+        queries = []
+        meta = {}
+        idx = 0
+        for m in all_cw:
+            dims = {d['Name']: d['Value'] for d in m['Dimensions']}
+            mn = m['MetricName']
+            if mn == 'AgentExecutionMinutes' and 'SegmentIndex' in dims:
+                continue
+            qid = f'm{idx}'
+            idx += 1
+            queries.append({
+                'Id': qid,
+                'MetricStat': {
+                    'Metric': m,
+                    'Period': max(int((end_time - start_time).total_seconds()), 60),
+                    'Stat': 'Sum' if mn != 'ExecutionDuration' else 'Average',
+                },
+                'ReturnData': True,
+            })
+            meta[qid] = (mn, dims)
+
+        for m in all_cw:
+            if m['MetricName'] == 'AgentExecutionMinutes':
+                dims = {d['Name']: d['Value'] for d in m['Dimensions']}
+                qid = f'm{idx}'
+                idx += 1
+                queries.append({
+                    'Id': qid,
+                    'MetricStat': {
+                        'Metric': m,
+                        'Period': max(int((end_time - start_time).total_seconds()), 60),
+                        'Stat': 'Sum',
+                    },
+                    'ReturnData': True,
+                })
+                meta[qid] = ('AgentExecutionMinutes', dims)
+
+        if not queries:
+            return _empty_transform_result()
+
+        totals = {}
+        by_transform = {}
+        by_repo = {}
+        conversations = set()
+        executions = set()
+
+        for batch_start in range(0, len(queries), 500):
+            batch_q = queries[batch_start:batch_start + 500]
+            resp = cloudwatch.get_metric_data(MetricDataQueries=batch_q, StartTime=start_time, EndTime=end_time)
+            for r in resp.get('MetricDataResults', []):
+                val = sum(r.get('Values', []))
+                if val == 0:
+                    continue
+                mn, dims = meta.get(r['Id'], (None, {}))
+                if not mn:
+                    continue
+                totals[mn] = totals.get(mn, 0) + val
+                cid = dims.get('ConversationId')
+                eid = dims.get('ExecutionId')
+                if cid:
+                    conversations.add(cid)
+                if eid:
+                    executions.add(eid)
+                t_name = dims.get('TransformationName')
+                if t_name:
+                    t = by_transform.setdefault(t_name, {})
+                    t[mn] = t.get(mn, 0) + val
+                repo = dims.get('RepositoryName')
+                if repo:
+                    r_entry = by_repo.setdefault(repo, {})
+                    r_entry[mn] = r_entry.get(mn, 0) + val
+
+        for d in [totals, *by_transform.values(), *by_repo.values()]:
+            for k in d:
+                if isinstance(d[k], float):
+                    d[k] = round(d[k], 2)
+
+        return {
+            'totals': totals,
+            'uniqueConversations': len(conversations),
+            'uniqueExecutions': len(executions),
+            'byTransformation': by_transform,
+            'byRepository': by_repo,
+        }
+    except Exception as e:
+        print(f"Error getting TransformCustom metrics: {e}")
+        return _empty_transform_result()
+
+
+def _empty_transform_result():
+    return {'totals': {}, 'uniqueConversations': 0, 'uniqueExecutions': 0, 'byTransformation': {}, 'byRepository': {}}
+
+
+def _get_transform_executions(start_time, end_time):
+    """Per-execution breakdown: each ExecutionId gets its own entry with metrics and dimensions."""
+    namespace = 'AWS/TransformCustom'
+    try:
+        all_cw = _list_all_metrics(namespace)
+        exec_map = {}
+        conv_list = []
+
+        queries = []
+        meta = {}
+        idx = 0
+        for m in all_cw:
+            dims = {d['Name']: d['Value'] for d in m['Dimensions']}
+            mn = m['MetricName']
+            if mn == 'AgentExecutionMinutes' and 'SegmentIndex' in dims:
+                continue
+            qid = f'e{idx}'
+            idx += 1
+            stat = 'Average' if mn == 'ExecutionDuration' else 'Sum'
+            queries.append({
+                'Id': qid,
+                'MetricStat': {'Metric': m, 'Period': max(int((end_time - start_time).total_seconds()), 60), 'Stat': stat},
+                'ReturnData': True,
+            })
+            meta[qid] = (mn, dims)
+
+        for m in all_cw:
+            if m['MetricName'] == 'AgentExecutionMinutes':
+                dims = {d['Name']: d['Value'] for d in m['Dimensions']}
+                qid = f'e{idx}'
+                idx += 1
+                queries.append({
+                    'Id': qid,
+                    'MetricStat': {'Metric': m, 'Period': max(int((end_time - start_time).total_seconds()), 60), 'Stat': 'Sum'},
+                    'ReturnData': True,
+                })
+                meta[qid] = ('AgentExecutionMinutes', dims)
+
+        if not queries:
+            return []
+
+        for batch_start in range(0, len(queries), 500):
+            batch_q = queries[batch_start:batch_start + 500]
+            resp = cloudwatch.get_metric_data(MetricDataQueries=batch_q, StartTime=start_time, EndTime=end_time)
+            for r in resp.get('MetricDataResults', []):
+                val = sum(r.get('Values', []))
+                if val == 0:
+                    continue
+                mn, dims = meta.get(r['Id'], (None, {}))
+                if not mn:
+                    continue
+                eid = dims.get('ExecutionId')
+                if eid:
+                    entry = exec_map.setdefault(eid, {'executionId': eid, 'dimensions': {}, 'metrics': {}})
+                    for k, v in dims.items():
+                        if k != 'SegmentIndex':
+                            entry['dimensions'][k] = v
+                    entry['metrics'][mn] = entry['metrics'].get(mn, 0) + val
+                elif mn == 'ConversationStarted':
+                    conv_list.append({'dimensions': dims, 'metrics': {mn: val}})
+
+        for entry in exec_map.values():
+            for k in entry['metrics']:
+                if isinstance(entry['metrics'][k], float):
+                    entry['metrics'][k] = round(entry['metrics'][k], 2)
+
+        result = sorted(exec_map.values(), key=lambda x: x['dimensions'].get('ConversationId', ''), reverse=True)
+        if conv_list:
+            result.append({'type': 'conversations', 'entries': conv_list})
+        return result
+    except Exception as e:
+        print(f"Error getting transform executions: {e}")
+        return []
+
+
+def _get_lambda_metrics(start_time, end_time):
+    functions = [
+        'atx-trigger-job', 'atx-trigger-batch-jobs',
+        'atx-get-job-status', 'atx-get-batch-status',
+        'atx-get-knowledge-items', 'atx-get-metrics', 'atx-async-invoke-agent',
+    ]
+    metrics = {}
+    for fn in functions:
+        invocations = _get_stat('AWS/Lambda', 'Invocations', 'FunctionName', fn, start_time, end_time, 'Sum')
+        errors = _get_stat('AWS/Lambda', 'Errors', 'FunctionName', fn, start_time, end_time, 'Sum')
+        avg_dur = _get_stat('AWS/Lambda', 'Duration', 'FunctionName', fn, start_time, end_time, 'Average')
+        if invocations or errors:
+            metrics[fn] = {
+                'invocations': int(invocations or 0),
+                'errors': int(errors or 0),
+                'avgDurationMs': round(avg_dur, 1) if avg_dur else None,
+            }
+    return metrics
+
+
+def _get_api_metrics(start_time, end_time):
+    g = lambda m: int(_get_stat('AWS/ApiGateway', m, 'ApiName', 'atx-transform-api', start_time, end_time, 'Sum') or 0)
+    return {'requests': g('Count'), '4xxErrors': g('4XXError'), '5xxErrors': g('5XXError')}
+
+
+def _get_stat(namespace, metric, dim_name, dim_value, start, end, stat):
+    try:
+        resp = cloudwatch.get_metric_statistics(
+            Namespace=namespace, MetricName=metric,
+            Dimensions=[{'Name': dim_name, 'Value': dim_value}],
+            StartTime=start, EndTime=end,
+            Period=int((end - start).total_seconds()),
+            Statistics=[stat],
+        )
+        pts = resp.get('Datapoints', [])
+        return pts[0][stat] if pts else None
+    except Exception:
+        return None

--- a/agentic-atx-platform/api/lambda/metrics.py
+++ b/agentic-atx-platform/api/lambda/metrics.py
@@ -15,7 +15,8 @@ Entry point: get_metrics(params: dict) -> dict
   jobId:     required when type=job_detail
 """
 import os
-from datetime import datetime, timedelta
+import re
+from datetime import datetime, timezone, timedelta
 
 import boto3
 
@@ -23,6 +24,38 @@ batch = boto3.client('batch')
 cloudwatch = boto3.client('cloudwatch')
 
 VALID_TYPES = {'jobs', 'transform', 'transform_detail', 'lambda', 'api', 'all', 'job_list', 'job_detail'}
+
+
+def _utcnow():
+    """Naive UTC now (faithful replacement for the deprecated datetime.utcnow())."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _utc_from_ms(ms):
+    """Naive UTC datetime from epoch ms (replacement for deprecated utcfromtimestamp)."""
+    return datetime.fromtimestamp(ms / 1000, timezone.utc).replace(tzinfo=None)
+
+
+def _iso_z(dt):
+    """ISO-8601 string with a trailing 'Z', matching the API's original format."""
+    return dt.isoformat() + 'Z'
+
+
+def _job_s3_output(job):
+    """Extract (s3_bucket, output_prefix) from a Batch job's container env/command."""
+    s3_bucket = None
+    for v in job.get('container', {}).get('environment', []):
+        if v.get('name') == 'S3_BUCKET':
+            s3_bucket = v.get('value')
+    output_prefix = 'transformations/'
+    cmd = job.get('container', {}).get('command', [])
+    try:
+        idx = cmd.index('--output')
+        if idx + 1 < len(cmd):
+            output_prefix = cmd[idx + 1]
+    except (ValueError, IndexError):
+        pass
+    return s3_bucket, output_prefix
 
 
 def get_metrics(params):
@@ -39,10 +72,10 @@ def get_metrics(params):
         end_time = datetime.fromisoformat(str(params['endDate']).replace('Z', ''))
     elif params.get('startDate'):
         start_time = datetime.fromisoformat(str(params['startDate']).replace('Z', ''))
-        end_time = datetime.utcnow()
+        end_time = _utcnow()
     else:
         period_hours = min(int(params.get('period', 24)), 720)
-        end_time = datetime.utcnow()
+        end_time = _utcnow()
         start_time = end_time - timedelta(hours=period_hours)
 
     if metric_type == 'job_list':
@@ -56,15 +89,15 @@ def get_metrics(params):
 
     if metric_type == 'transform_detail':
         return {
-            'startTime': start_time.isoformat() + 'Z',
-            'endTime': end_time.isoformat() + 'Z',
+            'startTime': _iso_z(start_time),
+            'endTime': _iso_z(end_time),
             'executions': _get_transform_executions(start_time, end_time),
         }
 
     fetch_all = metric_type == 'all'
     result = {
-        'startTime': start_time.isoformat() + 'Z',
-        'endTime': end_time.isoformat() + 'Z',
+        'startTime': _iso_z(start_time),
+        'endTime': _iso_z(end_time),
     }
     if fetch_all or metric_type == 'jobs':
         result['jobs'] = _get_job_counts()
@@ -143,7 +176,6 @@ def _get_job_detail(job_id):
                 logGroupName=log_group, logStreamName=log_stream,
                 limit=200, startFromHead=False,
             )
-            import re
             for ev in log_resp.get('events', []):
                 msg = ev.get('message', '')
                 m = re.search(r'/atx/custom/(\d{8}_\d{6}_[a-f0-9]+)/', msg)
@@ -154,22 +186,10 @@ def _get_job_detail(job_id):
             print(f"Error reading logs: {e}")
 
     if not conversation_id:
-        s3_bucket = None
-        for v in job.get('container', {}).get('environment', []):
-            if v.get('name') == 'S3_BUCKET':
-                s3_bucket = v.get('value')
-        cmd = job.get('container', {}).get('command', [])
-        output_prefix = 'transformations/'
-        try:
-            idx = cmd.index('--output')
-            if idx + 1 < len(cmd):
-                output_prefix = cmd[idx + 1]
-        except (ValueError, IndexError):
-            pass
+        s3_bucket, output_prefix = _job_s3_output(job)
         if s3_bucket:
             try:
                 s3_resp = s3_client.list_objects_v2(Bucket=s3_bucket, Prefix=output_prefix, MaxKeys=5)
-                import re
                 for obj in s3_resp.get('Contents', []):
                     m = re.search(r'/(\d{8}_\d{6}_[a-f0-9]+)/', obj['Key'])
                     if m:
@@ -180,26 +200,15 @@ def _get_job_detail(job_id):
 
     result['conversationId'] = conversation_id
     if conversation_id:
-        s3_bucket = None
-        for v in job.get('container', {}).get('environment', []):
-            if v.get('name') == 'S3_BUCKET':
-                s3_bucket = v.get('value')
-        cmd = job.get('container', {}).get('command', [])
-        output_prefix = 'transformations/'
-        try:
-            idx = cmd.index('--output')
-            if idx + 1 < len(cmd):
-                output_prefix = cmd[idx + 1]
-        except (ValueError, IndexError):
-            pass
+        s3_bucket, output_prefix = _job_s3_output(job)
         if s3_bucket:
             result['s3OutputPath'] = f"s3://{s3_bucket}/{output_prefix}{conversation_id}/"
 
     start_ms = job.get('createdAt') or job.get('startedAt')
     stop_ms = job.get('stoppedAt')
     if start_ms:
-        m_start = datetime.utcfromtimestamp(start_ms / 1000) - timedelta(minutes=5)
-        m_end = datetime.utcfromtimestamp(stop_ms / 1000) + timedelta(minutes=5) if stop_ms else datetime.utcnow()
+        m_start = _utc_from_ms(start_ms) - timedelta(minutes=5)
+        m_end = _utc_from_ms(stop_ms) + timedelta(minutes=5) if stop_ms else _utcnow()
 
         for fn in ['atx-trigger-job', 'atx-trigger-batch-jobs', 'atx-async-invoke-agent']:
             inv = _get_stat('AWS/Lambda', 'Invocations', 'FunctionName', fn, m_start, m_end, 'Sum')
@@ -247,7 +256,7 @@ def _get_job_transform_metrics(job_name, conversation_id, start_time, end_time):
 
 def _fmt_ts(ts_ms):
     if ts_ms:
-        return datetime.utcfromtimestamp(ts_ms / 1000).isoformat() + 'Z'
+        return _iso_z(_utc_from_ms(ts_ms))
     return None
 
 

--- a/agentic-atx-platform/api/lambda/tests/test_metrics_helpers.py
+++ b/agentic-atx-platform/api/lambda/tests/test_metrics_helpers.py
@@ -1,0 +1,76 @@
+"""
+Tests for metrics.py helpers added while addressing PR feedback:
+  - _utcnow / _utc_from_ms / _iso_z are non-deprecated and preserve the 'Z' format
+  - _job_s3_output extracts (bucket, prefix) and dedupes the repeated logic
+
+boto3 is mocked so metrics.py imports without AWS access.
+
+Run from agentic-atx-platform/api/lambda:
+    python3 -m unittest discover -s tests -v
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def _import_metrics():
+    boto3_mock = mock.MagicMock()
+    with mock.patch.dict(sys.modules, {'boto3': boto3_mock}):
+        sys.modules.pop('metrics', None)
+        import metrics
+        return metrics
+
+
+class TestDatetimeHelpers(unittest.TestCase):
+    def setUp(self):
+        self.m = _import_metrics()
+
+    def test_iso_z_format(self):
+        # _iso_z output must end with Z and not contain a +00:00 offset.
+        s = self.m._iso_z(self.m._utcnow())
+        self.assertTrue(s.endswith('Z'), s)
+        self.assertNotIn('+00:00', s)
+
+    def test_utc_from_ms(self):
+        # 2021-01-01T00:00:00Z == 1609459200000 ms
+        dt = self.m._utc_from_ms(1609459200000)
+        self.assertEqual(dt.year, 2021)
+        self.assertEqual(dt.month, 1)
+        self.assertEqual(dt.day, 1)
+
+    def test_no_deprecated_utcnow_in_source(self):
+        # Guard against regressions to the deprecated APIs. Ignore comment lines
+        # (the helper docstrings intentionally mention the deprecated names).
+        src_lines = open(os.path.join(os.path.dirname(__file__), '..', 'metrics.py')).read().splitlines()
+        code = '\n'.join(l for l in src_lines if not l.lstrip().startswith('#') and '"""' not in l)
+        self.assertNotIn('datetime.utcnow(', code)
+        self.assertNotIn('.utcfromtimestamp(', code)
+
+
+class TestJobS3Output(unittest.TestCase):
+    def setUp(self):
+        self.m = _import_metrics()
+
+    def test_extracts_bucket_and_prefix(self):
+        job = {
+            'container': {
+                'environment': [{'name': 'S3_BUCKET', 'value': 'my-bucket'}],
+                'command': ['--output', 'transformations/my-job/', '--command', 'atx ...'],
+            }
+        }
+        bucket, prefix = self.m._job_s3_output(job)
+        self.assertEqual(bucket, 'my-bucket')
+        self.assertEqual(prefix, 'transformations/my-job/')
+
+    def test_defaults_when_missing(self):
+        bucket, prefix = self.m._job_s3_output({'container': {}})
+        self.assertIsNone(bucket)
+        self.assertEqual(prefix, 'transformations/')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agentic-atx-platform/orchestrator/tools/createtransform.py
+++ b/agentic-atx-platform/orchestrator/tools/createtransform.py
@@ -12,6 +12,7 @@ import os
 import json
 import time
 import logging
+import re
 import boto3
 from typing import Any, Dict
 
@@ -41,7 +42,6 @@ def _get_source_bucket():
 # single hyphens, 1-64 chars, no leading/trailing/consecutive hyphens. Must match
 # the parent directory name. Normalize so `atx custom def publish` won't reject it.
 def _normalize_skill_name(name: str) -> str:
-    import re
     n = (name or "").strip().lower()
     n = re.sub(r'[^a-z0-9]+', '-', n)   # non-alphanumeric runs -> single hyphen
     n = re.sub(r'-{2,}', '-', n)         # collapse consecutive hyphens

--- a/agentic-atx-platform/orchestrator/tools/createtransform.py
+++ b/agentic-atx-platform/orchestrator/tools/createtransform.py
@@ -4,7 +4,7 @@ CreateTransform Sub-Agent
 Creates custom transformation definitions by:
 1. Cloning repo to S3 via Batch job
 2. AI-driven file selection: list files → pick relevant ones → read them
-3. Generating transformation_definition.md using Bedrock with full source context
+3. Generating SKILL.md (ATX skill format) using Bedrock with full source context
 4. Publishing to ATX registry via Batch job
 """
 
@@ -35,6 +35,27 @@ def _get_account():
 
 def _get_source_bucket():
     return f"atx-source-code-{_get_account()}"
+
+
+# SKILL.md name rules (from ATX CLI skill discovery): lowercase alphanumeric +
+# single hyphens, 1-64 chars, no leading/trailing/consecutive hyphens. Must match
+# the parent directory name. Normalize so `atx custom def publish` won't reject it.
+def _normalize_skill_name(name: str) -> str:
+    import re
+    n = (name or "").strip().lower()
+    n = re.sub(r'[^a-z0-9]+', '-', n)   # non-alphanumeric runs -> single hyphen
+    n = re.sub(r'-{2,}', '-', n)         # collapse consecutive hyphens
+    n = n.strip('-')                      # no leading/trailing hyphen
+    if not n:
+        n = "custom-transformation"
+    return n[:64].rstrip('-')
+
+
+# YAML-escape a value for the SKILL.md frontmatter (handles quotes/colons/newlines).
+def _yaml_escape(value: str) -> str:
+    s = (value or "").replace('\n', ' ').strip()
+    s = s.replace('\\', '\\\\').replace('"', '\\"')
+    return f'"{s}"'
 
 
 @tool
@@ -158,7 +179,7 @@ def read_repo_file(name: str, file_path: str) -> Dict[str, Any]:
 def generate_transformation_definition(name: str, description: str, requirements: str,
                                         source_context: str = "") -> Dict[str, Any]:
     """
-    Generate a transformation_definition.md file using Bedrock AI and upload to S3.
+    Generate a SKILL.md file (ATX skill format) using Bedrock AI and upload to S3.
 
     Args:
         name: Name for the transformation (e.g., 'add-structured-logging')
@@ -170,24 +191,25 @@ def generate_transformation_definition(name: str, description: str, requirements
         Dictionary with the generated definition and S3 location
     """
     bucket = _get_source_bucket()
+    skill_name = _normalize_skill_name(name)
 
-    prompt = f"""Create a transformation_definition.md file for AWS Transform custom.
+    prompt = f"""Create the instructions body for an AWS Transform custom SKILL.md file.
 
-Name: {name}
+Name: {skill_name}
 Description: {description}
 Requirements: {requirements}
 """
     if source_context:
         prompt += f"""
 The following is the actual source code from the target repository.
-Use this to make the transformation definition specific and accurate for this codebase.
+Use this to make the transformation instructions specific and accurate for this codebase.
 Reference actual file names, function names, class names, and patterns you see.
 
 {source_context}
 """
 
     prompt += """
-The file should contain clear, detailed instructions that an AI agent will follow to transform code.
+The content should contain clear, detailed instructions that an AI agent will follow to transform code.
 Include:
 - What changes to make (be specific based on the actual code patterns found)
 - Specific files and functions to modify
@@ -195,7 +217,8 @@ Include:
 - How to validate the changes
 - Edge cases to handle
 
-Output ONLY the markdown content, no code fences."""
+Output ONLY the markdown instructions body (no YAML frontmatter, no code fences).
+Do not include a top-level title line; it will be added automatically."""
 
     try:
         response = bedrock_runtime.invoke_model(
@@ -208,21 +231,35 @@ Output ONLY the markdown content, no code fences."""
             })
         )
         body = json.loads(response['body'].read())
-        definition_md = body['content'][0]['text'].strip()
+        instructions = body['content'][0]['text'].strip()
 
-        s3_key = f"custom-definitions/{name}/transformation_definition.md"
+        # Assemble SKILL.md: YAML frontmatter (name + description) + instructions.
+        # ATX requires `name` to match the parent directory and `description` to be 1-1024 chars.
+        desc = (description or skill_name).strip()
+        if len(desc) > 1024:
+            desc = desc[:1021] + '...'
+        skill_md = (
+            "---\n"
+            f"name: {skill_name}\n"
+            f"description: {_yaml_escape(desc)}\n"
+            "---\n"
+            f"# {skill_name}\n\n"
+            f"{instructions}\n"
+        )
+
+        s3_key = f"custom-definitions/{skill_name}/SKILL.md"
         s3_client.put_object(
             Bucket=bucket, Key=s3_key,
-            Body=definition_md.encode('utf-8'),
+            Body=skill_md.encode('utf-8'),
             ContentType='text/markdown'
         )
 
         return {
             "status": "success",
-            "name": name,
+            "name": skill_name,
             "s3_uri": f"s3://{bucket}/{s3_key}",
             "source_analyzed": bool(source_context),
-            "definition_preview": definition_md[:500] + "..." if len(definition_md) > 500 else definition_md,
+            "definition_preview": skill_md[:500] + "..." if len(skill_md) > 500 else skill_md,
         }
     except Exception as e:
         return {"status": "error", "error": str(e)}
@@ -241,20 +278,33 @@ def publish_transformation(name: str, description: str) -> Dict[str, Any]:
         Dictionary with the Batch job ID for the publish operation
     """
     bucket = _get_source_bucket()
-    s3_key = f"custom-definitions/{name}/transformation_definition.md"
+    skill_name = _normalize_skill_name(name)
 
-    try:
-        s3_client.head_object(Bucket=bucket, Key=s3_key)
-    except Exception:
-        return {"status": "error", "error": f"Definition not found: s3://{bucket}/{s3_key}. Generate it first."}
+    # Prefer the new SKILL.md format; fall back to the legacy transformation_definition.md
+    # so previously-generated definitions can still be published.
+    skill_key = f"custom-definitions/{skill_name}/SKILL.md"
+    legacy_key = f"custom-definitions/{skill_name}/transformation_definition.md"
+    staged_file = None
+    for candidate in (skill_key, legacy_key):
+        try:
+            s3_client.head_object(Bucket=bucket, Key=candidate)
+            staged_file = candidate
+            break
+        except Exception:
+            continue
+    if not staged_file:
+        return {"status": "error",
+                "error": f"Definition not found: s3://{bucket}/{skill_key} (or legacy transformation_definition.md). Generate it first."}
 
+    name = skill_name
     job_name = f"publish-{name}-{int(time.time())}"
     job_queue = os.environ.get('JOB_QUEUE_NAME', 'atx-job-queue')
     job_definition = os.environ.get('JOB_DEFINITION_NAME', 'atx-transform-job')
 
+    filename = staged_file.split('/')[-1]
     cmd = (
         f"mkdir -p /tmp/{name} && "
-        f"aws s3 cp s3://{bucket}/custom-definitions/{name}/transformation_definition.md /tmp/{name}/transformation_definition.md && "
+        f"aws s3 cp s3://{bucket}/{staged_file} /tmp/{name}/{filename} && "
         f"atx custom def publish -n {name} --description '{description}' --sd /tmp/{name}"
     )
 

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -23,6 +23,10 @@ Parameters:
     Type: String
     Default: ""
     Description: ECR URI for the orchestrator container (built by deploy.sh)
+  AgentRuntimeArn:
+    Type: String
+    Default: ""
+    Description: AgentCore runtime ARN (set after the orchestrator is deployed). Preserved across redeploys.
 
 Globals:
   Function:
@@ -189,6 +193,21 @@ Resources:
                 Action: batch:DescribeJobs
                 Resource: "*"
               - Effect: Allow
+                Action: batch:ListJobs
+                Resource: "*"
+              - Effect: Allow
+                Action: batch:SubmitJob
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:ListMetrics
+                  - cloudwatch:GetMetricData
+                Resource: "*"
+              - Effect: Allow
+                Action: logs:GetLogEvents
+                Resource: !Sub "arn:aws:logs:${AwsRegion}:${AWS::AccountId}:log-group:/aws/batch/atx-transform:*"
+              - Effect: Allow
                 Action: sts:GetCallerIdentity
                 Resource: "*"
               - Effect: Allow
@@ -221,8 +240,10 @@ Resources:
       Tracing: Active
       Environment:
         Variables:
-          AGENT_RUNTIME_ARN: ""  # Updated after deploy-agent is invoked
+          AGENT_RUNTIME_ARN: !Ref AgentRuntimeArn
           RESULT_BUCKET: !Ref OutputBucketName
+          JOB_QUEUE_NAME: atx-job-queue
+          JOB_DEFINITION_NAME: atx-transform-job
       Events:
         Orchestrate:
           Type: HttpApi

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -189,15 +189,20 @@ Resources:
                   - !Sub "arn:aws:s3:::${OutputBucketName}/*"
                   - !Sub "arn:aws:s3:::${SourceBucketName}"
                   - !Sub "arn:aws:s3:::${SourceBucketName}/*"
+              # DescribeJobs has no resource-level ARN support in AWS Batch
+              # (jobs are described by dynamic job id), so it requires "*".
               - Effect: Allow
                 Action: batch:DescribeJobs
                 Resource: "*"
               - Effect: Allow
                 Action: batch:ListJobs
-                Resource: "*"
+                Resource: !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-queue/atx-job-queue"
               - Effect: Allow
                 Action: batch:SubmitJob
-                Resource: "*"
+                Resource:
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-queue/atx-job-queue"
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-definition/atx-transform-job"
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-definition/atx-transform-job:*"
               - Effect: Allow
                 Action:
                   - cloudwatch:GetMetricStatistics

--- a/agentic-atx-platform/ui/package-lock.json
+++ b/agentic-atx-platform/ui/package-lock.json
@@ -8,8 +8,10 @@
       "name": "atx-transform-ui",
       "version": "1.0.0",
       "dependencies": {
+        "chart.js": "^4.4.3",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.2.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
@@ -740,6 +742,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1238,6 +1246,18 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1486,6 +1506,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.1.tgz",
+      "integrity": "sha512-h5IPXKg9EXpjoBzUfyWJvllMjG2mQ4EiuHQFhms/AjUm0XSZHhyRy2xVmLXHKrtcdrPO4mnGqRtYoD0vp95A0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/agentic-atx-platform/ui/package.json
+++ b/agentic-atx-platform/ui/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "papaparse": "^5.4.1"
+    "papaparse": "^5.4.1",
+    "chart.js": "^4.4.3",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/agentic-atx-platform/ui/src/App.jsx
+++ b/agentic-atx-platform/ui/src/App.jsx
@@ -5,8 +5,10 @@ import CreateCustom from './components/CreateCustom'
 import CsvUpload from './components/CsvUpload'
 import JobTracker from './components/JobTracker'
 import Chat from './components/Chat'
+import Metrics from './components/Metrics'
+import KnowledgeItems from './components/KnowledgeItems'
 
-const TABS = ['Transformations', 'Execute', 'Create Custom', 'CSV Batch', 'Jobs', 'Chat']
+const TABS = ['Transformations', 'Execute', 'Create Custom', 'CSV Batch', 'Jobs', 'Metrics', 'Knowledge', 'Chat']
 const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 
 // Async orchestrator for AI operations
@@ -133,6 +135,8 @@ export default function App() {
         {tab === 'Create Custom' && <CreateCustom submitAsync={submitAsync} onJobCreated={addJob} orchestrate={orchestrate} />}
         {tab === 'CSV Batch' && <CsvUpload orchestrate={orchestrate} onJobsCreated={addJobs} />}
         {tab === 'Jobs' && <JobTracker orchestrate={orchestrate} directCall={directCall} jobs={jobs} setJobs={updateJobs} />}
+        {tab === 'Metrics' && <Metrics />}
+        {tab === 'Knowledge' && <KnowledgeItems />}
         {tab === 'Chat' && <Chat orchestrate={orchestrate} jobs={jobs} />}
       </main>
     </div>

--- a/agentic-atx-platform/ui/src/components/CreateCustom.jsx
+++ b/agentic-atx-platform/ui/src/components/CreateCustom.jsx
@@ -200,7 +200,7 @@ export default function CreateCustom({ submitAsync, onJobCreated, orchestrate })
         <div className="card">
           <div className="flex-between" style={{ marginBottom: 12 }}>
             <span style={{ color: '#c9d1d9', fontSize: 14, fontWeight: 500 }}>
-              Review: {name} — transformation_definition.md
+              Review: {name} — SKILL.md
             </span>
             <button className="btn btn-secondary btn-sm" onClick={() => setReviewMode(false)}>← Back</button>
           </div>
@@ -227,7 +227,7 @@ export default function CreateCustom({ submitAsync, onJobCreated, orchestrate })
         <h3 style={{ fontSize: 14, marginBottom: 8 }}>How it works</h3>
         <ol style={{ color: '#8b949e', fontSize: 12, lineHeight: 1.8, paddingLeft: 20 }}>
           <li>If a source repo is provided, a Batch job clones and analyzes the code</li>
-          <li>AI generates a <code>transformation_definition.md</code> based on your requirements and the code analysis</li>
+          <li>AI generates a <code>SKILL.md</code> (ATX skill format) based on your requirements and the code analysis</li>
           <li><strong>Create & Publish</strong>: auto-publishes immediately | <strong>Generate & Review</strong>: lets you edit before publishing</li>
           <li>A Batch job runs <code>atx custom def publish</code> to register it</li>
           <li>Once published, use it like any other transformation</li>

--- a/agentic-atx-platform/ui/src/components/JobTracker.jsx
+++ b/agentic-atx-platform/ui/src/components/JobTracker.jsx
@@ -396,13 +396,14 @@ function ViewDefinitionButton({ name }) {
         body: JSON.stringify({ action: 'direct', op: 'get_file', definition_name: name })
       })
       const result = await res.json()
+      const label = result.key ? result.key.replace('custom-definitions/', '') : `${name}/SKILL.md`
       if (result.content) {
-        setPreview({ name: `${name}/transformation_definition.md`, content: result.content })
+        setPreview({ name: label, content: result.content })
       } else {
-        setPreview({ name: `${name}/transformation_definition.md`, content: `Could not load: ${result.error || 'Unknown error'}` })
+        setPreview({ name: label, content: `Could not load: ${result.error || 'Unknown error'}` })
       }
     } catch (e) {
-      setPreview({ name: `${name}/transformation_definition.md`, content: `Error: ${e.message}` })
+      setPreview({ name: `${name}/SKILL.md`, content: `Error: ${e.message}` })
     }
     setLoading(false)
   }

--- a/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
+++ b/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
@@ -1,0 +1,325 @@
+import { useState, useEffect } from 'react'
+import {
+  readCachedKnowledgeItems, refreshKnowledgeItems,
+  setKnowledgeItemStatus, deleteKnowledgeItem, exportKnowledgeItems,
+} from '../knowledgeApi'
+
+// Transformations that can have knowledge items (managed catalog + custom go here).
+const TRANSFORMATIONS = [
+  'AWS/java-version-upgrade',
+  'AWS/python-version-upgrade',
+  'AWS/nodejs-version-upgrade',
+  'AWS/python-boto2-to-boto3',
+  'AWS/java-aws-sdk-v1-to-v2',
+  'AWS/nodejs-aws-sdk-v2-to-v3',
+  'AWS/comprehensive-codebase-analysis',
+]
+
+const preStyle = {
+  background: '#0d1117', border: '1px solid #30363d', borderRadius: 6,
+  padding: 12, fontSize: 12, lineHeight: 1.5, color: '#c9d1d9',
+  overflowX: 'auto', whiteSpace: 'pre-wrap',
+}
+
+function StatusBadge({ status }) {
+  const enabled = status === 'ENABLED'
+  return (
+    <span className="status" style={{
+      background: enabled ? '#0c2d1a' : '#1f2937',
+      color: enabled ? '#3fb950' : '#8b949e',
+    }}>
+      {status}
+    </span>
+  )
+}
+
+// The ATX `list-ki --json` output carries fix data in a `changes` field that is a
+// (double-escaped) JSON string of { file_changes, code_samples: { before, after } }.
+// Older/blog-style items may instead carry a plain `fix` string. Normalize both.
+function parseChanges(item) {
+  if (item.fix && typeof item.fix === 'string') {
+    return { rawFix: item.fix }
+  }
+  if (!item.changes) return null
+  try {
+    let parsed = item.changes
+    // `changes` is often a JSON string; may be wrapped/escaped more than once.
+    for (let i = 0; i < 3 && typeof parsed === 'string'; i++) {
+      parsed = JSON.parse(parsed)
+    }
+    if (parsed && typeof parsed === 'object') {
+      const files = parsed.file_changes?.modified || parsed.file_changes?.added || []
+      const before = parsed.code_samples?.before
+      const after = parsed.code_samples?.after
+      return {
+        files: Array.isArray(files) ? files : [],
+        before, after,
+      }
+    }
+  } catch {
+    // Fall back to showing the raw string if it won't parse.
+    return { rawFix: typeof item.changes === 'string' ? item.changes : JSON.stringify(item.changes) }
+  }
+  return null
+}
+
+function KnowledgeItemCard({ item, transformationName, onChanged }) {
+  const [expanded, setExpanded] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [localStatus, setLocalStatus] = useState(item.status)
+
+  async function toggle() {
+    const next = localStatus === 'ENABLED' ? 'DISABLED' : 'ENABLED'
+    setBusy(true)
+    try {
+      await setKnowledgeItemStatus(transformationName, item.id, next)
+      setLocalStatus(next)
+      onChanged?.()
+    } catch (e) {
+      alert(`Failed to update: ${e.message}`)
+    }
+    setBusy(false)
+  }
+
+  async function remove() {
+    if (!confirm(`Delete knowledge item "${item.title}"? This cannot be undone.`)) return
+    setBusy(true)
+    try {
+      await deleteKnowledgeItem(transformationName, item.id)
+      onChanged?.(item.id)
+    } catch (e) {
+      alert(`Failed to delete: ${e.message}`)
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="card">
+      <div className="flex-between" style={{ alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="flex gap-8" style={{ alignItems: 'center', marginBottom: 4 }}>
+            <StatusBadge status={localStatus} />
+            <span style={{ color: '#c9d1d9', fontSize: 14, fontWeight: 500 }}>{item.title}</span>
+          </div>
+          <p style={{ fontSize: 11, color: '#484f58', fontFamily: 'monospace' }}>{item.id}</p>
+        </div>
+        <div className="flex gap-8">
+          <button className="btn btn-sm btn-secondary" onClick={() => setExpanded(e => !e)}>
+            {expanded ? 'Hide' : 'Details'}
+          </button>
+          <button
+            className={`btn btn-sm ${localStatus === 'ENABLED' ? 'btn-secondary' : 'btn-primary'}`}
+            onClick={toggle} disabled={busy}>
+            {busy ? <span className="spinner" /> : localStatus === 'ENABLED' ? 'Disable' : 'Enable'}
+          </button>
+          <button className="btn btn-sm btn-danger" onClick={remove} disabled={busy}>Delete</button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div style={{ marginTop: 12 }}>
+          <p style={{ color: '#8b949e', fontSize: 13, lineHeight: 1.6, marginBottom: 12 }}>
+            {item.description}
+          </p>
+
+          {item.rationale && (
+            <div style={{ marginBottom: 12 }}>
+              <p style={{ color: '#c9d1d9', fontSize: 12, fontWeight: 500, marginBottom: 4 }}>Rationale</p>
+              <p style={{ color: '#8b949e', fontSize: 13, lineHeight: 1.6 }}>{item.rationale}</p>
+            </div>
+          )}
+
+          {(() => {
+            const c = parseChanges(item)
+            if (!c) return null
+
+            if (c.rawFix) {
+              return (
+                <>
+                  <p style={{ color: '#c9d1d9', fontSize: 12, fontWeight: 500, marginBottom: 6 }}>Fix</p>
+                  <pre style={preStyle}>{c.rawFix}</pre>
+                </>
+              )
+            }
+
+            return (
+              <>
+                {c.files.length > 0 && (
+                  <div style={{ marginBottom: 12 }}>
+                    <p style={{ color: '#c9d1d9', fontSize: 12, fontWeight: 500, marginBottom: 6 }}>
+                      Files changed
+                    </p>
+                    {c.files.map((f, i) => (
+                      <div key={i} style={{ fontSize: 12, fontFamily: 'monospace', color: '#8b949e', marginBottom: 2 }}>
+                        <span className="tag" style={{ marginRight: 6 }}>{f.type || 'MODIFY'}</span>
+                        {f.file}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {c.before?.code && (
+                  <div style={{ marginBottom: 8 }}>
+                    <p style={{ color: '#f85149', fontSize: 12, fontWeight: 500, marginBottom: 6 }}>
+                      Before {c.before.file ? `— ${c.before.file}` : ''}
+                    </p>
+                    <pre style={preStyle}>{c.before.code}</pre>
+                  </div>
+                )}
+                {c.after?.code && (
+                  <div>
+                    <p style={{ color: '#3fb950', fontSize: 12, fontWeight: 500, marginBottom: 6 }}>
+                      After {c.after.file ? `— ${c.after.file}` : ''}
+                    </p>
+                    <pre style={preStyle}>{c.after.code}</pre>
+                  </div>
+                )}
+              </>
+            )
+          })()}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function KnowledgeItems() {
+  const [transformation, setTransformation] = useState(TRANSFORMATIONS[0])
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [refreshing, setRefreshing] = useState(false)
+  const [statusText, setStatusText] = useState('')
+  const [error, setError] = useState(null)
+  const [source, setSource] = useState(null)
+  const [exporting, setExporting] = useState(false)
+  const [banner, setBanner] = useState(null)
+
+  // On load / transformation change: read the S3 cache only (instant, no Batch job).
+  async function loadCache() {
+    setLoading(true)
+    setError(null)
+    try {
+      const { knowledgeItems, source } = await readCachedKnowledgeItems(transformation)
+      setItems(knowledgeItems)
+      setSource(source)
+    } catch (e) {
+      setError(e.message)
+    }
+    setLoading(false)
+  }
+
+  // Explicit user action: run a list-ki Batch job and poll (can take minutes).
+  async function refresh() {
+    setRefreshing(true)
+    setError(null)
+    setStatusText('Submitting refresh job...')
+    try {
+      const { knowledgeItems, source } = await refreshKnowledgeItems(transformation, {
+        onStatus: setStatusText,
+      })
+      setItems(knowledgeItems)
+      setSource(source)
+    } catch (e) {
+      setError(e.message)
+    }
+    setRefreshing(false)
+    setStatusText('')
+  }
+
+  useEffect(() => { loadCache() }, [transformation])
+
+  async function handleExport() {
+    setExporting(true)
+    setBanner(null)
+    try {
+      await exportKnowledgeItems(transformation)
+      setBanner('Export job submitted. Markdown will be written to the output bucket.')
+    } catch (e) {
+      setBanner(`Export failed: ${e.message}`)
+    }
+    setExporting(false)
+  }
+
+  function handleItemChanged(deletedId) {
+    if (deletedId) setItems(prev => prev.filter(i => i.id !== deletedId))
+  }
+
+  const enabledCount = items.filter(i => i.status === 'ENABLED').length
+
+  return (
+    <div>
+      <div className="flex-between" style={{ marginBottom: 16 }}>
+        <div>
+          <h2 style={{ fontSize: 18 }}>Knowledge Items</h2>
+          <p style={{ color: '#8b949e', fontSize: 13, marginTop: 2 }}>
+            Patterns and fixes ATX learned during runs. New items start <strong>disabled</strong> — review and enable to apply them on future runs.
+          </p>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="flex gap-8" style={{ alignItems: 'flex-end', flexWrap: 'wrap' }}>
+          <div className="form-group" style={{ marginBottom: 0, flex: 1, minWidth: 240 }}>
+            <label htmlFor="ki-transform">Transformation</label>
+            <select id="ki-transform" value={transformation} onChange={e => setTransformation(e.target.value)}>
+              {TRANSFORMATIONS.map(t => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          <button className="btn btn-secondary" onClick={refresh} disabled={loading || refreshing}>
+            {refreshing ? <><span className="spinner" /> Refreshing...</> : '↻ Pull from registry'}
+          </button>
+          <button className="btn btn-secondary" onClick={handleExport} disabled={exporting || items.length === 0}>
+            {exporting ? <><span className="spinner" /> Exporting...</> : 'Export Markdown'}
+          </button>
+        </div>
+      </div>
+
+      {banner && (
+        <div className="card" style={{ borderColor: '#1f6feb', background: '#0d1f3c' }}>
+          <p style={{ color: '#79c0ff', fontSize: 13 }}>{banner}</p>
+        </div>
+      )}
+
+      {!loading && !refreshing && !error && items.length > 0 && (
+        <p style={{ color: '#8b949e', fontSize: 12, margin: '4px 4px 12px' }}>
+          {items.length} item{items.length !== 1 ? 's' : ''} · {enabledCount} enabled
+          {source === 'cache' && ' · cached'}
+        </p>
+      )}
+
+      {(loading || refreshing) && (
+        <div className="card">
+          <span className="spinner" />
+          <span className="loading-text">
+            {refreshing ? (statusText || 'Refreshing...') : 'Loading cached knowledge items...'}
+          </span>
+        </div>
+      )}
+
+      {error && (
+        <div className="card" style={{ borderColor: '#da3633', background: '#3d1114' }}>
+          <p style={{ color: '#f85149', fontSize: 14 }}>❌ {error}</p>
+        </div>
+      )}
+
+      {!loading && !refreshing && !error && items.length === 0 && (
+        <div className="empty-state">
+          <div className="icon">🧠</div>
+          <p>No knowledge items cached for this transformation.</p>
+          <p style={{ fontSize: 12, marginTop: 6 }}>
+            They're generated automatically after runs. Click <strong>Pull from registry</strong> to fetch the latest —
+            this runs a background job and can take a few minutes.
+          </p>
+        </div>
+      )}
+
+      {!loading && !refreshing && !error && items.map(item => (
+        <KnowledgeItemCard
+          key={item.id}
+          item={item}
+          transformationName={transformation}
+          onChanged={handleItemChanged}
+        />
+      ))}
+    </div>
+  )
+}

--- a/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
+++ b/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
@@ -3,17 +3,12 @@ import {
   readCachedKnowledgeItems, refreshKnowledgeItems,
   setKnowledgeItemStatus, deleteKnowledgeItem, exportKnowledgeItems,
 } from '../knowledgeApi'
+import { MANAGED_TRANSFORMATION_NAMES } from '../transformations'
 
-// Transformations that can have knowledge items (managed catalog + custom go here).
-const TRANSFORMATIONS = [
-  'AWS/java-version-upgrade',
-  'AWS/python-version-upgrade',
-  'AWS/nodejs-version-upgrade',
-  'AWS/python-boto2-to-boto3',
-  'AWS/java-aws-sdk-v1-to-v2',
-  'AWS/nodejs-aws-sdk-v2-to-v3',
-  'AWS/comprehensive-codebase-analysis',
-]
+const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
+
+// Knowledge items can exist for any AWS-managed transformation (shared catalog)
+// plus any published custom transformations (fetched via the list_custom op).
 
 const preStyle = {
   background: '#0d1117', border: '1px solid #30363d', borderRadius: 6,
@@ -183,7 +178,8 @@ function KnowledgeItemCard({ item, transformationName, onChanged }) {
 }
 
 export default function KnowledgeItems() {
-  const [transformation, setTransformation] = useState(TRANSFORMATIONS[0])
+  const [transformations, setTransformations] = useState(MANAGED_TRANSFORMATION_NAMES)
+  const [transformation, setTransformation] = useState(MANAGED_TRANSFORMATION_NAMES[0])
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
@@ -227,6 +223,35 @@ export default function KnowledgeItems() {
 
   useEffect(() => { loadCache() }, [transformation])
 
+  // Fetch published custom transformations once and append them to the dropdown.
+  useEffect(() => {
+    let cancelled = false
+    async function loadCustoms() {
+      try {
+        const res = await fetch(`${API_BASE}/orchestrate`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'direct', op: 'list_custom' }),
+        })
+        const data = await res.json()
+        const customNames = (data.customs || [])
+          .filter(c => c.status === 'published' && c.name)
+          .map(c => c.name)
+        if (!cancelled && customNames.length > 0) {
+          setTransformations(prev => {
+            const merged = [...prev]
+            for (const n of customNames) if (!merged.includes(n)) merged.push(n)
+            return merged
+          })
+        }
+      } catch (e) {
+        console.error('Failed to load custom transformations:', e)
+      }
+    }
+    loadCustoms()
+    return () => { cancelled = true }
+  }, [])
+
   async function handleExport() {
     setExporting(true)
     setBanner(null)
@@ -261,7 +286,7 @@ export default function KnowledgeItems() {
           <div className="form-group" style={{ marginBottom: 0, flex: 1, minWidth: 240 }}>
             <label htmlFor="ki-transform">Transformation</label>
             <select id="ki-transform" value={transformation} onChange={e => setTransformation(e.target.value)}>
-              {TRANSFORMATIONS.map(t => <option key={t} value={t}>{t}</option>)}
+              {transformations.map(t => <option key={t} value={t}>{t}</option>)}
             </select>
           </div>
           <button className="btn btn-secondary" onClick={refresh} disabled={loading || refreshing}>

--- a/agentic-atx-platform/ui/src/components/Metrics.jsx
+++ b/agentic-atx-platform/ui/src/components/Metrics.jsx
@@ -119,7 +119,7 @@ export default function Metrics() {
 
   // Execution status / type doughnuts (from per-execution detail)
   const statusData = statusSplit(executions)
-  const statusColorMap = { Success: COLORS.green, Failure: COLORS.red, InProgress: COLORS.blue }
+  const statusColorMap = { Success: COLORS.green, Failed: COLORS.red, Failure: COLORS.red, InProgress: COLORS.blue }
   const statusChart = {
     labels: statusData.map(d => d.key),
     datasets: [{

--- a/agentic-atx-platform/ui/src/components/Metrics.jsx
+++ b/agentic-atx-platform/ui/src/components/Metrics.jsx
@@ -45,6 +45,28 @@ export default function Metrics() {
   const [detail, setDetail] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [lastUpdated, setLastUpdated] = useState(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  // Load metrics for the current range. `isManual` distinguishes a user-triggered
+  // refresh (keeps existing charts visible, shows a small spinner) from the initial
+  // load (full-screen loading state).
+  async function load({ isManual = false } = {}) {
+    if (isManual) setRefreshing(true)
+    else setLoading(true)
+    setError(null)
+    try {
+      const [agg, det] = await Promise.all([fetchMetrics({ range }), fetchExecutions({ range })])
+      setData(agg)
+      setDetail(det)
+      setLastUpdated(new Date())
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -52,7 +74,7 @@ export default function Metrics() {
     setError(null)
     Promise.all([fetchMetrics({ range }), fetchExecutions({ range })])
       .then(([agg, det]) => {
-        if (!cancelled) { setData(agg); setDetail(det) }
+        if (!cancelled) { setData(agg); setDetail(det); setLastUpdated(new Date()) }
       })
       .catch(e => { if (!cancelled) setError(e.message) })
       .finally(() => { if (!cancelled) setLoading(false) })
@@ -127,7 +149,15 @@ export default function Metrics() {
             From the <code>AWS/TransformCustom</code> CloudWatch namespace.
           </p>
         </div>
-        <div className="filter-bar" style={{ margin: 0 }}>
+        <div className="filter-bar" style={{ margin: 0, alignItems: 'center', gap: 12 }}>
+          {lastUpdated && (
+            <span style={{ color: '#8b949e', fontSize: 12 }}>
+              Updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+          <button className="btn btn-secondary btn-sm" onClick={() => load({ isManual: true })} disabled={loading || refreshing} title="Refresh metrics">
+            {refreshing ? <><span className="spinner" /> Refreshing...</> : '↻ Refresh'}
+          </button>
           <select value={range} onChange={e => setRange(e.target.value)}>
             {RANGES.map(r => <option key={r.id} value={r.id}>{r.label}</option>)}
           </select>

--- a/agentic-atx-platform/ui/src/components/Metrics.jsx
+++ b/agentic-atx-platform/ui/src/components/Metrics.jsx
@@ -1,0 +1,246 @@
+import { useState, useEffect } from 'react'
+import {
+  Chart as ChartJS,
+  CategoryScale, LinearScale, BarElement, ArcElement,
+  Title, Tooltip, Legend,
+} from 'chart.js'
+import { Bar, Doughnut } from 'react-chartjs-2'
+import { fetchMetrics, fetchExecutions, rankBy, statusSplit, typeSplit } from '../metricsApi'
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend)
+
+const RANGES = [
+  { id: '24h', label: 'Last 24h' },
+  { id: '7d', label: 'Last 7 days' },
+  { id: '30d', label: 'Last 30 days' },
+]
+
+const COLORS = {
+  blue: '#58a6ff', green: '#3fb950', red: '#f85149',
+  purple: '#d2a8ff', orange: '#f0883e', teal: '#39c5cf', gray: '#8b949e', yellow: '#d29922',
+}
+
+const gridColor = '#21262d'
+const tickColor = '#8b949e'
+const baseScales = {
+  x: { grid: { color: gridColor }, ticks: { color: tickColor, autoSkip: true } },
+  y: { grid: { color: gridColor }, ticks: { color: tickColor }, beginAtZero: true },
+}
+const legendOpts = { labels: { color: '#c9d1d9', boxWidth: 12, font: { size: 11 } } }
+
+function StatCard({ label, value, accent }) {
+  return (
+    <div className="card" style={{ margin: 0, padding: 16 }}>
+      <p style={{ color: '#8b949e', fontSize: 12, marginBottom: 6 }}>{label}</p>
+      <div style={{ fontSize: 26, fontWeight: 600, color: accent || '#e1e4e8' }}>
+        {(value ?? 0).toLocaleString()}
+      </div>
+    </div>
+  )
+}
+
+export default function Metrics() {
+  const [range, setRange] = useState('7d')
+  const [data, setData] = useState(null)
+  const [detail, setDetail] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    Promise.all([fetchMetrics({ range }), fetchExecutions({ range })])
+      .then(([agg, det]) => {
+        if (!cancelled) { setData(agg); setDetail(det) }
+      })
+      .catch(e => { if (!cancelled) setError(e.message) })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [range])
+
+  const tc = data?.transformCustom
+  const totals = tc?.totals || {}
+  const jobs = data?.jobs || {}
+  const executions = detail?.executions?.filter(e => e.executionId) || []
+
+  // Job status counts → bar
+  const jobStatusChart = {
+    labels: ['Succeeded', 'Failed', 'Running', 'Starting', 'Runnable', 'Pending', 'Submitted'],
+    datasets: [{
+      label: 'Jobs',
+      data: [jobs.SUCCEEDED, jobs.FAILED, jobs.RUNNING, jobs.STARTING, jobs.RUNNABLE, jobs.PENDING, jobs.SUBMITTED].map(v => v || 0),
+      backgroundColor: [COLORS.green, COLORS.red, COLORS.blue, COLORS.purple, COLORS.teal, COLORS.yellow, COLORS.gray],
+    }],
+  }
+
+  // Top transformations by completed executions
+  const topTransforms = rankBy(tc?.byTransformation, 'TransformationExecutionCompleted')
+  const topTransformsChart = {
+    labels: topTransforms.map(d => d.key.replace(/^AWS\//, '')),
+    datasets: [{ label: 'Completed', data: topTransforms.map(d => d.value), backgroundColor: COLORS.blue }],
+  }
+
+  // Agent minutes by transformation
+  const minutesByTransform = rankBy(tc?.byTransformation, 'AgentExecutionMinutes')
+  const minutesChart = {
+    labels: minutesByTransform.map(d => d.key.replace(/^AWS\//, '')),
+    datasets: [{ label: 'Agent Minutes', data: minutesByTransform.map(d => d.value), backgroundColor: COLORS.teal }],
+  }
+
+  // Top repositories by agent minutes
+  const topRepos = rankBy(tc?.byRepository, 'AgentExecutionMinutes')
+  const topReposChart = {
+    labels: topRepos.map(d => d.key),
+    datasets: [{ label: 'Agent Minutes', data: topRepos.map(d => d.value), backgroundColor: COLORS.purple }],
+  }
+
+  // Execution status / type doughnuts (from per-execution detail)
+  const statusData = statusSplit(executions)
+  const statusColorMap = { Success: COLORS.green, Failure: COLORS.red, InProgress: COLORS.blue }
+  const statusChart = {
+    labels: statusData.map(d => d.key),
+    datasets: [{
+      data: statusData.map(d => d.value),
+      backgroundColor: statusData.map(d => statusColorMap[d.key] || COLORS.gray),
+      borderColor: '#161b22', borderWidth: 2,
+    }],
+  }
+  const typeData = typeSplit(executions)
+  const typeChart = {
+    labels: typeData.map(d => d.key),
+    datasets: [{
+      data: typeData.map(d => d.value),
+      backgroundColor: [COLORS.blue, COLORS.orange, COLORS.gray],
+      borderColor: '#161b22', borderWidth: 2,
+    }],
+  }
+
+  const hasTransformData = topTransforms.length > 0 || minutesByTransform.length > 0
+
+  return (
+    <div>
+      <div className="flex-between" style={{ marginBottom: 16 }}>
+        <div>
+          <h2 style={{ fontSize: 18 }}>Metrics</h2>
+          <p style={{ color: '#8b949e', fontSize: 13, marginTop: 2 }}>
+            From the <code>AWS/TransformCustom</code> CloudWatch namespace.
+          </p>
+        </div>
+        <div className="filter-bar" style={{ margin: 0 }}>
+          <select value={range} onChange={e => setRange(e.target.value)}>
+            {RANGES.map(r => <option key={r.id} value={r.id}>{r.label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="card"><span className="spinner" /><span className="loading-text">Loading metrics...</span></div>
+      )}
+
+      {error && (
+        <div className="card" style={{ borderColor: '#da3633', background: '#3d1114' }}>
+          <p style={{ color: '#f85149', fontSize: 14 }}>❌ Failed to load metrics: {error}</p>
+        </div>
+      )}
+
+      {!loading && !error && data && (
+        <>
+          {/* Summary stat cards */}
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: 12, marginBottom: 16 }}>
+            <StatCard label="Conversations Started" value={totals.ConversationStarted} accent={COLORS.purple} />
+            <StatCard label="Executions Started" value={totals.TransformationExecutionStarted} accent={COLORS.blue} />
+            <StatCard label="Executions Completed" value={totals.TransformationExecutionCompleted} accent={COLORS.green} />
+            <StatCard label="Agent Exec Minutes" value={Math.round(totals.AgentExecutionMinutes || 0)} accent={COLORS.teal} />
+            <StatCard label="Unique Conversations" value={tc?.uniqueConversations} />
+            <StatCard label="Unique Executions" value={tc?.uniqueExecutions} />
+          </div>
+
+          {/* Job status overview */}
+          <div className="card">
+            <h3 style={{ fontSize: 14, marginBottom: 12 }}>Batch Job Status</h3>
+            <div style={{ height: 240 }}>
+              <Bar data={jobStatusChart} options={{
+                responsive: true, maintainAspectRatio: false,
+                plugins: { legend: { display: false } }, scales: baseScales,
+              }} />
+            </div>
+          </div>
+
+          {/* Execution status + type doughnuts */}
+          {executions.length > 0 && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+              <div className="card">
+                <h3 style={{ fontSize: 14, marginBottom: 12 }}>Execution Status</h3>
+                <div style={{ height: 240 }}>
+                  <Doughnut data={statusChart} options={{
+                    responsive: true, maintainAspectRatio: false,
+                    plugins: { legend: { ...legendOpts, position: 'bottom' } },
+                  }} />
+                </div>
+              </div>
+              <div className="card">
+                <h3 style={{ fontSize: 14, marginBottom: 12 }}>Execution Type</h3>
+                <div style={{ height: 240 }}>
+                  <Doughnut data={typeChart} options={{
+                    responsive: true, maintainAspectRatio: false,
+                    plugins: { legend: { ...legendOpts, position: 'bottom' } },
+                  }} />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Top transformations + agent minutes */}
+          {hasTransformData && (
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16 }}>
+              <div className="card">
+                <h3 style={{ fontSize: 14, marginBottom: 12 }}>Top Transformations (completed)</h3>
+                <div style={{ height: 260 }}>
+                  <Bar data={topTransformsChart} options={{
+                    indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+                    plugins: { legend: { display: false } }, scales: baseScales,
+                  }} />
+                </div>
+              </div>
+              <div className="card">
+                <h3 style={{ fontSize: 14, marginBottom: 12 }}>Agent Minutes by Transformation</h3>
+                <div style={{ height: 260 }}>
+                  <Bar data={minutesChart} options={{
+                    indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+                    plugins: { legend: { display: false } }, scales: baseScales,
+                  }} />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Top repositories */}
+          {topRepos.length > 0 && (
+            <div className="card">
+              <h3 style={{ fontSize: 14, marginBottom: 12 }}>Top Repositories (agent minutes)</h3>
+              <div style={{ height: 240 }}>
+                <Bar data={topReposChart} options={{
+                  indexAxis: 'y', responsive: true, maintainAspectRatio: false,
+                  plugins: { legend: { display: false } }, scales: baseScales,
+                }} />
+              </div>
+            </div>
+          )}
+
+          {/* Code impact (companions of TransformationExecutionCompleted) */}
+          <div className="card">
+            <h3 style={{ fontSize: 14, marginBottom: 12 }}>Code Impact</h3>
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))', gap: 12 }}>
+              <StatCard label="Lines Added" value={totals.LinesAdded} accent={COLORS.green} />
+              <StatCard label="Lines Deleted" value={totals.LinesDeleted} accent={COLORS.red} />
+              <StatCard label="Lines Modified" value={totals.LinesModified} accent={COLORS.orange} />
+              <StatCard label="Files Read" value={totals.FilesRead} accent={COLORS.blue} />
+              <StatCard label="Files Modified" value={totals.FilesModified} accent={COLORS.purple} />
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/agentic-atx-platform/ui/src/components/TransformationList.jsx
+++ b/agentic-atx-platform/ui/src/components/TransformationList.jsx
@@ -31,6 +31,7 @@ async function directCall(op, extra = {}) {
 
 function CustomTransformCard({ name, description }) {
   const [preview, setPreview] = useState(null)
+  const [previewKey, setPreviewKey] = useState('')
   const [loading, setLoading] = useState(false)
 
   async function viewDefinition() {
@@ -43,6 +44,7 @@ function CustomTransformCard({ name, description }) {
         body: JSON.stringify({ action: 'direct', op: 'get_file', definition_name: normalized })
       })
       const data = await res.json()
+      setPreviewKey(data.key ? data.key.replace('custom-definitions/', '') : `${normalized}/SKILL.md`)
       if (data.content) setPreview(data.content)
       else setPreview(`Could not load: ${data.error || 'Unknown error'}`)
     } catch (e) { setPreview(`Error: ${e.message}`) }
@@ -67,7 +69,7 @@ function CustomTransformCard({ name, description }) {
           <div style={{ background: '#161b22', border: '1px solid #30363d', borderRadius: 8, width: '80%', maxWidth: 900, maxHeight: '80vh', display: 'flex', flexDirection: 'column' }}
             onClick={e => e.stopPropagation()}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '12px 16px', borderBottom: '1px solid #21262d' }}>
-              <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#c9d1d9' }}>{name}/transformation_definition.md</span>
+              <span style={{ fontFamily: 'monospace', fontSize: 13, color: '#c9d1d9' }}>{previewKey || `${name}/SKILL.md`}</span>
               <button className="btn btn-secondary btn-sm" onClick={() => setPreview(null)}>✕ Close</button>
             </div>
             <pre style={{ padding: 16, margin: 0, overflow: 'auto', flex: 1, fontSize: 12, lineHeight: 1.5, color: '#c9d1d9', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>

--- a/agentic-atx-platform/ui/src/components/TransformationList.jsx
+++ b/agentic-atx-platform/ui/src/components/TransformationList.jsx
@@ -1,24 +1,9 @@
 import React, { useState, useEffect } from 'react'
+import { MANAGED_TRANSFORMATIONS } from '../transformations'
 
 const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 
 const GITHUB_BASE = 'https://github.com/aws-samples/aws-transform-custom-samples/tree/main/aws-managed-definitions'
-
-const MANAGED_TRANSFORMATIONS = [
-  { name: 'AWS/python-version-upgrade', language: 'python', description: 'Upgrade Python applications from 3.8/3.9 to 3.11/3.12/3.13', managed: true },
-  { name: 'AWS/java-version-upgrade', language: 'java', description: 'Upgrade Java applications from any source JDK to any target JDK with dependency modernization', managed: true },
-  { name: 'AWS/nodejs-version-upgrade', language: 'nodejs', description: 'Upgrade Node.js applications from any source to any target version', managed: true },
-  { name: 'AWS/python-boto2-to-boto3', language: 'python', description: 'Migrate Python applications from boto2 to boto3', managed: true },
-  { name: 'AWS/java-aws-sdk-v1-to-v2', language: 'java', description: 'Upgrade AWS SDK from v1 to v2 for Java (Maven or Gradle)', managed: true },
-  { name: 'AWS/nodejs-aws-sdk-v2-to-v3', language: 'nodejs', description: 'Upgrade Node.js from AWS SDK v2 to v3 modular architecture', managed: true },
-  { name: 'AWS/comprehensive-codebase-analysis', language: 'all', description: 'Deep static analysis with technical debt, security, and modernization insights', managed: true },
-  { name: 'AWS/java-performance-optimization', language: 'java', description: 'Optimize Java performance by analyzing JFR profiling data to detect CPU/memory hotspots and apply targeted fixes', managed: true },
-  { name: 'AWS/early-access-java-x86-to-graviton', language: 'java', description: '[Early Access] Validate and migrate Java applications to ARM64 for AWS Graviton', managed: true },
-  { name: 'AWS/early-access-angular-to-react-migration', language: 'nodejs', description: '[Early Access] Transform Angular applications to React', managed: true },
-  { name: 'AWS/vue.js-version-upgrade', language: 'nodejs', description: '[Early Access] Upgrade Vue.js 2 applications to Vue.js 3', managed: true },
-  { name: 'AWS/angular-version-upgrade', language: 'nodejs', description: '[Early Access] Upgrade older Angular applications to a target Angular version', managed: true },
-  { name: 'AWS/early-access-log4j-to-slf4j-migration', language: 'java', description: '[Early Access] Migrate Java applications from Log4j (1.x/2.x) to SLF4J with Logback backend', managed: true },
-]
 
 async function directCall(op, extra = {}) {
   const res = await fetch(`${API_BASE}/orchestrate`, {

--- a/agentic-atx-platform/ui/src/knowledgeApi.js
+++ b/agentic-atx-platform/ui/src/knowledgeApi.js
@@ -1,0 +1,150 @@
+// Knowledge Items API client.
+//
+// Backend: get_knowledge_items.py logic ported into the agentic platform's
+// async_invoke_agent Lambda, exposed via `/orchestrate` as `op: "knowledge_items"`
+// with a `kiAction` selector. Reads are two-tier: an instant S3 cache (kiAction:"get"),
+// falling back to a Batch job (kiAction:"submit") that you poll (kiAction:"poll").
+// Writes (enable/disable/delete/export) are fire-and-forget Batch jobs.
+//
+// A knowledge item: { id, status: 'ENABLED'|'DISABLED', title, description, fix }
+//
+// SWAP POINT: set VITE_KI_MOCK=false once the Lambda op is deployed.
+
+const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
+const USE_MOCK = (import.meta.env.VITE_KI_MOCK ?? 'true') !== 'false'
+
+async function ki(payload) {
+  const res = await fetch(`${API_BASE}/orchestrate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'direct', op: 'knowledge_items', ...payload }),
+  })
+  if (!res.ok) throw new Error(`Knowledge Items API returned ${res.status}`)
+  const data = await res.json()
+  if (data.error) throw new Error(data.error)
+  return data
+}
+
+/**
+ * Read cached knowledge items for a transformation (instant, no Batch job).
+ * @param {string} transformationName
+ * @returns {Promise<{ knowledgeItems: object[], source: string }>}
+ */
+export async function readCachedKnowledgeItems(transformationName) {
+  if (USE_MOCK) {
+    await new Promise(r => setTimeout(r, 300))
+    return { source: 'cache', knowledgeItems: mockItems(transformationName) }
+  }
+  const cached = await ki({ kiAction: 'get', transformationName })
+  return { source: 'cache', knowledgeItems: cached.knowledgeItems || [] }
+}
+
+/**
+ * Refresh knowledge items by running a list-ki Batch job and polling for the result.
+ * This is the expensive path (Fargate cold start) — call it explicitly, not on load.
+ * @param {string} transformationName
+ * @param {object} opts - { onStatus, pollIntervalMs, maxPollMs }
+ * @returns {Promise<{ knowledgeItems: object[], source: string }>}
+ */
+export async function refreshKnowledgeItems(transformationName, opts = {}) {
+  const { onStatus, pollIntervalMs = 4000, maxPollMs = 180000 } = opts
+
+  if (USE_MOCK) {
+    await new Promise(r => setTimeout(r, 800))
+    return { source: 'refresh', knowledgeItems: mockItems(transformationName) }
+  }
+
+  onStatus?.('Submitting refresh job...')
+  const submit = await ki({ kiAction: 'submit', cliAction: 'list-ki', transformationName })
+  const requestId = submit.request_id
+  if (!requestId) throw new Error('No request_id returned from submit')
+
+  const deadline = Date.now() + maxPollMs
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, pollIntervalMs))
+    const polled = await ki({ kiAction: 'poll', request_id: requestId })
+    if (polled.status === 'COMPLETED') {
+      return { source: 'refresh', knowledgeItems: polled.knowledgeItems || [] }
+    }
+    if (polled.status === 'FAILED') throw new Error(polled.error || 'Refresh failed')
+    onStatus?.('Running list-ki job (this can take a few minutes)...')
+  }
+  throw new Error('Timed out refreshing knowledge items')
+}
+
+/** Enable or disable a knowledge item. status: 'ENABLED' | 'DISABLED' */
+export async function setKnowledgeItemStatus(transformationName, id, status) {
+  if (USE_MOCK) { await new Promise(r => setTimeout(r, 300)); return { status: 'SUBMITTED' } }
+  return ki({ kiAction: 'update-ki-status', transformationName, id, status })
+}
+
+/** Delete a knowledge item. */
+export async function deleteKnowledgeItem(transformationName, id) {
+  if (USE_MOCK) { await new Promise(r => setTimeout(r, 300)); return { status: 'SUBMITTED' } }
+  return ki({ kiAction: 'delete-ki', transformationName, id })
+}
+
+/** Toggle auto-apply of new knowledge items. autoEnabled: 'TRUE' | 'FALSE' */
+export async function setAutoApply(transformationName, autoEnabled) {
+  if (USE_MOCK) { await new Promise(r => setTimeout(r, 300)); return { status: 'SUBMITTED' } }
+  return ki({ kiAction: 'update-ki-config', transformationName, autoEnabled })
+}
+
+/** Export all knowledge items to markdown (Batch job). */
+export async function exportKnowledgeItems(transformationName) {
+  if (USE_MOCK) { await new Promise(r => setTimeout(r, 300)); return { status: 'SUBMITTED' } }
+  return ki({ kiAction: 'export-ki-markdown', transformationName })
+}
+
+// ---- Mock data (shape from the ATX list-ki output in the AWS blog) ----
+
+function mockItems(transformationName) {
+  if (transformationName !== 'AWS/java-version-upgrade') {
+    return [
+      {
+        id: 'c2a1f0e3-1111-2222-3333-444455556666',
+        status: 'DISABLED',
+        title: 'Sample learned pattern',
+        description: 'A representative knowledge item captured during a prior run of this transformation.',
+        rationale: 'Illustrates the shape of a knowledge item before any real runs populate the cache.',
+        changes: JSON.stringify({
+          file_changes: { modified: [{ file: 'src/example.txt', type: 'MODIFY' }] },
+          code_samples: {
+            before: { file: 'src/example.txt', code: 'old value' },
+            after: { file: 'src/example.txt', code: 'new value' },
+          },
+        }),
+      },
+    ]
+  }
+  return [
+    {
+      id: '7f36cfd4-2926-44fa-8fa5-eb5384e65c77',
+      status: 'DISABLED',
+      title: 'Mockito 5.14.2 ByteBuddy incompatible with Java 26',
+      description: 'Mockito 5.14.2 fails to mock standard library classes like ArrayList under Java 26. ByteBuddy cannot modify ArrayList and related collection classes. Mockito 5.15.2 resolves the compatibility issue.',
+      rationale: 'Bytecode manipulation libraries must support the target Java class file format. ByteBuddy bundled with Mockito 5.14.2 cannot handle Java 26 (class major version 70).',
+      changes: JSON.stringify({
+        file_changes: { modified: [{ file: 'pom.xml', type: 'MODIFY' }] },
+        code_samples: {
+          before: { language: 'xml', file: 'pom.xml', code: '<dependency>\n  <groupId>org.mockito</groupId>\n  <artifactId>mockito-core</artifactId>\n  <version>5.14.2</version>\n  <scope>test</scope>\n</dependency>' },
+          after: { language: 'xml', file: 'pom.xml', code: '<dependency>\n  <groupId>org.mockito</groupId>\n  <artifactId>mockito-core</artifactId>\n  <version>5.15.2</version>\n  <scope>test</scope>\n</dependency>' },
+        },
+      }),
+    },
+    {
+      id: 'adb1b8e6-4199-4d4d-964c-1eab5c94de1a',
+      status: 'DISABLED',
+      title: 'Spring Boot 3.2.12 ASM lacks Java 26 class format support',
+      description: 'Spring Boot 3.2.12 uses an ASM version that cannot parse Java 26 class files (major version 70). Test execution fails with "Incompatible class format" during classpath scanning. Spring Boot 3.5.14 or newer is required.',
+      rationale: 'Classpath scanning at test time parses bytecode; an ASM version without Java 26 support breaks the entire test run, not just compilation.',
+      changes: JSON.stringify({
+        file_changes: { modified: [{ file: 'pom.xml', type: 'MODIFY' }] },
+        code_samples: {
+          before: { language: 'xml', file: 'pom.xml', code: '<parent>\n  <groupId>org.springframework.boot</groupId>\n  <artifactId>spring-boot-starter-parent</artifactId>\n  <version>3.2.12</version>\n</parent>' },
+          after: { language: 'xml', file: 'pom.xml', code: '<parent>\n  <groupId>org.springframework.boot</groupId>\n  <artifactId>spring-boot-starter-parent</artifactId>\n  <version>3.5.14</version>\n</parent>' },
+        },
+      }),
+    },
+  ]
+}

--- a/agentic-atx-platform/ui/src/metricsApi.js
+++ b/agentic-atx-platform/ui/src/metricsApi.js
@@ -1,0 +1,171 @@
+// Metrics API client for the AWS/TransformCustom CloudWatch namespace.
+//
+// Backend: the metrics logic from scaled-execution-containers PR #41 (get_metrics.py)
+// is ported into the agentic platform's async_invoke_agent Lambda and exposed via the
+// existing `/orchestrate` endpoint as `op: "metrics"`. This keeps the UI on the single
+// unauthenticated HTTP API (no SigV4) instead of the IAM-authed REST API.
+//
+// The response shape matches get_metrics.py `type=all` / `type=transform`:
+//   {
+//     startTime, endTime,
+//     jobs: { SUBMITTED, PENDING, RUNNABLE, STARTING, RUNNING, SUCCEEDED, FAILED },
+//     transformCustom: {
+//       totals: { TransformationExecutionStarted, TransformationExecutionCompleted,
+//                 ConversationStarted, AgentExecutionMinutes, ExecutionDuration,
+//                 FilesRead, FilesModified, LinesAdded, LinesDeleted, LinesModified },
+//       uniqueConversations, uniqueExecutions,
+//       byTransformation: { [name]: { <metric>: value, ... } },
+//       byRepository:     { [repo]: { <metric>: value, ... } }
+//     },
+//     lambda: {...}, api: {...}
+//   }
+//
+// SWAP POINT: set VITE_METRICS_MOCK=false (or change USE_MOCK) once the Lambda op is deployed.
+
+const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
+const USE_MOCK = (import.meta.env.VITE_METRICS_MOCK ?? 'true') !== 'false'
+
+// period (hours) for each UI range option
+const RANGE_HOURS = { '24h': 24, '7d': 168, '30d': 720 }
+
+/**
+ * Fetch aggregate metrics (type=all) for a UI range.
+ * @param {Object} opts
+ * @param {string} opts.range - '24h' | '7d' | '30d'
+ * @returns raw get_metrics.py response (see shape above)
+ */
+export async function fetchMetrics({ range = '7d' } = {}) {
+  if (USE_MOCK) {
+    await new Promise(r => setTimeout(r, 400))
+    return mockMetrics(range)
+  }
+
+  const res = await fetch(`${API_BASE}/orchestrate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'direct', op: 'metrics', type: 'all', period: RANGE_HOURS[range] || 168 }),
+  })
+  if (!res.ok) throw new Error(`Metrics API returned ${res.status}`)
+  const data = await res.json()
+  if (data.error) throw new Error(data.error)
+  return data
+}
+
+/**
+ * Per-execution breakdown (type=transform_detail).
+ * @returns { startTime, endTime, executions: [{ executionId, dimensions, metrics }, ...] }
+ */
+export async function fetchExecutions({ range = '7d' } = {}) {
+  if (USE_MOCK) {
+    await new Promise(r => setTimeout(r, 300))
+    return mockExecutions()
+  }
+  const res = await fetch(`${API_BASE}/orchestrate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ action: 'direct', op: 'metrics', type: 'transform_detail', period: RANGE_HOURS[range] || 168 }),
+  })
+  if (!res.ok) throw new Error(`Metrics API returned ${res.status}`)
+  const data = await res.json()
+  if (data.error) throw new Error(data.error)
+  return data
+}
+
+// ---- Derivation helpers (shared by component so live + mock behave identically) ----
+
+// Turn { byTransformation: { name: { Metric: v } } } into sorted [{ key, value }]
+// ranked by a chosen metric (default: TransformationExecutionCompleted, fallback started).
+export function rankBy(group, metric = 'TransformationExecutionCompleted', limit = 8) {
+  if (!group) return []
+  return Object.entries(group)
+    .map(([key, m]) => ({
+      key,
+      value: m[metric] ?? m.TransformationExecutionStarted ?? m.AgentExecutionMinutes ?? 0,
+    }))
+    .filter(d => d.value > 0)
+    .sort((a, b) => b.value - a.value)
+    .slice(0, limit)
+}
+
+// Execution status split derived from per-execution detail (ExecutionStatus dimension).
+export function statusSplit(executions = []) {
+  const counts = {}
+  for (const e of executions) {
+    const s = e?.dimensions?.ExecutionStatus
+    if (s) counts[s] = (counts[s] || 0) + 1
+  }
+  return Object.entries(counts).map(([key, value]) => ({ key, value }))
+}
+
+export function typeSplit(executions = []) {
+  const counts = {}
+  for (const e of executions) {
+    const t = e?.dimensions?.ExecutionType
+    if (t) counts[t] = (counts[t] || 0) + 1
+  }
+  return Object.entries(counts).map(([key, value]) => ({ key, value }))
+}
+
+// ---- Mock data (shaped identically to get_metrics.py) ----
+
+function mockMetrics(range) {
+  const scale = range === '24h' ? 0.3 : range === '30d' ? 3 : 1
+  const r = (n) => Math.round(n * scale)
+  return {
+    startTime: new Date(Date.now() - (RANGE_HOURS[range] || 168) * 3600_000).toISOString(),
+    endTime: new Date().toISOString(),
+    jobs: { SUBMITTED: 0, PENDING: 0, RUNNABLE: 1, STARTING: 2, RUNNING: 3, SUCCEEDED: r(31), FAILED: r(3) },
+    transformCustom: {
+      totals: {
+        TransformationExecutionStarted: r(8),
+        TransformationExecutionCompleted: r(5),
+        ConversationStarted: r(125),
+        AgentExecutionMinutes: r(635.5),
+        ExecutionDuration: r(8495.94),
+        FilesRead: r(336),
+        FilesModified: r(28),
+        LinesAdded: r(68),
+        LinesDeleted: r(79),
+        LinesModified: r(229),
+      },
+      uniqueConversations: r(12),
+      uniqueExecutions: r(12),
+      byTransformation: {
+        'AWS/python-version-upgrade': { TransformationExecutionCompleted: r(2), TransformationExecutionStarted: r(3), AgentExecutionMinutes: r(92.65), FilesModified: r(12), FilesRead: r(60), LinesModified: r(189) },
+        'AWS/java-version-upgrade': { TransformationExecutionStarted: r(2), TransformationExecutionCompleted: r(1), AgentExecutionMinutes: r(49.08), FilesRead: r(49), FilesModified: r(13), LinesAdded: r(68) },
+        'AWS/nodejs-version-upgrade': { TransformationExecutionStarted: r(2), TransformationExecutionCompleted: r(1), AgentExecutionMinutes: r(55.75), FilesModified: r(3), LinesModified: r(40) },
+        'AWS/comprehensive-codebase-analysis': { TransformationExecutionStarted: r(4), TransformationExecutionCompleted: r(2), AgentExecutionMinutes: r(438.03), FilesRead: r(227) },
+      },
+      byRepository: {
+        'todoapilambda': { TransformationExecutionCompleted: r(2), TransformationExecutionStarted: r(3), AgentExecutionMinutes: r(189.22), FilesModified: r(12), FilesRead: r(60) },
+        'spring-petclinic': { TransformationExecutionStarted: r(2), AgentExecutionMinutes: r(167.79), FilesRead: r(78) },
+        'auth-gateway': { TransformationExecutionCompleted: r(1), TransformationExecutionStarted: r(2), AgentExecutionMinutes: r(70.5) },
+      },
+    },
+    lambda: { 'atx-async-invoke-agent': { invocations: r(42), errors: 0, avgDurationMs: 245.3 } },
+    api: { requests: r(120), '4xxErrors': r(2), '5xxErrors': 0 },
+  }
+}
+
+function mockExecutions() {
+  const mk = (status, type, transform, repo, mins) => ({
+    executionId: crypto.randomUUID(),
+    dimensions: {
+      ExecutionStatus: status, ExecutionType: type,
+      TransformationName: transform, RepositoryName: repo,
+      ConversationId: '2026' + Math.random().toString().slice(2, 10),
+    },
+    metrics: { AgentExecutionMinutes: mins },
+  })
+  return {
+    startTime: new Date(Date.now() - 168 * 3600_000).toISOString(),
+    endTime: new Date().toISOString(),
+    executions: [
+      mk('Success', 'Unsupervised', 'AWS/python-version-upgrade', 'todoapilambda', 39.19),
+      mk('Success', 'Unsupervised', 'AWS/java-version-upgrade', 'auth-gateway', 49.08),
+      mk('Failure', 'Supervised', 'AWS/nodejs-version-upgrade', 'web-frontend', 12.5),
+      mk('Success', 'Unsupervised', 'AWS/comprehensive-codebase-analysis', 'spring-petclinic', 88.3),
+      mk('InProgress', 'Unsupervised', 'AWS/python-version-upgrade', 'inventory-api', 15.0),
+    ],
+  }
+}

--- a/agentic-atx-platform/ui/src/metricsApi.js
+++ b/agentic-atx-platform/ui/src/metricsApi.js
@@ -87,12 +87,26 @@ export function rankBy(group, metric = 'TransformationExecutionCompleted', limit
     .slice(0, limit)
 }
 
-// Execution status split derived from per-execution detail (ExecutionStatus dimension).
+// Execution status split, derived from each execution's metrics rather than the raw
+// ExecutionStatus dimension. ATX stamps ExecutionStatus at emit time and doesn't always
+// reconcile it to a terminal value (e.g. comprehensive-codebase-analysis emits final
+// metrics while still tagged "InProgress"). So we treat presence of
+// TransformationExecutionCompleted as the source of truth:
+//   - completed + Failure dimension      -> Failed
+//   - completed (any other status)       -> Success
+//   - no completion metric               -> fall back to the raw status (e.g. InProgress)
 export function statusSplit(executions = []) {
   const counts = {}
   for (const e of executions) {
-    const s = e?.dimensions?.ExecutionStatus
-    if (s) counts[s] = (counts[s] || 0) + 1
+    const rawStatus = e?.dimensions?.ExecutionStatus
+    const completed = !!e?.metrics?.TransformationExecutionCompleted
+    let bucket
+    if (completed) {
+      bucket = rawStatus === 'Failure' ? 'Failed' : 'Success'
+    } else {
+      bucket = rawStatus || 'InProgress'
+    }
+    counts[bucket] = (counts[bucket] || 0) + 1
   }
   return Object.entries(counts).map(([key, value]) => ({ key, value }))
 }
@@ -155,7 +169,10 @@ function mockExecutions() {
       TransformationName: transform, RepositoryName: repo,
       ConversationId: '2026' + Math.random().toString().slice(2, 10),
     },
-    metrics: { AgentExecutionMinutes: mins },
+    // Terminal runs carry a completion metric; InProgress runs don't (mirrors real ATX data).
+    metrics: status === 'InProgress'
+      ? { AgentExecutionMinutes: mins }
+      : { AgentExecutionMinutes: mins, TransformationExecutionCompleted: 1 },
   })
   return {
     startTime: new Date(Date.now() - 168 * 3600_000).toISOString(),

--- a/agentic-atx-platform/ui/src/transformations.js
+++ b/agentic-atx-platform/ui/src/transformations.js
@@ -1,0 +1,20 @@
+// Shared catalog of AWS-managed transformations. Used by TransformationList
+// (display) and KnowledgeItems (dropdown) so the two never drift.
+
+export const MANAGED_TRANSFORMATIONS = [
+  { name: 'AWS/python-version-upgrade', language: 'python', description: 'Upgrade Python applications from 3.8/3.9 to 3.11/3.12/3.13', managed: true },
+  { name: 'AWS/java-version-upgrade', language: 'java', description: 'Upgrade Java applications from any source JDK to any target JDK with dependency modernization', managed: true },
+  { name: 'AWS/nodejs-version-upgrade', language: 'nodejs', description: 'Upgrade Node.js applications from any source to any target version', managed: true },
+  { name: 'AWS/python-boto2-to-boto3', language: 'python', description: 'Migrate Python applications from boto2 to boto3', managed: true },
+  { name: 'AWS/java-aws-sdk-v1-to-v2', language: 'java', description: 'Upgrade AWS SDK from v1 to v2 for Java (Maven or Gradle)', managed: true },
+  { name: 'AWS/nodejs-aws-sdk-v2-to-v3', language: 'nodejs', description: 'Upgrade Node.js from AWS SDK v2 to v3 modular architecture', managed: true },
+  { name: 'AWS/comprehensive-codebase-analysis', language: 'all', description: 'Deep static analysis with technical debt, security, and modernization insights', managed: true },
+  { name: 'AWS/java-performance-optimization', language: 'java', description: 'Optimize Java performance by analyzing JFR profiling data to detect CPU/memory hotspots and apply targeted fixes', managed: true },
+  { name: 'AWS/early-access-java-x86-to-graviton', language: 'java', description: '[Early Access] Validate and migrate Java applications to ARM64 for AWS Graviton', managed: true },
+  { name: 'AWS/early-access-angular-to-react-migration', language: 'nodejs', description: '[Early Access] Transform Angular applications to React', managed: true },
+  { name: 'AWS/vue.js-version-upgrade', language: 'nodejs', description: '[Early Access] Upgrade Vue.js 2 applications to Vue.js 3', managed: true },
+  { name: 'AWS/angular-version-upgrade', language: 'nodejs', description: '[Early Access] Upgrade older Angular applications to a target Angular version', managed: true },
+  { name: 'AWS/early-access-log4j-to-slf4j-migration', language: 'java', description: '[Early Access] Migrate Java applications from Log4j (1.x/2.x) to SLF4J with Logback backend', managed: true },
+]
+
+export const MANAGED_TRANSFORMATION_NAMES = MANAGED_TRANSFORMATIONS.map(t => t.name)


### PR DESCRIPTION
## Summary
Adds Metrics and Knowledge Items to the agentic-atx-platform UI, and migrates the
custom-transformation create flow to the new ATX SKILL.md format.

### Metrics
- New `direct` op `metrics` on the async Lambda, porting the CloudWatch
  `AWS/TransformCustom` query logic from scaled-execution-containers (PR #41)
- New Metrics dashboard tab (Chart.js): summary cards, batch job status,
  execution status/type, top transformations/repos, code-impact panel
<img width="1098" height="634" alt="image" src="https://github.com/user-attachments/assets/f2a2c7df-2fdf-4872-b0ed-7798b9c6c66c" />
<img width="1090" height="685" alt="image" src="https://github.com/user-attachments/assets/abeafc6c-3066-4092-a63f-fda7a8640ee1" />
<img width="1076" height="522" alt="image" src="https://github.com/user-attachments/assets/49ef47e2-34b2-4f67-8b09-ff16e7032bcd" />

### Knowledge Items
- New `direct` op `knowledge_items` (cache-read + submit/poll + write actions)
- New Knowledge tab: list / enable / disable / delete / export-markdown,
  cache-first load with an explicit "Pull from registry" Batch refresh
- Renders the real `list-ki` schema (rationale + changes file_changes/code_samples)
<img width="1089" height="835" alt="image" src="https://github.com/user-attachments/assets/ab570209-0694-4012-88d5-8060e24d334b" />


### SKILL.md format
- Create flow now generates `SKILL.md` (YAML frontmatter name+description) instead
  of `transformation_definition.md`; publish stages SKILL.md with legacy fallback
- Name normalization to satisfy ATX skill naming rules
- `get_file` op + UI previews resolve SKILL.md first, fall back to legacy file

### Infra
- AsyncInvokeRole: cloudwatch read, batch:SubmitJob/ListJobs, logs:GetLogEvents
- Add JOB_QUEUE_NAME / JOB_DEFINITION_NAME env; promote AgentRuntimeArn to a
  template parameter so redeploys preserve the runtime ARN

## Testing
- Deployed and smoke-tested on dev account
- `metrics` + `knowledge_items` ops verified live via the API
- SKILL.md generation verified end-to-end (valid frontmatter in S3)
- UI builds clean; mock flags allow demo without backend
