### PR TITLE
feat: secure-by-default Cognito authentication for agentic platform API

### DIFF
--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -159,14 +159,18 @@ UI (Cognito Hosted UI, OAuth2 auth-code + PKCE)
   → user signs in → app exchanges ?code= for an access token (sessionStorage)
   → authedFetch attaches Authorization: Bearer <token> to every /orchestrate call
 
-async_invoke_agent Lambda (auth.py)
-  → ENABLE_AUTH=true: verify Cognito JWT (JWKS signature, issuer, audience,
-    expiry, token_use, client_id) before routing any action; 401 on failure
-  → ENABLE_AUTH=false: open (blog/demo mode)
+API Gateway (raw ApiGatewayV2 + Cognito JWT authorizer)
+  → EnableAuth=true: /orchestrate route requires a valid Cognito JWT; rejects
+    unauthenticated/invalid tokens with 401 at the edge (Lambda not invoked)
+  → EnableAuth=false: route is open (AuthorizationType NONE) for blog/demo mode
+
+async_invoke_agent Lambda (auth.py) — defense-in-depth
+  → trusts gateway-validated claims when present; otherwise re-verifies the JWT
+    (JWKS signature, issuer, audience, expiry, token_use, client_id)
   → internal async self-invokes and CORS preflight bypass the gate
 
-Note: auth is enforced in the Lambda (not an API Gateway JWT authorizer) because
-SAM cannot conditionally toggle a default authorizer on one HTTP API.
+Note: raw ApiGatewayV2 resources are used (not SAM's HttpApi `Auth` shorthand) so
+the JWT authorizer can be attached conditionally via !If on EnableAuth.
 ```
 
 ## Components

--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -151,6 +151,24 @@ Knowledge items are generated DISABLED by ATX after a run; the UI lists them
 cache-first and only triggers the Batch refresh on an explicit "Pull from registry".
 ```
 
+### Authentication
+```
+Secure by default (EnableAuth=true).
+
+UI (Cognito Hosted UI, OAuth2 auth-code + PKCE)
+  → user signs in → app exchanges ?code= for an access token (sessionStorage)
+  → authedFetch attaches Authorization: Bearer <token> to every /orchestrate call
+
+async_invoke_agent Lambda (auth.py)
+  → ENABLE_AUTH=true: verify Cognito JWT (JWKS signature, issuer, audience,
+    expiry, token_use, client_id) before routing any action; 401 on failure
+  → ENABLE_AUTH=false: open (blog/demo mode)
+  → internal async self-invokes and CORS preflight bypass the gate
+
+Note: auth is enforced in the Lambda (not an API Gateway JWT authorizer) because
+SAM cannot conditionally toggle a default authorizer on one HTTP API.
+```
+
 ## Components
 
 | Component | Path | Purpose |
@@ -163,6 +181,7 @@ cache-first and only triggers the Batch refresh on an explicit "Pull from regist
 | Async Lambda | `api/lambda/async_invoke_agent.py` | Submit/poll/direct bridge |
 | Metrics | `api/lambda/metrics.py` | CloudWatch AWS/TransformCustom metrics (direct op) |
 | Knowledge Items | `api/lambda/knowledge_items.py` | List/enable/disable/delete/export KIs (direct op) |
+| Auth | `api/lambda/auth.py` | Cognito JWT verification (secure-by-default, fails closed) |
 | UI | `ui/src/` | React app (8 tabs) |
 | Infrastructure | `cdk/` | Batch, S3, VPC, CloudFront, AgentCore |
 | SAM Layer | `sam/` | AgentCore deploy Lambda + API (Option A) |
@@ -181,6 +200,7 @@ cache-first and only triggers the Batch refresh on an explicit "Pull from regist
 | API Gateway v2 (HTTP) | Single /orchestrate endpoint |
 | Lambda | Async bridge (submit/poll/direct) |
 | DynamoDB | Job tracking (persisted across sessions) |
+| Cognito (User Pool) | UI authentication — JWT verified in Lambda (when EnableAuth=true) |
 
 ## Project Structure
 
@@ -192,8 +212,10 @@ cache-first and only triggers the Batch refresh on an explicit "Pull from regist
 │   └── requirements.txt
 ├── api/lambda/                 # Async bridge Lambda
 │   ├── async_invoke_agent.py
+│   ├── auth.py                 # Cognito JWT verification (secure by default)
 │   ├── metrics.py              # CloudWatch metrics (op: metrics)
-│   └── knowledge_items.py      # Knowledge items (op: knowledge_items)
+│   ├── knowledge_items.py      # Knowledge items (op: knowledge_items)
+│   └── tests/                  # unittest suite (auth enforcement, no open endpoints)
 ├── ui/                         # React frontend (8 tabs)
 │   └── src/components/         # TransformationList, Form, CreateCustom, CsvUpload, JobTracker, Metrics, KnowledgeItems, Chat
 ├── cdk/                        # CDK stacks (Container, Infrastructure, AgentCore, UI)

--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -137,6 +137,15 @@ No AI/AgentCore involved — deterministic CloudWatch query. Ported from
 scaled-execution-containers get_metrics.py. The dashboard (Chart.js) reads
 type=all + type=transform_detail and derives execution status from the
 TransformationExecutionCompleted metric (not the raw ExecutionStatus dimension).
+
+Limitation — ~14-day window: metrics.py discovers which metrics/dimensions exist
+via cloudwatch:ListMetrics, which only returns metrics that published data in the
+last ~2 weeks. So the dashboard reflects only ~the last 14 days of activity
+regardless of the selected range, and shows empty if nothing has run recently
+(the underlying data points persist in CloudWatch but aren't rediscovered). The UI
+range selector is capped at 14 days for this reason. Longer historical lookback
+would require discovering metrics another way (e.g. cached dimension sets,
+CloudWatch Metrics Insights, or a per-run metrics snapshot in DynamoDB/S3).
 ```
 
 ### Knowledge Items

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -58,6 +58,7 @@ Key settings:
 | `BEDROCK_MODEL_ID` | `us.anthropic.claude-sonnet-4-5-20250929-v1:0` | AI model for orchestrator |
 | `FARGATE_VCPU` | `2` | vCPU for Batch jobs |
 | `FARGATE_MEMORY` | `4096` | Memory (MB) for Batch jobs |
+| `ENABLE_AUTH` | `true` | Secure by default. `true` requires Cognito JWT auth; set `false` for the open blog/demo walkthrough |
 | `JOB_TIMEOUT` | `43200` | Max job duration (seconds) |
 
 See `deployment/config.env.template` for all options.
@@ -291,6 +292,74 @@ Create via the "Create Custom" tab. Published to the ATX registry via `atx custo
 | **Jobs** | Track job status, view results |
 | **Metrics** | CloudWatch dashboard for the `AWS/TransformCustom` namespace (Chart.js) |
 | **Knowledge** | Review/enable/disable/delete knowledge items per transformation |
+
+---
+
+## Authentication
+
+The HTTP API is **secure by default** (`EnableAuth=true`). It requires a Cognito
+JWT access token; the `atx-async-invoke-agent` Lambda verifies the token
+(signature via the user pool JWKS, plus issuer/audience/expiry) and rejects
+unauthenticated calls with `401`. The React UI signs in through the Cognito
+Hosted UI (OAuth2 authorization-code + PKCE) and attaches the token to every
+API call.
+
+> **Open demo mode:** for the blog/demo walkthrough where no login is desired,
+> deploy with `ENABLE_AUTH=false` and build the UI without `VITE_AUTH_ENABLED`.
+
+### Enabling auth (default)
+
+1. **Deploy the stack** (creates the Cognito User Pool, app client, and hosted UI domain):
+   ```bash
+   cd sam && ./deploy.sh          # ENABLE_AUTH defaults to true
+   ```
+   Note the stack outputs: `UserPoolId`, `UserPoolClientId`, `CognitoHostedUiDomain`.
+
+2. **Create a user** (self-signup is disabled — admin-create only):
+   ```bash
+   aws cognito-idp admin-create-user \
+     --user-pool-id <UserPoolId> \
+     --username you@example.com \
+     --user-attributes Name=email,Value=you@example.com Name=email_verified,Value=true
+   # then set a permanent password:
+   aws cognito-idp admin-set-user-password \
+     --user-pool-id <UserPoolId> --username you@example.com \
+     --password '<StrongPassw0rd!>' --permanent
+   ```
+
+3. **Build + deploy the UI** with auth config from the stack outputs:
+   ```bash
+   cd ui && npm install
+   VITE_API_ENDPOINT=$API_URL \
+   VITE_AUTH_ENABLED=true \
+   VITE_COGNITO_DOMAIN=<CognitoHostedUiDomain> \
+   VITE_COGNITO_CLIENT_ID=<UserPoolClientId> \
+   VITE_AUTH_REDIRECT_URI=<your CloudFront URL> \
+   npx vite build
+   ./deploy-aws.sh
+   ```
+
+4. **Verify:** an unauthenticated call returns 401; the UI redirects to the
+   Cognito Hosted UI for login.
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}\n" -X POST $API_URL/orchestrate \
+     -H 'Content-Type: application/json' -d '{"action":"direct","op":"list_jobs"}'   # -> 401
+   ```
+
+### UI auth build flags
+
+| Flag | Description |
+|------|-------------|
+| `VITE_AUTH_ENABLED` | `true` to enable the Hosted UI login flow |
+| `VITE_COGNITO_DOMAIN` | Cognito hosted UI domain (stack output `CognitoHostedUiDomain`) |
+| `VITE_COGNITO_CLIENT_ID` | App client id (stack output `UserPoolClientId`) |
+| `VITE_AUTH_REDIRECT_URI` | OAuth redirect URI (defaults to `window.location.origin`) |
+
+> **Design note:** auth is enforced in the Lambda rather than via an API Gateway
+> JWT authorizer. AWS SAM cannot conditionally toggle a default authorizer on a
+> single HTTP API, so the function performs full JWT verification and fails closed.
+> Unauthenticated requests reach the function but are rejected with 401 before any
+> Batch/AgentCore work runs.
 
 ---
 

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -356,11 +356,12 @@ API call.
 | `VITE_COGNITO_CLIENT_ID` | App client id (stack output `UserPoolClientId`) |
 | `VITE_AUTH_REDIRECT_URI` | OAuth redirect URI (defaults to `window.location.origin`) |
 
-> **Design note:** auth is enforced in the Lambda rather than via an API Gateway
-> JWT authorizer. AWS SAM cannot conditionally toggle a default authorizer on a
-> single HTTP API, so the function performs full JWT verification and fails closed.
-> Unauthenticated requests reach the function but are rejected with 401 before any
-> Batch/AgentCore work runs.
+> **Design note:** auth is enforced at the **API Gateway JWT authorizer** — the
+> `/orchestrate` route rejects unauthenticated/invalid tokens with `401` at the edge,
+> before the Lambda is invoked. The Lambda (`auth.py`) additionally verifies the JWT
+> as defense-in-depth (and trusts gateway-validated claims when present). Raw
+> `AWS::ApiGatewayV2` resources are used (instead of SAM's HttpApi `Auth` shorthand)
+> so the authorizer can be attached conditionally on `EnableAuth`.
 
 ---
 

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -316,7 +316,10 @@ API call.
    ```
    Note the stack outputs: `UserPoolId`, `UserPoolClientId`, `CognitoHostedUiDomain`.
 
-2. **Create a user** (self-signup is disabled — admin-create only):
+2. **Create a user** — required to access the app. Only users you add to the
+   Cognito User Pool can sign in; self-signup is disabled (admin-create only), so
+   no one can reach the UI until at least one user exists. Repeat for each person
+   who needs access.
    ```bash
    aws cognito-idp admin-create-user \
      --user-pool-id <UserPoolId> \
@@ -327,6 +330,9 @@ API call.
      --user-pool-id <UserPoolId> --username you@example.com \
      --password '<StrongPassw0rd!>' --permanent
    ```
+   > Without `--permanent`, an admin-created user is left in `FORCE_CHANGE_PASSWORD`
+   > and will be prompted to set a new password on first sign-in. You can also create
+   > users from the Cognito console (User pools → your pool → Users → Create user).
 
 3. **Build + deploy the UI** with auth config from the stack outputs:
    ```bash
@@ -340,8 +346,9 @@ API call.
    ./deploy-aws.sh
    ```
 
-4. **Verify:** an unauthenticated call returns 401; the UI redirects to the
-   Cognito Hosted UI for login.
+4. **Verify:** an unauthenticated call returns 401; opening the UI redirects to the
+   Cognito Hosted UI, where you sign in as the user created in step 2. After login
+   the app loads and API calls carry the bearer token.
    ```bash
    curl -s -o /dev/null -w "%{http_code}\n" -X POST $API_URL/orchestrate \
      -H 'Content-Type: application/json' -d '{"action":"direct","op":"list_jobs"}'   # -> 401

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -334,17 +334,22 @@ API call.
    > and will be prompted to set a new password on first sign-in. You can also create
    > users from the Cognito console (User pools → your pool → Users → Create user).
 
-3. **Build + deploy the UI** with auth config from the stack outputs:
+3. **Build + deploy the UI** with auth config from the stack outputs. Copy
+   `ui/.env.example` to `ui/.env` and fill in the values (Vite auto-loads `.env`):
    ```bash
    cd ui && npm install
-   VITE_API_ENDPOINT=$API_URL \
-   VITE_AUTH_ENABLED=true \
-   VITE_COGNITO_DOMAIN=<CognitoHostedUiDomain> \
-   VITE_COGNITO_CLIENT_ID=<UserPoolClientId> \
-   VITE_AUTH_REDIRECT_URI=<your CloudFront URL> \
+   cp .env.example .env          # then edit .env with your stack outputs
    npx vite build
    ./deploy-aws.sh
    ```
+   `.env` is gitignored. The values map to stack outputs: `VITE_API_ENDPOINT` ←
+   `ApiEndpoint`, `VITE_COGNITO_DOMAIN` ← `CognitoHostedUiDomain`,
+   `VITE_COGNITO_CLIENT_ID` ← `UserPoolClientId`. (You can also pass them inline
+   instead of using `.env`, e.g. `VITE_API_ENDPOINT=$API_URL ... npx vite build`.)
+
+   > These same vars drive the generated Content-Security-Policy (`connect-src` is
+   > scoped to your exact API + Cognito origins), so they must be correct or the
+   > browser will block API/login calls.
 
 4. **Verify:** an unauthenticated call returns 401; opening the UI redirects to the
    Cognito Hosted UI, where you sign in as the user created in step 2. After login
@@ -395,10 +400,13 @@ plan for them:
 
 > **Hardening notes:** the UI sets a Content-Security-Policy (`script-src 'self'`) as
 > the primary XSS mitigation, since the short-lived access token lives in
-> `sessionStorage` (no refresh token is stored in the browser). For stronger coverage,
-> set CSP and `frame-ancestors`/HSTS via a CloudFront response-headers policy, and
-> consider a backend-for-frontend with HttpOnly cookies if browser token storage must
-> be eliminated. See `docs/SECURITY.md`.
+> `sessionStorage` (no refresh token is stored in the browser). The CSP is generated
+> at build time (`vite.config.js`) and scopes `connect-src` to the **exact** API
+> Gateway and Cognito origins from `VITE_API_ENDPOINT` / `VITE_COGNITO_DOMAIN` — so
+> those build vars must be correct or the browser will block API/login calls. For
+> stronger coverage, also set CSP and `frame-ancestors`/HSTS via a CloudFront
+> response-headers policy, and consider a backend-for-frontend with HttpOnly cookies
+> if browser token storage must be eliminated. See `docs/SECURITY.md`.
 
 ---
 

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -370,6 +370,36 @@ API call.
 > `AWS::ApiGatewayV2` resources are used (instead of SAM's HttpApi `Auth` shorthand)
 > so the authorizer can be attached conditionally on `EnableAuth`.
 
+### Upgrading from the pre-auth version
+
+Updating an existing (pre-auth) deployment introduces **two breaking changes** —
+plan for them:
+
+1. **The API endpoint URL changes.** The API moved from `AWS::Serverless::HttpApi`
+   to raw `AWS::ApiGatewayV2::Api` (so the JWT authorizer can be conditional).
+   CloudFormation replaces the API, so its ID/URL changes on update. You must rebuild
+   the UI with the new `VITE_API_ENDPOINT` (from the `ApiEndpoint` stack output) and
+   repoint any external integrations.
+2. **Auth is on by default.** `EnableAuth` defaults to `true`, so after the update the
+   API requires a Cognito login. Open deployments will stop working until you create
+   users and rebuild the UI with the `VITE_AUTH_*` flags. To intentionally keep the
+   old open behavior, deploy with `ENABLE_AUTH=false` (you still get the new endpoint).
+
+**Upgrade runbook:**
+```
+1. Deploy the stack (sam/deploy.sh) — note the new ApiEndpoint + Cognito outputs
+2. Create user(s):  aws cognito-idp admin-create-user ...  (see "Create a user" above)
+3. Rebuild + redeploy the UI with VITE_API_ENDPOINT (new) + VITE_AUTH_* flags
+4. Verify: unauthenticated call -> 401; UI login works
+```
+
+> **Hardening notes:** the UI sets a Content-Security-Policy (`script-src 'self'`) as
+> the primary XSS mitigation, since the short-lived access token lives in
+> `sessionStorage` (no refresh token is stored in the browser). For stronger coverage,
+> set CSP and `frame-ancestors`/HSTS via a CloudFront response-headers policy, and
+> consider a backend-for-frontend with HttpOnly cookies if browser token storage must
+> be eliminated. See `docs/SECURITY.md`.
+
 ---
 
 ## Project Structure

--- a/agentic-atx-platform/api/lambda/async_invoke_agent.py
+++ b/agentic-atx-platform/api/lambda/async_invoke_agent.py
@@ -46,6 +46,13 @@ def lambda_handler(event, context):
     if event.get('requestContext', {}).get('http', {}).get('method') == 'OPTIONS':
         return cors_response(200, '')
 
+    # Enforce auth at the function boundary (defense-in-depth). No-op when
+    # ENABLE_AUTH != "true"; otherwise requires API Gateway-validated JWT claims.
+    from auth import authorize
+    ok, auth_error, _claims = authorize(event)
+    if not ok:
+        return cors_response(401, json.dumps({'error': auth_error}))
+
     try:
         body = json.loads(event.get('body', '{}'))
         action = body.get('action', 'submit')
@@ -583,9 +590,9 @@ def cors_response(status_code, body):
         'statusCode': status_code,
         'headers': {
             'Content-Type': 'application/json',
-            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Origin': os.environ.get('ALLOWED_ORIGIN', '*'),
             'Access-Control-Allow-Methods': 'POST, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': 'Content-Type, Authorization',
         },
         'body': body
     }

--- a/agentic-atx-platform/api/lambda/async_invoke_agent.py
+++ b/agentic-atx-platform/api/lambda/async_invoke_agent.py
@@ -11,6 +11,8 @@ import os
 import logging
 import boto3
 
+from auth import authorize
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -48,7 +50,6 @@ def lambda_handler(event, context):
 
     # Enforce auth at the function boundary (defense-in-depth). No-op when
     # ENABLE_AUTH != "true"; otherwise requires API Gateway-validated JWT claims.
-    from auth import authorize
     ok, auth_error, _claims = authorize(event)
     if not ok:
         return cors_response(401, json.dumps({'error': auth_error}))

--- a/agentic-atx-platform/api/lambda/auth.py
+++ b/agentic-atx-platform/api/lambda/auth.py
@@ -73,6 +73,18 @@ def _bearer_token(event) -> str:
     return auth_header.strip()
 
 
+def _gateway_claims(event) -> dict:
+    """Claims attached by the API Gateway JWT authorizer (HTTP API payload v2)."""
+    authorizer = event.get('requestContext', {}).get('authorizer', {})
+    jwt_claims = authorizer.get('jwt', {})
+    claims = jwt_claims.get('claims') if isinstance(jwt_claims, dict) else None
+    if claims:
+        return claims
+    if isinstance(authorizer.get('claims'), dict):
+        return authorizer['claims']
+    return {}
+
+
 def authorize(event):
     """
     Returns (ok: bool, error: str|None, claims: dict).
@@ -80,10 +92,20 @@ def authorize(event):
     - Auth disabled              -> (True, None, {})            [open mode]
     - Auth enabled + valid token -> (True, None, <claims>)
     - Auth enabled + bad/missing -> (False, reason, {})
+
+    When the API Gateway JWT authorizer is attached it has already validated the
+    token and populated requestContext.authorizer.jwt.claims; we trust those.
+    Otherwise (or as defense-in-depth) we verify the bearer token in-process.
     """
     if not auth_enabled():
         return True, None, {}
 
+    # 1. Trust gateway-validated claims if present (authorizer already verified sig/exp).
+    gw = _gateway_claims(event)
+    if gw:
+        return True, None, gw
+
+    # 2. Fallback: verify the bearer token ourselves.
     if not _JWT_AVAILABLE:
         # Fail closed: if the crypto library is missing while auth is on, do not serve.
         return False, 'Unauthorized: auth library unavailable', {}

--- a/agentic-atx-platform/api/lambda/auth.py
+++ b/agentic-atx-platform/api/lambda/auth.py
@@ -1,12 +1,14 @@
 """
-Auth enforcement for the async invoke Lambda.
+Defense-in-depth auth verification for the async invoke Lambda.
 
-Authentication is enforced here (not at the API Gateway) so a single EnableAuth
-toggle controls it cleanly — SAM cannot conditionally attach/detach a default JWT
-authorizer on one HTTP API. When ENABLE_AUTH=true, every HTTP request must carry a
-valid Cognito JWT in the Authorization header; the token is cryptographically
-verified (signature via the user pool JWKS, plus issuer/audience/expiry) before any
-action runs. When ENABLE_AUTH!=true the API is open (blog/demo mode).
+Primary enforcement is the API Gateway JWT authorizer on the /orchestrate route
+(raw ApiGatewayV2, attached conditionally on EnableAuth) — it rejects
+unauthenticated/invalid requests with 401 at the edge before this function runs.
+This module is the second layer: when API Gateway has validated the token it
+attaches the claims to the request, which we trust; otherwise (or as a safety net)
+we cryptographically verify the Cognito JWT ourselves (signature via the user pool
+JWKS, plus issuer/audience/expiry/token_use/client_id). When ENABLE_AUTH!=true the
+API is open (blog/demo mode). Fails closed if enabled but misconfigured.
 
 Verification uses PyJWT. The JWKS is fetched once per cold start and cached.
 """

--- a/agentic-atx-platform/api/lambda/auth.py
+++ b/agentic-atx-platform/api/lambda/auth.py
@@ -1,0 +1,126 @@
+"""
+Auth enforcement for the async invoke Lambda.
+
+Authentication is enforced here (not at the API Gateway) so a single EnableAuth
+toggle controls it cleanly — SAM cannot conditionally attach/detach a default JWT
+authorizer on one HTTP API. When ENABLE_AUTH=true, every HTTP request must carry a
+valid Cognito JWT in the Authorization header; the token is cryptographically
+verified (signature via the user pool JWKS, plus issuer/audience/expiry) before any
+action runs. When ENABLE_AUTH!=true the API is open (blog/demo mode).
+
+Verification uses PyJWT. The JWKS is fetched once per cold start and cached.
+"""
+
+import os
+import json
+import time
+import urllib.request
+
+try:
+    import jwt
+    from jwt import PyJWKClient
+    _JWT_AVAILABLE = True
+except Exception:  # pragma: no cover - import guard
+    _JWT_AVAILABLE = False
+
+REGION = os.environ.get('AWS_REGION', os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'))
+
+_jwk_client = None
+_jwk_client_url = None
+
+
+def auth_enabled() -> bool:
+    return os.environ.get('ENABLE_AUTH', 'false').strip().lower() == 'true'
+
+
+def is_internal_invoke(event) -> bool:
+    """Internal async self-invokes (InvocationType=Event) bypass HTTP auth."""
+    return bool(event.get('_async_execute') or event.get('_async_download'))
+
+
+def _issuer() -> str:
+    pool_id = os.environ.get('COGNITO_USER_POOL_ID', '')
+    return f"https://cognito-idp.{REGION}.amazonaws.com/{pool_id}"
+
+
+def _jwks_url() -> str:
+    return f"{_issuer()}/.well-known/jwks.json"
+
+
+def _get_jwk_client():
+    global _jwk_client, _jwk_client_url
+    url = _jwks_url()
+    if _jwk_client is None or _jwk_client_url != url:
+        _jwk_client = PyJWKClient(url)
+        _jwk_client_url = url
+    return _jwk_client
+
+
+def _bearer_token(event) -> str:
+    """Extract the bearer token from the Authorization header (case-insensitive)."""
+    headers = event.get('headers') or {}
+    auth_header = ''
+    for k, v in headers.items():
+        if k and k.lower() == 'authorization':
+            auth_header = v or ''
+            break
+    if not auth_header:
+        return ''
+    parts = auth_header.split()
+    if len(parts) == 2 and parts[0].lower() == 'bearer':
+        return parts[1]
+    # Some clients send the raw token without the Bearer prefix.
+    return auth_header.strip()
+
+
+def authorize(event):
+    """
+    Returns (ok: bool, error: str|None, claims: dict).
+
+    - Auth disabled              -> (True, None, {})            [open mode]
+    - Auth enabled + valid token -> (True, None, <claims>)
+    - Auth enabled + bad/missing -> (False, reason, {})
+    """
+    if not auth_enabled():
+        return True, None, {}
+
+    if not _JWT_AVAILABLE:
+        # Fail closed: if the crypto library is missing while auth is on, do not serve.
+        return False, 'Unauthorized: auth library unavailable', {}
+
+    pool_id = os.environ.get('COGNITO_USER_POOL_ID', '')
+    app_client_id = os.environ.get('COGNITO_APP_CLIENT_ID', '')
+    if not pool_id or not app_client_id:
+        return False, 'Unauthorized: auth not configured', {}
+
+    token = _bearer_token(event)
+    if not token:
+        return False, 'Unauthorized: missing bearer token', {}
+
+    try:
+        signing_key = _get_jwk_client().get_signing_key_from_jwt(token)
+        expected_use = os.environ.get('EXPECTED_TOKEN_USE', 'access').strip().lower()
+        # Access tokens do not carry an `aud` claim (they use client_id); id tokens do.
+        # Verify audience only for id tokens; always verify issuer + signature + expiry.
+        decode_kwargs = {
+            'algorithms': ['RS256'],
+            'issuer': _issuer(),
+            'options': {'require': ['exp', 'iat']},
+        }
+        if expected_use == 'id':
+            decode_kwargs['audience'] = app_client_id
+        claims = jwt.decode(token, signing_key.key, **decode_kwargs)
+
+        token_use = str(claims.get('token_use', '')).lower()
+        if expected_use and token_use and token_use != expected_use:
+            return False, f'Unauthorized: unexpected token_use "{token_use}"', {}
+
+        # For access tokens, validate the client_id claim matches our app client.
+        if token_use == 'access':
+            if claims.get('client_id') and claims['client_id'] != app_client_id:
+                return False, 'Unauthorized: token client_id mismatch', {}
+
+        return True, None, claims
+
+    except Exception as e:  # invalid signature, expired, wrong issuer, etc.
+        return False, f'Unauthorized: {type(e).__name__}', {}

--- a/agentic-atx-platform/api/lambda/auth.py
+++ b/agentic-atx-platform/api/lambda/auth.py
@@ -59,7 +59,12 @@ def _get_jwk_client():
 
 
 def _bearer_token(event) -> str:
-    """Extract the bearer token from the Authorization header (case-insensitive)."""
+    """Extract the token from a well-formed 'Authorization: Bearer <token>' header.
+
+    Requires the RFC 6750 Bearer scheme (case-insensitive on the scheme name).
+    Anything else — a raw token without the scheme, a different scheme, or a
+    malformed header — returns '' and is rejected.
+    """
     headers = event.get('headers') or {}
     auth_header = ''
     for k, v in headers.items():
@@ -71,8 +76,7 @@ def _bearer_token(event) -> str:
     parts = auth_header.split()
     if len(parts) == 2 and parts[0].lower() == 'bearer':
         return parts[1]
-    # Some clients send the raw token without the Bearer prefix.
-    return auth_header.strip()
+    return ''
 
 
 def _gateway_claims(event) -> dict:

--- a/agentic-atx-platform/api/lambda/metrics.py
+++ b/agentic-atx-platform/api/lambda/metrics.py
@@ -282,8 +282,8 @@ def _get_job_counts():
                 token = resp.get('nextToken')
                 if not token:
                     break
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"Error counting {status} jobs: {e}")
         counts[status] = total
     return counts
 

--- a/agentic-atx-platform/api/lambda/requirements.txt
+++ b/agentic-atx-platform/api/lambda/requirements.txt
@@ -1,0 +1,1 @@
+PyJWT[crypto]>=2.8.0

--- a/agentic-atx-platform/api/lambda/tests/test_auth.py
+++ b/agentic-atx-platform/api/lambda/tests/test_auth.py
@@ -111,6 +111,22 @@ class TestAuthEnabled(unittest.TestCase):
                 self.assertIn('client_id', err)
 
 
+class TestGatewayClaims(unittest.TestCase):
+    def test_gateway_validated_claims_trusted(self):
+        # When the API Gateway JWT authorizer has validated and attached claims,
+        # authorize() trusts them without re-verifying the token.
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            ev = {
+                'requestContext': {'http': {'method': 'POST'},
+                                   'authorizer': {'jwt': {'claims': {'sub': 'gw-user', 'token_use': 'access'}}}},
+                'headers': {},
+                'body': '{}',
+            }
+            ok, err, claims = auth.authorize(ev)
+            self.assertTrue(ok, err)
+            self.assertEqual(claims['sub'], 'gw-user')
+
+
 class TestBearerExtraction(unittest.TestCase):
     def test_case_insensitive_header(self):
         ev = {'headers': {'authorization': 'Bearer abc'}}

--- a/agentic-atx-platform/api/lambda/tests/test_auth.py
+++ b/agentic-atx-platform/api/lambda/tests/test_auth.py
@@ -1,0 +1,135 @@
+"""
+Tests for auth enforcement on the async invoke Lambda.
+
+Run from agentic-atx-platform/api/lambda:
+    python3 -m unittest discover -s tests -v
+
+Covers:
+  - auth disabled (open/demo mode) lets requests through
+  - auth enabled rejects requests with no bearer token (401)
+  - auth enabled rejects when JWT verification fails (bad signature/expired)
+  - auth enabled accepts a valid token and returns its claims
+  - token_use / client_id mismatches are rejected
+  - misconfiguration (no pool/client) fails closed
+  - internal async self-invokes bypass HTTP auth
+"""
+
+import os
+import sys
+import json
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import auth  # noqa: E402
+
+POOL_ENV = {
+    'ENABLE_AUTH': 'true',
+    'COGNITO_USER_POOL_ID': 'us-east-1_pool',
+    'COGNITO_APP_CLIENT_ID': 'client123',
+    'EXPECTED_TOKEN_USE': 'access',
+    'AWS_REGION': 'us-east-1',
+}
+
+
+def http_event(token=None, body=None, method='POST'):
+    headers = {}
+    if token is not None:
+        headers['Authorization'] = f'Bearer {token}'
+    return {
+        'requestContext': {'http': {'method': method}},
+        'headers': headers,
+        'body': json.dumps(body or {'action': 'direct', 'op': 'list_jobs'}),
+    }
+
+
+class TestAuthDisabled(unittest.TestCase):
+    def test_disabled_is_open(self):
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'false'}, clear=False):
+            ok, err, claims = auth.authorize(http_event())
+            self.assertTrue(ok)
+            self.assertIsNone(err)
+
+    def test_disabled_variants(self):
+        for val in ('', 'False', 'no', '0', 'FALSE'):
+            with mock.patch.dict(os.environ, {'ENABLE_AUTH': val}, clear=False):
+                self.assertFalse(auth.auth_enabled(), f"{val!r} should be disabled")
+
+
+class TestAuthEnabled(unittest.TestCase):
+    def test_missing_token_rejected(self):
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            ok, err, _ = auth.authorize(http_event(token=None))
+            self.assertFalse(ok)
+            self.assertIn('missing bearer token', err)
+
+    def test_unconfigured_fails_closed(self):
+        env = dict(POOL_ENV)
+        env['COGNITO_USER_POOL_ID'] = ''
+        with mock.patch.dict(os.environ, env, clear=False):
+            ok, err, _ = auth.authorize(http_event(token='x'))
+            self.assertFalse(ok)
+            self.assertIn('not configured', err)
+
+    def test_invalid_token_rejected(self):
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            with mock.patch.object(auth, '_get_jwk_client') as gk:
+                gk.return_value.get_signing_key_from_jwt.side_effect = Exception('bad key')
+                ok, err, _ = auth.authorize(http_event(token='tampered'))
+                self.assertFalse(ok)
+                self.assertIn('Unauthorized', err)
+
+    def test_valid_access_token_accepted(self):
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            with mock.patch.object(auth, '_get_jwk_client') as gk, \
+                 mock.patch.object(auth, 'jwt') as jwtmod:
+                gk.return_value.get_signing_key_from_jwt.return_value = mock.Mock(key='K')
+                jwtmod.decode.return_value = {'sub': 'u1', 'token_use': 'access', 'client_id': 'client123'}
+                ok, err, claims = auth.authorize(http_event(token='good'))
+                self.assertTrue(ok, err)
+                self.assertEqual(claims['sub'], 'u1')
+
+    def test_wrong_token_use_rejected(self):
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            with mock.patch.object(auth, '_get_jwk_client') as gk, \
+                 mock.patch.object(auth, 'jwt') as jwtmod:
+                gk.return_value.get_signing_key_from_jwt.return_value = mock.Mock(key='K')
+                jwtmod.decode.return_value = {'sub': 'u1', 'token_use': 'id'}
+                ok, err, _ = auth.authorize(http_event(token='good'))
+                self.assertFalse(ok)
+                self.assertIn('token_use', err)
+
+    def test_client_id_mismatch_rejected(self):
+        with mock.patch.dict(os.environ, POOL_ENV, clear=False):
+            with mock.patch.object(auth, '_get_jwk_client') as gk, \
+                 mock.patch.object(auth, 'jwt') as jwtmod:
+                gk.return_value.get_signing_key_from_jwt.return_value = mock.Mock(key='K')
+                jwtmod.decode.return_value = {'sub': 'u1', 'token_use': 'access', 'client_id': 'someoneelse'}
+                ok, err, _ = auth.authorize(http_event(token='good'))
+                self.assertFalse(ok)
+                self.assertIn('client_id', err)
+
+
+class TestBearerExtraction(unittest.TestCase):
+    def test_case_insensitive_header(self):
+        ev = {'headers': {'authorization': 'Bearer abc'}}
+        self.assertEqual(auth._bearer_token(ev), 'abc')
+
+    def test_raw_token_without_prefix(self):
+        ev = {'headers': {'Authorization': 'abc'}}
+        self.assertEqual(auth._bearer_token(ev), 'abc')
+
+    def test_no_header(self):
+        self.assertEqual(auth._bearer_token({'headers': {}}), '')
+
+
+class TestInternalInvoke(unittest.TestCase):
+    def test_internal_invoke_detection(self):
+        self.assertTrue(auth.is_internal_invoke({'_async_execute': True}))
+        self.assertTrue(auth.is_internal_invoke({'_async_download': True}))
+        self.assertFalse(auth.is_internal_invoke(http_event()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agentic-atx-platform/api/lambda/tests/test_auth.py
+++ b/agentic-atx-platform/api/lambda/tests/test_auth.py
@@ -132,9 +132,14 @@ class TestBearerExtraction(unittest.TestCase):
         ev = {'headers': {'authorization': 'Bearer abc'}}
         self.assertEqual(auth._bearer_token(ev), 'abc')
 
-    def test_raw_token_without_prefix(self):
+    def test_raw_token_without_prefix_rejected(self):
+        # Raw token without the Bearer scheme is not accepted (RFC 6750).
         ev = {'headers': {'Authorization': 'abc'}}
-        self.assertEqual(auth._bearer_token(ev), 'abc')
+        self.assertEqual(auth._bearer_token(ev), '')
+
+    def test_non_bearer_scheme_rejected(self):
+        ev = {'headers': {'Authorization': 'Basic dXNlcjpwYXNz'}}
+        self.assertEqual(auth._bearer_token(ev), '')
 
     def test_no_header(self):
         self.assertEqual(auth._bearer_token({'headers': {}}), '')

--- a/agentic-atx-platform/api/lambda/tests/test_handler_auth.py
+++ b/agentic-atx-platform/api/lambda/tests/test_handler_auth.py
@@ -1,0 +1,102 @@
+"""
+Handler-level auth enforcement tests for async_invoke_agent.lambda_handler.
+
+Ensures that when ENABLE_AUTH=true, EVERY HTTP entry path (submit, poll, direct,
+and unknown actions) is rejected with 401 unless API Gateway-validated JWT claims
+are present — i.e. there are no unauthenticated endpoints. Also verifies that
+internal async self-invokes and CORS preflight are handled correctly.
+
+boto3 is mocked so the handler imports without AWS access.
+
+Run from agentic-atx-platform/api/lambda:
+    python3 -m unittest discover -s tests -v
+"""
+
+import os
+import sys
+import json
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+
+def _import_handler():
+    """Import the handler with boto3 fully mocked."""
+    boto3_mock = mock.MagicMock()
+    with mock.patch.dict(sys.modules, {'boto3': boto3_mock}):
+        # Fresh import each time so module-level boto3 clients are the mocks
+        for mod in ('async_invoke_agent',):
+            sys.modules.pop(mod, None)
+        import async_invoke_agent
+        return async_invoke_agent
+
+
+def http_event(action='submit', extra=None, token=None, method='POST'):
+    body = {'action': action}
+    if action == 'submit':
+        body['prompt'] = 'do something'
+    if extra:
+        body.update(extra)
+    headers = {}
+    if token is not None:
+        headers['Authorization'] = f'Bearer {token}'
+    return {'requestContext': {'http': {'method': method}}, 'headers': headers, 'body': json.dumps(body)}
+
+
+HTTP_ACTIONS = ['submit', 'poll', 'direct', 'bogus-action']
+
+
+class TestHandlerAuthEnabled(unittest.TestCase):
+    def setUp(self):
+        self.handler = _import_handler()
+
+    def test_all_http_actions_rejected_without_token(self):
+        # Auth on + no token => authorize() returns False => 401 for every action.
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'true', 'COGNITO_USER_POOL_ID': 'p', 'COGNITO_APP_CLIENT_ID': 'c'}, clear=False):
+            for action in HTTP_ACTIONS:
+                ev = http_event(action=action, token=None)
+                resp = self.handler.lambda_handler(ev, None)
+                self.assertEqual(resp['statusCode'], 401,
+                                 f"action={action} should be 401 without token, got {resp['statusCode']}")
+                self.assertIn('Unauthorized', json.loads(resp['body'])['error'])
+
+    def test_options_preflight_allowed_without_auth(self):
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'true'}, clear=False):
+            resp = self.handler.lambda_handler(http_event(method='OPTIONS', token=None), None)
+            self.assertEqual(resp['statusCode'], 200)
+
+    def test_internal_async_execute_bypasses_http_auth(self):
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'true'}, clear=False):
+            with mock.patch.object(self.handler, '_execute_agentcore', return_value={'ok': True}) as m:
+                resp = self.handler.lambda_handler(
+                    {'_async_execute': True, 'request_id': 'r1', 'prompt': 'p'}, None)
+                m.assert_called_once()
+                self.assertEqual(resp, {'ok': True})
+
+    def test_valid_token_passes_auth_gate(self):
+        # Mock the auth module the handler imports so a valid token passes the gate.
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'true'}, clear=False):
+            import auth as auth_mod
+            with mock.patch.object(auth_mod, 'authorize', return_value=(True, None, {'sub': 'u'})), \
+                 mock.patch.object(self.handler, '_handle_submit', return_value=self.handler.cors_response(200, '{"status":"SUBMITTED"}')) as m:
+                ev = http_event(action='submit', token='good')
+                resp = self.handler.lambda_handler(ev, None)
+                m.assert_called_once()
+                self.assertEqual(resp['statusCode'], 200)
+
+
+class TestHandlerAuthDisabled(unittest.TestCase):
+    def setUp(self):
+        self.handler = _import_handler()
+
+    def test_open_mode_does_not_require_token(self):
+        with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'false'}, clear=False):
+            with mock.patch.object(self.handler, '_handle_submit', return_value=self.handler.cors_response(200, '{}')) as m:
+                resp = self.handler.lambda_handler(http_event(action='submit', token=None), None)
+                m.assert_called_once()
+                self.assertEqual(resp['statusCode'], 200)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agentic-atx-platform/api/lambda/tests/test_handler_auth.py
+++ b/agentic-atx-platform/api/lambda/tests/test_handler_auth.py
@@ -75,10 +75,9 @@ class TestHandlerAuthEnabled(unittest.TestCase):
                 self.assertEqual(resp, {'ok': True})
 
     def test_valid_token_passes_auth_gate(self):
-        # Mock the auth module the handler imports so a valid token passes the gate.
+        # authorize is imported at module top, so patch the handler's bound reference.
         with mock.patch.dict(os.environ, {'ENABLE_AUTH': 'true'}, clear=False):
-            import auth as auth_mod
-            with mock.patch.object(auth_mod, 'authorize', return_value=(True, None, {'sub': 'u'})), \
+            with mock.patch.object(self.handler, 'authorize', return_value=(True, None, {'sub': 'u'})), \
                  mock.patch.object(self.handler, '_handle_submit', return_value=self.handler.cors_response(200, '{"status":"SUBMITTED"}')) as m:
                 ev = http_event(action='submit', token='good')
                 resp = self.handler.lambda_handler(ev, None)

--- a/agentic-atx-platform/api/lambda/tests/test_template_no_open_endpoints.py
+++ b/agentic-atx-platform/api/lambda/tests/test_template_no_open_endpoints.py
@@ -48,10 +48,21 @@ class TestTemplateSecurity(unittest.TestCase):
             self.assertIn(res, self.text)
         self.assertGreaterEqual(self.text.count('Condition: AuthEnabled'), 2)
 
-    def test_single_httpapi_route(self):
-        events = re.findall(r'Type:\s*HttpApi\b', self.text)
-        self.assertEqual(len(events), 1, f"expected exactly 1 HttpApi event, found {len(events)}")
-        self.assertIn('Path: /orchestrate', self.text)
+    def test_jwt_authorizer_conditional(self):
+        # A JWT authorizer is declared and gated on AuthEnabled.
+        self.assertRegex(self.text, r'HttpApiJwtAuthorizer:\s*\n\s*Type:\s*AWS::ApiGatewayV2::Authorizer\s*\n\s*Condition:\s*AuthEnabled')
+        self.assertIn('AuthorizerType: JWT', self.text)
+        self.assertIn('cognito-idp.', self.text)
+
+    def test_route_auth_is_conditional(self):
+        # The route's AuthorizationType flips JWT/NONE and AuthorizerId is conditional.
+        self.assertRegex(self.text, r'AuthorizationType:\s*!If\s*\[\s*AuthEnabled,\s*"JWT",\s*"NONE"\s*\]')
+        self.assertRegex(self.text, r'AuthorizerId:\s*!If\s*\[\s*AuthEnabled,\s*!Ref HttpApiJwtAuthorizer,\s*!Ref "AWS::NoValue"\s*\]')
+
+    def test_single_route(self):
+        # Exactly one route, and it's POST /orchestrate.
+        routes = re.findall(r'RouteKey:\s*"POST /orchestrate"', self.text)
+        self.assertEqual(len(routes), 1, f"expected exactly 1 /orchestrate route, found {len(routes)}")
 
     def test_no_public_function_urls(self):
         self.assertNotIn('AWS::Lambda::Url', self.text)

--- a/agentic-atx-platform/api/lambda/tests/test_template_no_open_endpoints.py
+++ b/agentic-atx-platform/api/lambda/tests/test_template_no_open_endpoints.py
@@ -1,0 +1,89 @@
+"""
+Static checks guaranteeing there are no unauthenticated endpoints once auth is on.
+
+Auth is enforced in the Lambda (auth.py) rather than a gateway authorizer (SAM can't
+toggle a default JWT authorizer on one HttpApi). These tests assert the security
+invariants that keep the surface closed:
+
+  1. EnableAuth parameter + AuthEnabled condition exist; Cognito resources are gated.
+  2. There is exactly one HTTP API route (/orchestrate) — no stray public routes.
+  3. No AWS::Lambda::Url / FunctionUrlConfig (those bypass the handler's auth gate).
+  4. The handler calls auth.authorize() before routing any HTTP action, and the
+     OPTIONS/preflight short-circuit happens before action routing.
+  5. auth.py fails closed (rejects) when enabled but unconfigured or token invalid.
+
+Run from agentic-atx-platform/api/lambda:
+    python3 -m unittest discover -s tests -v
+"""
+
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(__file__)
+TEMPLATE = os.path.abspath(os.path.join(HERE, '..', '..', '..', 'sam', 'template.yaml'))
+HANDLER = os.path.abspath(os.path.join(HERE, '..', 'async_invoke_agent.py'))
+
+
+class TestTemplateSecurity(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with open(TEMPLATE) as f:
+            cls.text = f.read()
+        with open(HANDLER) as f:
+            cls.handler = f.read()
+
+    def test_enable_auth_parameter_present(self):
+        self.assertIn('EnableAuth:', self.text)
+        self.assertRegex(self.text, r'AuthEnabled:\s*!Equals\s*\[\s*!Ref EnableAuth,\s*"true"\s*\]')
+
+    def test_auth_enabled_by_default(self):
+        # Secure by default: the EnableAuth parameter must default to "true".
+        m = re.search(r'EnableAuth:\s*\n\s*Type:\s*String\s*\n\s*Default:\s*"(\w+)"', self.text)
+        self.assertIsNotNone(m, "EnableAuth parameter/Default not found")
+        self.assertEqual(m.group(1), 'true', "EnableAuth must default to 'true' (secure by default)")
+
+    def test_cognito_resources_conditional(self):
+        for res in ('UserPool:', 'UserPoolClient:'):
+            self.assertIn(res, self.text)
+        self.assertGreaterEqual(self.text.count('Condition: AuthEnabled'), 2)
+
+    def test_single_httpapi_route(self):
+        events = re.findall(r'Type:\s*HttpApi\b', self.text)
+        self.assertEqual(len(events), 1, f"expected exactly 1 HttpApi event, found {len(events)}")
+        self.assertIn('Path: /orchestrate', self.text)
+
+    def test_no_public_function_urls(self):
+        self.assertNotIn('AWS::Lambda::Url', self.text)
+        self.assertNotIn('FunctionUrlConfig', self.text)
+
+    def test_lambda_receives_auth_config(self):
+        for env in ('ENABLE_AUTH:', 'COGNITO_USER_POOL_ID:', 'COGNITO_APP_CLIENT_ID:'):
+            self.assertIn(env, self.text)
+
+    def test_handler_enforces_auth_before_routing(self):
+        # authorize() must be invoked, and its failure must return before action routing.
+        self.assertIn('from auth import authorize', self.handler)
+        self.assertIn('authorize(event)', self.handler)
+        idx_auth = self.handler.index('authorize(event)')
+        idx_submit = self.handler.index("action == 'submit'")
+        self.assertLess(idx_auth, idx_submit, "auth gate must run before action routing")
+        # A 401 must be returned on failure.
+        self.assertRegex(self.handler, r'return cors_response\(401')
+
+
+class TestAuthFailsClosed(unittest.TestCase):
+    def test_unconfigured_when_enabled_rejects(self):
+        import sys
+        sys.path.insert(0, os.path.abspath(os.path.join(HERE, '..')))
+        import auth
+        from unittest import mock
+        env = {'ENABLE_AUTH': 'true', 'COGNITO_USER_POOL_ID': '', 'COGNITO_APP_CLIENT_ID': ''}
+        with mock.patch.dict(os.environ, env, clear=False):
+            ev = {'headers': {'Authorization': 'Bearer x'}, 'requestContext': {'http': {'method': 'POST'}}}
+            ok, err, _ = auth.authorize(ev)
+            self.assertFalse(ok)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -91,6 +91,31 @@ The agentic platform exposes a single HTTP API (`POST /orchestrate`). It is
 - Self-signup is disabled; create users via `admin-create-user`.
 - Restrict `AllowedOrigin` to the exact UI URL (avoid `*`) when auth is enabled.
 
+### Private API endpoint (network isolation)
+
+The `/orchestrate` API is a **public** regional endpoint protected by the Cognito
+JWT authorizer. If you have private network access to AWS (VPN, Direct Connect, or
+in-VPC clients) and want to remove public internet exposure entirely, consider a
+private API. Important trade-offs:
+
+- **HTTP API (API Gateway v2) does not support private endpoints.** Private API is
+  a REST API (v1) feature — it uses an interface VPC endpoint (`execute-api`) plus a
+  resource policy that restricts access to your VPC/VPCe. Making this API private is
+  therefore a migration from HTTP API → REST API, not a config toggle.
+- **A browser UI cannot reach a private endpoint** over the public internet. Going
+  private only makes sense if the UI is also internal (VPN, WorkSpaces, or an
+  in-VPC/internal ALB front end). For a public browser SPA, keep the public endpoint
+  and rely on the JWT authorizer (and optionally WAF — see below).
+- **WAF caveat:** AWS WAF cannot be associated with an HTTP API. To add WAF
+  (e.g. rate-based rules, IP allowlists) you would either route the API through
+  CloudFront as an origin and attach WAF to the distribution, or migrate to REST API
+  and attach WAF directly. WAF can also be attached to the Cognito user pool to
+  protect the login/token endpoints.
+
+**Recommendation:** for the public-UI deployment, keep the public HTTP API + Cognito
+JWT auth; add CloudFront-fronted WAF for rate limiting/IP restriction if needed. Use
+a private REST API only when the entire access path (including the UI) is internal.
+
 ### Container REST API (scaled-execution-containers)
 
 The separate `scaled-execution-containers` REST API uses **IAM authentication**

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -64,38 +64,37 @@ Security considerations and best practices for the AWS Transform CLI container.
 - Enable VPC Flow Logs for audit
 - Monitor network traffic patterns with CloudWatch
 
-## REST API Security
+## API Security
 
-### IAM Authentication
+### Agentic Platform HTTP API (Cognito JWT)
+
+The agentic platform exposes a single HTTP API (`POST /orchestrate`). It is
+**secure by default** (`EnableAuth=true`).
 
 ✅ **Implemented:**
-- AWS IAM authentication (AWS Signature V4)
-- No API keys or shared secrets
-- IAM user/role permissions with `execute-api:Invoke`
-- Full CloudTrail audit trail
+- Cognito User Pool authentication; UI signs in via the Hosted UI (OAuth2
+  authorization-code + PKCE)
+- The `atx-async-invoke-agent` Lambda verifies the Cognito JWT on every request
+  (JWKS signature, issuer, audience, expiry, token_use, client_id) and rejects
+  unauthenticated calls with `401`
+- Fails closed: if auth is enabled but misconfigured, requests are denied
+- CORS restricted to the configured UI origin (`AllowedOrigin`)
+- Internal async self-invokes (Lambda→Lambda) and CORS preflight bypass the gate
 
-⚠️ **Recommendations:**
-- Grant users `execute-api:Invoke` permission on the API
-- Use temporary credentials (AWS SSO or STS)
-- Monitor API access via CloudTrail
-- Set up CloudWatch Alarms for unusual activity
+⚠️ **Notes / recommendations:**
+- Auth is enforced in the Lambda rather than an API Gateway JWT authorizer
+  (SAM cannot conditionally toggle a default authorizer on one HTTP API).
+  Unauthenticated requests reach the function but are rejected before any
+  Batch/AgentCore work runs.
+- `ENABLE_AUTH=false` deploys an **open** API for the blog/demo walkthrough only —
+  do not use open mode for shared or internet-reachable environments.
+- Self-signup is disabled; create users via `admin-create-user`.
+- Restrict `AllowedOrigin` to the exact UI URL (avoid `*`) when auth is enabled.
 
-**Grant API access:**
-```bash
-aws iam put-user-policy \
-  --user-name YOUR_USERNAME \
-  --policy-name InvokeATXApi \
-  --policy-document '{
-    "Version": "2012-10-17",
-    "Statement": [{
-      "Effect": "Allow",
-      "Action": "execute-api:Invoke",
-      "Resource": "arn:aws:execute-api:*:*:*/prod/*"
-    }]
-  }'
-```
+### Container REST API (scaled-execution-containers)
 
-**See:** The orchestrator handles API authentication via AgentCore IAM roles.
+The separate `scaled-execution-containers` REST API uses **IAM authentication**
+(AWS Signature V4); callers need `execute-api:Invoke`. See that project's docs.
 
 ## Secrets Management
 
@@ -283,6 +282,9 @@ aws ecr start-image-scan \
 ### Before Deployment
 
 - [ ] Review and customize IAM policies
+- [ ] Keep `EnableAuth=true` (default) for any shared/reachable environment
+- [ ] Set `AllowedOrigin` to the exact UI URL (not `*`) when auth is enabled
+- [ ] Create Cognito users via `admin-create-user` (self-signup is disabled)
 - [ ] Configure VPC and subnets
 - [ ] Set up security groups
 - [ ] Enable ECR image scanning

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -74,18 +74,18 @@ The agentic platform exposes a single HTTP API (`POST /orchestrate`). It is
 ✅ **Implemented:**
 - Cognito User Pool authentication; UI signs in via the Hosted UI (OAuth2
   authorization-code + PKCE)
-- The `atx-async-invoke-agent` Lambda verifies the Cognito JWT on every request
-  (JWKS signature, issuer, audience, expiry, token_use, client_id) and rejects
-  unauthenticated calls with `401`
+- **API Gateway JWT authorizer** on the `/orchestrate` route: unauthenticated or
+  invalid tokens are rejected with `401` at the edge, before the Lambda is invoked
+- Defense-in-depth: the `atx-async-invoke-agent` Lambda (`auth.py`) also verifies
+  the Cognito JWT (JWKS signature, issuer, audience, expiry, token_use, client_id),
+  trusting gateway-validated claims when present
 - Fails closed: if auth is enabled but misconfigured, requests are denied
 - CORS restricted to the configured UI origin (`AllowedOrigin`)
 - Internal async self-invokes (Lambda→Lambda) and CORS preflight bypass the gate
 
 ⚠️ **Notes / recommendations:**
-- Auth is enforced in the Lambda rather than an API Gateway JWT authorizer
-  (SAM cannot conditionally toggle a default authorizer on one HTTP API).
-  Unauthenticated requests reach the function but are rejected before any
-  Batch/AgentCore work runs.
+- The authorizer is implemented with raw `AWS::ApiGatewayV2` resources (not SAM's
+  HttpApi `Auth` shorthand) so it can be attached conditionally on `EnableAuth`.
 - `ENABLE_AUTH=false` deploys an **open** API for the blog/demo walkthrough only —
   do not use open mode for shared or internet-reachable environments.
 - Self-signup is disabled; create users via `admin-create-user`.

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -101,9 +101,12 @@ short-lived (60 min). Mitigations against token theft via XSS:
 - The UI ships a **Content-Security-Policy** (`script-src 'self'`, restricted
   `connect-src`) as a `<meta>` tag — this blocks injected/remote scripts, the primary
   vector for reading the token.
-- For stronger enforcement, also serve CSP as a real **HTTP header** via a CloudFront
-  response-headers policy (some directives, e.g. `frame-ancestors`, only take effect
-  as a header), along with `Strict-Transport-Security` and `X-Content-Type-Options`.
+- **Planned follow-up:** serve security headers via a **CloudFront response-headers
+  policy** — CSP as a real HTTP header plus `frame-ancestors`/`X-Frame-Options`
+  (clickjacking), `Strict-Transport-Security` (HSTS), `X-Content-Type-Options: nosniff`,
+  and `Referrer-Policy`. These are header-only directives (a `<meta>` CSP cannot set
+  them), so the meta tag deliberately omits `frame-ancestors`. AWS's managed
+  `SecurityHeadersPolicy` covers most of these with minimal config.
 - To eliminate browser token storage entirely, use a **backend-for-frontend (BFF)**:
   exchange the code server-side and keep the session in an `HttpOnly`, `Secure`,
   `SameSite` cookie. This is a larger change (the API Gateway JWT authorizer expects an

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -91,6 +91,24 @@ The agentic platform exposes a single HTTP API (`POST /orchestrate`). It is
 - Self-signup is disabled; create users via `admin-create-user`.
 - Restrict `AllowedOrigin` to the exact UI URL (avoid `*`) when auth is enabled.
 
+### Browser token storage & XSS
+
+The UI holds the **access token** in `sessionStorage` (cleared on tab close) and
+does **not** store a refresh token in the browser — on expiry the user re-auths via
+the Hosted UI, so there is no long-lived credential to steal. Access tokens are
+short-lived (60 min). Mitigations against token theft via XSS:
+
+- The UI ships a **Content-Security-Policy** (`script-src 'self'`, restricted
+  `connect-src`) as a `<meta>` tag — this blocks injected/remote scripts, the primary
+  vector for reading the token.
+- For stronger enforcement, also serve CSP as a real **HTTP header** via a CloudFront
+  response-headers policy (some directives, e.g. `frame-ancestors`, only take effect
+  as a header), along with `Strict-Transport-Security` and `X-Content-Type-Options`.
+- To eliminate browser token storage entirely, use a **backend-for-frontend (BFF)**:
+  exchange the code server-side and keep the session in an `HttpOnly`, `Secure`,
+  `SameSite` cookie. This is a larger change (the API Gateway JWT authorizer expects an
+  `Authorization` header, not a cookie) and is left as a documented hardening option.
+
 ### Extending auth: federation (SAML / OIDC / SSO)
 
 Auth is intentionally built on Cognito + the Hosted UI so it can be extended to an

--- a/agentic-atx-platform/docs/SECURITY.md
+++ b/agentic-atx-platform/docs/SECURITY.md
@@ -91,6 +91,32 @@ The agentic platform exposes a single HTTP API (`POST /orchestrate`). It is
 - Self-signup is disabled; create users via `admin-create-user`.
 - Restrict `AllowedOrigin` to the exact UI URL (avoid `*`) when auth is enabled.
 
+### Extending auth: federation (SAML / OIDC / SSO)
+
+Auth is intentionally built on Cognito + the Hosted UI so it can be extended to an
+organization's existing identity provider **without changing the UI or API** — both
+already redirect to the Hosted UI and consume Cognito-issued JWTs, so the token the
+gateway authorizer validates is identical regardless of how the user signed in.
+
+To federate with a corporate IdP:
+
+- **SAML 2.0** (Okta, Microsoft Entra ID / Azure AD, PingFederate, ADFS, etc.):
+  add an `AWS::Cognito::UserPoolIdentityProvider` with `ProviderType: SAML` pointing
+  at the IdP metadata (URL or file), map SAML assertion attributes (email, name,
+  groups) to Cognito attributes, and add the provider to the app client's
+  `SupportedIdentityProviders`. Register Cognito's ACS URL + entity ID as a relying
+  party on the IdP side.
+- **OIDC** (if the IdP speaks OpenID Connect): same pattern with
+  `ProviderType: OIDC` — often simpler than SAML.
+- **AWS workforce SSO:** IAM Identity Center is an option for AWS-centric orgs.
+
+Notes:
+- No app changes are required — federation is a Cognito-side configuration.
+- For **authorization** (roles/permissions), map the IdP's group/role claims into
+  the token and gate actions in the app (see the scopes/groups discussion).
+- This sample ships with Cognito-native users by default; federation is left as a
+  documented extension point so teams can wire in their own IdP for their use case.
+
 ### Private API endpoint (network isolation)
 
 The `/orchestrate` API is a **public** regional endpoint protected by the Cognito

--- a/agentic-atx-platform/sam/deploy.sh
+++ b/agentic-atx-platform/sam/deploy.sh
@@ -73,7 +73,11 @@ echo "4. Building SAM application..."
 SAM_CLI_CONTAINER_TOOL=docker sam build 2>&1
 echo ""
 
-echo "5. Deploying SAM stack..."
+# Auth is secure-by-default (EnableAuth=true). For the open blog/demo walkthrough,
+# export ENABLE_AUTH=false before running this script.
+AUTH_OVERRIDE="EnableAuth=${ENABLE_AUTH:-true}"
+
+echo "5. Deploying SAM stack... (auth: ${ENABLE_AUTH:-true})"
 sam deploy \
     --stack-name AtxAgentCoreSAM \
     --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
@@ -82,6 +86,7 @@ sam deploy \
         SourceBucketName="${SOURCE_BUCKET}" \
         AwsRegion="${REGION}" \
         ${MODEL_OVERRIDE} \
+        ${AUTH_OVERRIDE} \
         OrchestratorContainerUri="${ORCH_ECR_URI}:latest" \
     --no-confirm-changeset \
     --no-fail-on-empty-changeset \

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -219,14 +219,15 @@ Resources:
                   - !Sub "arn:aws:s3:::${OutputBucketName}/*"
                   - !Sub "arn:aws:s3:::${SourceBucketName}"
                   - !Sub "arn:aws:s3:::${SourceBucketName}/*"
-              # DescribeJobs has no resource-level ARN support in AWS Batch
-              # (jobs are described by dynamic job id), so it requires "*".
+              # ListJobs and DescribeJobs do NOT support resource-level permissions
+              # in AWS Batch — scoping them to an ARN silently denies the call, so
+              # they must use "*". Only SubmitJob supports queue/definition ARNs.
               - Effect: Allow
                 Action: batch:DescribeJobs
                 Resource: "*"
               - Effect: Allow
                 Action: batch:ListJobs
-                Resource: !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-queue/atx-job-queue"
+                Resource: "*"
               - Effect: Allow
                 Action: batch:SubmitJob
                 Resource:

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -139,10 +139,16 @@ Resources:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
                 Resource: "*"
+              # SubmitJob scoped to the ATX job queue + definition; DescribeJobs
+              # has no resource-level support in AWS Batch, so it requires "*".
               - Effect: Allow
-                Action:
-                  - batch:SubmitJob
-                  - batch:DescribeJobs
+                Action: batch:SubmitJob
+                Resource:
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-queue/atx-job-queue"
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-definition/atx-transform-job"
+                  - !Sub "arn:aws:batch:${AwsRegion}:${AWS::AccountId}:job-definition/atx-transform-job:*"
+              - Effect: Allow
+                Action: batch:DescribeJobs
                 Resource: "*"
               - Effect: Allow
                 Action:

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -273,27 +273,30 @@ Resources:
           ALLOWED_ORIGIN: !Ref AllowedOrigin
           COGNITO_USER_POOL_ID: !If [AuthEnabled, !Ref UserPool, ""]
           COGNITO_APP_CLIENT_ID: !If [AuthEnabled, !Ref UserPoolClient, ""]
-      Events:
-        Orchestrate:
-          Type: HttpApi
-          Properties:
-            Path: /orchestrate
-            Method: POST
-            ApiId: !Ref HttpApi
+
+  # Allow API Gateway to invoke the async function (explicit, since the HttpApi
+  # event is replaced by raw ApiGatewayV2 resources below).
+  AsyncInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AsyncInvokeFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AwsRegion}:${AWS::AccountId}:${HttpApi}/*/*/orchestrate"
 
   # ========================================
-  # 3. HTTP API Gateway
+  # 3. HTTP API Gateway (raw ApiGatewayV2 so the JWT authorizer can be conditional)
   # ========================================
-  # A single HTTP API. Authentication is enforced inside the Lambda (auth.py) based
-  # on the EnableAuth parameter, rather than via a gateway JWT authorizer — SAM does
-  # not support toggling a default authorizer on/off on one HttpApi, and Lambda-side
-  # verification keeps a single clean toggle. When EnableAuth=true the function
-  # cryptographically validates the Cognito JWT (issuer/audience/signature/expiry)
-  # and rejects anything unauthenticated with 401.
+  # When EnableAuth=true, a JWT authorizer (Cognito) is created and attached to the
+  # /orchestrate route (AuthorizationType: JWT). When false, the route is open
+  # (AuthorizationType: NONE). Using raw ApiGatewayV2 resources lets these properties
+  # be conditional via !If — which SAM's HttpApi `Auth` shorthand does not allow.
+  # The Lambda (auth.py) still verifies the JWT as defense-in-depth.
   HttpApi:
-    Type: AWS::Serverless::HttpApi
+    Type: AWS::ApiGatewayV2::Api
     Properties:
-      StageName: prod
+      Name: AtxAgentCoreSAM
+      ProtocolType: HTTP
       CorsConfiguration:
         AllowOrigins:
           - !Ref AllowedOrigin
@@ -304,6 +307,45 @@ Resources:
           - content-type
           - authorization
         MaxAge: 86400
+
+  HttpApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt AsyncInvokeFunction.Arn
+      PayloadFormatVersion: "2.0"
+
+  # Cognito JWT authorizer — only created when auth is enabled.
+  HttpApiJwtAuthorizer:
+    Type: AWS::ApiGatewayV2::Authorizer
+    Condition: AuthEnabled
+    Properties:
+      ApiId: !Ref HttpApi
+      AuthorizerType: JWT
+      Name: CognitoJwtAuthorizer
+      IdentitySource:
+        - "$request.header.Authorization"
+      JwtConfiguration:
+        Issuer: !Sub "https://cognito-idp.${AwsRegion}.amazonaws.com/${UserPool}"
+        Audience:
+          - !Ref UserPoolClient
+
+  HttpApiRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: "POST /orchestrate"
+      Target: !Sub "integrations/${HttpApiIntegration}"
+      AuthorizationType: !If [AuthEnabled, "JWT", "NONE"]
+      AuthorizerId: !If [AuthEnabled, !Ref HttpApiJwtAuthorizer, !Ref "AWS::NoValue"]
+
+  HttpApiStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref HttpApi
+      StageName: prod
+      AutoDeploy: true
 
   # ========================================
   # 4. Cognito (created only when EnableAuth=true)

--- a/agentic-atx-platform/sam/template.yaml
+++ b/agentic-atx-platform/sam/template.yaml
@@ -27,6 +27,30 @@ Parameters:
     Type: String
     Default: ""
     Description: AgentCore runtime ARN (set after the orchestrator is deployed). Preserved across redeploys.
+  EnableAuth:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >
+      Secure by default. When "true" (default), the API requires a valid Cognito JWT
+      (verified in the Lambda) and provisions a Cognito User Pool. Set to "false" only
+      for the open blog/demo walkthrough where no authentication is desired.
+  AllowedOrigin:
+    Type: String
+    Default: "*"
+    Description: >
+      CORS allowed origin. Use "*" for demo; set to the CloudFront/UI URL when auth is enabled.
+  CognitoCallbackUrl:
+    Type: String
+    Default: "https://localhost:3000"
+    Description: OAuth callback URL for the Cognito hosted UI (the deployed UI URL).
+  CognitoLogoutUrl:
+    Type: String
+    Default: "https://localhost:3000"
+    Description: OAuth sign-out redirect URL for the Cognito hosted UI.
+
+Conditions:
+  AuthEnabled: !Equals [!Ref EnableAuth, "true"]
 
 Globals:
   Function:
@@ -244,6 +268,11 @@ Resources:
           RESULT_BUCKET: !Ref OutputBucketName
           JOB_QUEUE_NAME: atx-job-queue
           JOB_DEFINITION_NAME: atx-transform-job
+          ENABLE_AUTH: !Ref EnableAuth
+          EXPECTED_TOKEN_USE: "access"
+          ALLOWED_ORIGIN: !Ref AllowedOrigin
+          COGNITO_USER_POOL_ID: !If [AuthEnabled, !Ref UserPool, ""]
+          COGNITO_APP_CLIENT_ID: !If [AuthEnabled, !Ref UserPoolClient, ""]
       Events:
         Orchestrate:
           Type: HttpApi
@@ -255,18 +284,86 @@ Resources:
   # ========================================
   # 3. HTTP API Gateway
   # ========================================
+  # A single HTTP API. Authentication is enforced inside the Lambda (auth.py) based
+  # on the EnableAuth parameter, rather than via a gateway JWT authorizer — SAM does
+  # not support toggling a default authorizer on/off on one HttpApi, and Lambda-side
+  # verification keeps a single clean toggle. When EnableAuth=true the function
+  # cryptographically validates the Cognito JWT (issuer/audience/signature/expiry)
+  # and rejects anything unauthenticated with 401.
   HttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: prod
       CorsConfiguration:
         AllowOrigins:
-          - "*"
+          - !Ref AllowedOrigin
         AllowMethods:
           - POST
+          - OPTIONS
         AllowHeaders:
           - content-type
+          - authorization
         MaxAge: 86400
+
+  # ========================================
+  # 4. Cognito (created only when EnableAuth=true)
+  # ========================================
+  UserPool:
+    Type: AWS::Cognito::UserPool
+    Condition: AuthEnabled
+    Properties:
+      UserPoolName: atx-transform-users
+      AutoVerifiedAttributes:
+        - email
+      UsernameAttributes:
+        - email
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 12
+          RequireUppercase: true
+          RequireLowercase: true
+          RequireNumbers: true
+          RequireSymbols: true
+
+  UserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Condition: AuthEnabled
+    Properties:
+      ClientName: atx-transform-ui
+      UserPoolId: !Ref UserPool
+      GenerateSecret: false
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthFlows:
+        - code
+      AllowedOAuthScopes:
+        - email
+        - openid
+        - profile
+      SupportedIdentityProviders:
+        - COGNITO
+      CallbackURLs:
+        - !Ref CognitoCallbackUrl
+      LogoutURLs:
+        - !Ref CognitoLogoutUrl
+      ExplicitAuthFlows:
+        - ALLOW_USER_SRP_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
+      AccessTokenValidity: 60
+      IdTokenValidity: 60
+      RefreshTokenValidity: 30
+      TokenValidityUnits:
+        AccessToken: minutes
+        IdToken: minutes
+        RefreshToken: days
+
+  UserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Condition: AuthEnabled
+    Properties:
+      Domain: !Sub "atx-transform-${AWS::AccountId}"
+      UserPoolId: !Ref UserPool
 
 Outputs:
   ApiEndpoint:
@@ -281,3 +378,15 @@ Outputs:
   AsyncLambdaName:
     Description: Async invoke Lambda function name
     Value: !Ref AsyncInvokeFunction
+  UserPoolId:
+    Description: Cognito User Pool ID (only when auth enabled)
+    Condition: AuthEnabled
+    Value: !Ref UserPool
+  UserPoolClientId:
+    Description: Cognito User Pool App Client ID (only when auth enabled)
+    Condition: AuthEnabled
+    Value: !Ref UserPoolClient
+  CognitoHostedUiDomain:
+    Description: Cognito hosted UI domain (only when auth enabled)
+    Condition: AuthEnabled
+    Value: !Sub "https://atx-transform-${AWS::AccountId}.auth.${AwsRegion}.amazoncognito.com"

--- a/agentic-atx-platform/ui/.env.example
+++ b/agentic-atx-platform/ui/.env.example
@@ -1,0 +1,39 @@
+# ATX Transform UI — build-time configuration (Vite)
+#
+# These are BUILD-TIME variables: Vite bakes them into the bundle during
+# `npx vite build`. Changing them requires a rebuild + redeploy (not a runtime toggle).
+#
+# Usage:
+#   1. Copy this file to `.env` in this directory:   cp .env.example .env
+#   2. Fill in the values from your SAM stack outputs (see below).
+#   3. Build:  npx vite build   (Vite auto-loads .env)
+#
+# `.env` is gitignored — do not commit real values. You can also pass these
+# inline instead of using a file:
+#   VITE_API_ENDPOINT=... VITE_AUTH_ENABLED=true ... npx vite build
+#
+# NOTE: VITE_API_ENDPOINT and VITE_COGNITO_DOMAIN also drive the generated
+# Content-Security-Policy (see vite.config.js). If they are wrong, the browser
+# will block API/login calls.
+
+# API Gateway endpoint — stack output `ApiEndpoint` (include the /prod stage).
+# Leave unset for local dev to use the Vite proxy at /api.
+VITE_API_ENDPOINT=https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/prod
+
+# ── Authentication (Cognito) ────────────────────────────────────────────────
+# Set to "true" to require login (recommended / secure by default on the backend).
+# Leave "false"/unset for the open blog-demo build.
+VITE_AUTH_ENABLED=true
+
+# Cognito hosted UI domain — stack output `CognitoHostedUiDomain`.
+VITE_COGNITO_DOMAIN=https://atx-transform-<account-id>.auth.us-east-1.amazoncognito.com
+
+# Cognito app client id — stack output `UserPoolClientId`.
+VITE_COGNITO_CLIENT_ID=xxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# OAuth redirect URI — your deployed UI URL (defaults to window.location.origin).
+VITE_AUTH_REDIRECT_URI=https://xxxxxxxxxxxxx.cloudfront.net
+
+# ── Optional: dashboard mock data (default off = live data) ─────────────────
+# VITE_METRICS_MOCK=false
+# VITE_KI_MOCK=false

--- a/agentic-atx-platform/ui/index.html
+++ b/agentic-atx-platform/ui/index.html
@@ -11,7 +11,7 @@
       directives only take effect as a real HTTP header — set those via the
       CloudFront response-headers policy for full coverage (see docs/SECURITY.md).
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com https://cognito-idp.*.amazonaws.com; base-uri 'self'; object-src 'none'; frame-ancestors 'none'" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; frame-ancestors 'none'" />
     <title>ATX Transform</title>
   </head>
   <body>

--- a/agentic-atx-platform/ui/index.html
+++ b/agentic-atx-platform/ui/index.html
@@ -4,14 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!--
-      Content-Security-Policy: primary XSS mitigation. `script-src 'self'` blocks
-      injected/remote scripts (which is what would read the access token from
-      sessionStorage), and connect-src limits where the page can send data to
-      same-origin + AWS API Gateway + Cognito. Note: frame-ancestors and some
-      directives only take effect as a real HTTP header — set those via the
-      CloudFront response-headers policy for full coverage (see docs/SECURITY.md).
+      Content-Security-Policy: primary XSS mitigation. Injected at build time by the
+      cspPlugin in vite.config.js so connect-src is scoped to the EXACT API Gateway
+      and Cognito origins this build targets (not a broad *.amazonaws.com wildcard).
+      `script-src 'self'` blocks injected/remote scripts (which would read the access
+      token from sessionStorage). Header-only directives (frame-ancestors, HSTS,
+      X-Frame-Options) are intentionally NOT in this meta tag — they're planned via a
+      CloudFront response-headers policy (see docs/SECURITY.md).
     -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.amazonaws.com https://*.amazoncognito.com; base-uri 'self'; object-src 'none'; frame-ancestors 'none'" />
+    <!--CSP_META-->
     <title>ATX Transform</title>
   </head>
   <body>

--- a/agentic-atx-platform/ui/index.html
+++ b/agentic-atx-platform/ui/index.html
@@ -3,6 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
+      Content-Security-Policy: primary XSS mitigation. `script-src 'self'` blocks
+      injected/remote scripts (which is what would read the access token from
+      sessionStorage), and connect-src limits where the page can send data to
+      same-origin + AWS API Gateway + Cognito. Note: frame-ancestors and some
+      directives only take effect as a real HTTP header — set those via the
+      CloudFront response-headers policy for full coverage (see docs/SECURITY.md).
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://*.execute-api.*.amazonaws.com https://*.amazoncognito.com https://cognito-idp.*.amazonaws.com; base-uri 'self'; object-src 'none'; frame-ancestors 'none'" />
     <title>ATX Transform</title>
   </head>
   <body>

--- a/agentic-atx-platform/ui/src/App.jsx
+++ b/agentic-atx-platform/ui/src/App.jsx
@@ -1,3 +1,4 @@
+import { authedFetch, authEnabled, handleAuthRedirect, isAuthenticated, login, logout } from "./auth"
 import React, { useState, useEffect } from 'react'
 import TransformationList from './components/TransformationList'
 import TransformationForm from './components/TransformationForm'
@@ -13,7 +14,7 @@ const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 
 // Async orchestrator for AI operations
 async function orchestrate(prompt, { onStep, pollIntervalMs = 5000, maxPollMs = 300000 } = {}) {
-  const submitRes = await fetch(`${API_BASE}/orchestrate`, {
+  const submitRes = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'submit', prompt })
@@ -24,7 +25,7 @@ async function orchestrate(prompt, { onStep, pollIntervalMs = 5000, maxPollMs = 
   const deadline = Date.now() + maxPollMs
   while (Date.now() < deadline) {
     await new Promise(r => setTimeout(r, pollIntervalMs))
-    const pollRes = await fetch(`${API_BASE}/orchestrate`, {
+    const pollRes = await authedFetch(`${API_BASE}/orchestrate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'poll', request_id })
@@ -46,7 +47,7 @@ async function orchestrate(prompt, { onStep, pollIntervalMs = 5000, maxPollMs = 
 
 // Direct calls for fast operations (status, results) - no AI overhead
 async function directCall(op, job_id) {
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'direct', op, job_id })
@@ -56,7 +57,7 @@ async function directCall(op, job_id) {
 
 // Fire-and-forget: submit to orchestrator without waiting for result
 async function submitAsync(prompt) {
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'submit', prompt })
@@ -68,12 +69,33 @@ export default function App() {
   const [tab, setTab] = useState('Transformations')
   const [jobs, setJobs] = useState([])
   const [jobsLoaded, setJobsLoaded] = useState(false)
+  const [authReady, setAuthReady] = useState(!authEnabled())
+  const [authed, setAuthed] = useState(isAuthenticated())
 
-  // Load jobs from DynamoDB on mount
+  // Handle the Cognito redirect (?code=...) and gate the app on auth when enabled.
   useEffect(() => {
+    if (!authEnabled()) { setAuthReady(true); setAuthed(true); return }
+    let cancelled = false
+    ;(async () => {
+      await handleAuthRedirect()
+      if (cancelled) return
+      if (isAuthenticated()) {
+        setAuthed(true)
+        setAuthReady(true)
+      } else {
+        // Not signed in — redirect to the Cognito Hosted UI.
+        login()
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  // Load jobs from DynamoDB on mount (only once authenticated)
+  useEffect(() => {
+    if (!authed) return
     async function loadJobs() {
       try {
-        const res = await fetch(`${API_BASE}/orchestrate`, {
+        const res = await authedFetch(`${API_BASE}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'list_jobs' })
@@ -84,7 +106,7 @@ export default function App() {
       setJobsLoaded(true)
     }
     loadJobs()
-  }, [])
+  }, [authed])
 
   function updateJobs(updater) {
     setJobs(prev => {
@@ -96,7 +118,7 @@ export default function App() {
   const addJob = (job) => {
     updateJobs(prev => [job, ...prev])
     // Persist to DynamoDB
-    fetch(`${API_BASE}/orchestrate`, {
+    authedFetch(`${API_BASE}/orchestrate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'direct', op: 'save_job', job })
@@ -107,7 +129,7 @@ export default function App() {
     updateJobs(prev => [...newJobs, ...prev])
     // Persist all to DynamoDB
     newJobs.forEach(job => {
-      fetch(`${API_BASE}/orchestrate`, {
+      authedFetch(`${API_BASE}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'save_job', job })
@@ -115,11 +137,28 @@ export default function App() {
     })
   }
 
+  // While auth is initializing/redirecting, don't render the app shell.
+  if (!authReady) {
+    return (
+      <div className="app">
+        <header><h1>ATX Transform</h1></header>
+        <div className="card"><span className="spinner" /><span className="loading-text">Signing in...</span></div>
+      </div>
+    )
+  }
+
   return (
     <div className="app">
       <header>
-        <h1>ATX Transform</h1>
-        <p className="subtitle">AI-Powered Code Transformation Platform</p>
+        <div className="flex-between">
+          <div>
+            <h1>ATX Transform</h1>
+            <p className="subtitle">AI-Powered Code Transformation Platform</p>
+          </div>
+          {authEnabled() && (
+            <button className="btn btn-secondary btn-sm" onClick={logout}>Sign out</button>
+          )}
+        </div>
       </header>
       <nav>
         {TABS.map(t => (

--- a/agentic-atx-platform/ui/src/auth.js
+++ b/agentic-atx-platform/ui/src/auth.js
@@ -1,0 +1,149 @@
+// UI auth helper for the agentic ATX platform.
+//
+// When VITE_AUTH_ENABLED=true, the app authenticates against a Cognito User Pool
+// using the Hosted UI (OAuth2 authorization-code + PKCE) and attaches the access
+// token as `Authorization: Bearer <token>` to every API call via authedFetch().
+// When the flag is off (default for the blog/demo build), authedFetch behaves like
+// plain fetch and no login is required.
+//
+// Build-time config (Vite env):
+//   VITE_AUTH_ENABLED      "true" to turn on auth
+//   VITE_COGNITO_DOMAIN    e.g. https://atx-transform-<acct>.auth.us-east-1.amazoncognito.com
+//   VITE_COGNITO_CLIENT_ID Cognito app client id
+//   VITE_AUTH_REDIRECT_URI defaults to window.location.origin
+
+const AUTH_ENABLED = (import.meta.env.VITE_AUTH_ENABLED ?? 'false') === 'true'
+const COGNITO_DOMAIN = (import.meta.env.VITE_COGNITO_DOMAIN || '').replace(/\/$/, '')
+const CLIENT_ID = import.meta.env.VITE_COGNITO_CLIENT_ID || ''
+const REDIRECT_URI = import.meta.env.VITE_AUTH_REDIRECT_URI || (typeof window !== 'undefined' ? window.location.origin : '')
+
+const TOKEN_KEY = 'atx_access_token'
+const TOKEN_EXP_KEY = 'atx_access_token_exp'
+const PKCE_VERIFIER_KEY = 'atx_pkce_verifier'
+
+export function authEnabled() {
+  return AUTH_ENABLED
+}
+
+// ---- PKCE helpers ----
+
+function base64UrlEncode(bytes) {
+  let str = ''
+  const arr = new Uint8Array(bytes)
+  for (let i = 0; i < arr.length; i++) str += String.fromCharCode(arr[i])
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+async function sha256(input) {
+  const data = new TextEncoder().encode(input)
+  return crypto.subtle.digest('SHA-256', data)
+}
+
+function randomString(len = 64) {
+  const arr = new Uint8Array(len)
+  crypto.getRandomValues(arr)
+  return base64UrlEncode(arr).slice(0, len)
+}
+
+// ---- Token storage ----
+
+function storeToken(accessToken, expiresInSec) {
+  sessionStorage.setItem(TOKEN_KEY, accessToken)
+  sessionStorage.setItem(TOKEN_EXP_KEY, String(Date.now() + (expiresInSec - 30) * 1000))
+}
+
+export function getToken() {
+  const token = sessionStorage.getItem(TOKEN_KEY)
+  const exp = Number(sessionStorage.getItem(TOKEN_EXP_KEY) || 0)
+  if (!token || Date.now() > exp) return null
+  return token
+}
+
+export function isAuthenticated() {
+  return !AUTH_ENABLED || !!getToken()
+}
+
+export function logout() {
+  sessionStorage.removeItem(TOKEN_KEY)
+  sessionStorage.removeItem(TOKEN_EXP_KEY)
+  if (AUTH_ENABLED && COGNITO_DOMAIN) {
+    const url = `${COGNITO_DOMAIN}/logout?client_id=${encodeURIComponent(CLIENT_ID)}&logout_uri=${encodeURIComponent(REDIRECT_URI)}`
+    window.location.assign(url)
+  }
+}
+
+// ---- Login (Hosted UI, authorization code + PKCE) ----
+
+export async function login() {
+  if (!AUTH_ENABLED) return
+  const verifier = randomString(64)
+  const challenge = base64UrlEncode(await sha256(verifier))
+  sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier)
+  const params = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    scope: 'openid email profile',
+    redirect_uri: REDIRECT_URI,
+    code_challenge_method: 'S256',
+    code_challenge: challenge,
+  })
+  window.location.assign(`${COGNITO_DOMAIN}/oauth2/authorize?${params.toString()}`)
+}
+
+// Exchange the ?code=... returned by the Hosted UI for tokens. Call once on app load.
+// Returns true if a code was present and exchanged.
+export async function handleAuthRedirect() {
+  if (!AUTH_ENABLED) return false
+  const url = new URL(window.location.href)
+  const code = url.searchParams.get('code')
+  if (!code) return false
+
+  const verifier = sessionStorage.getItem(PKCE_VERIFIER_KEY) || ''
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    code,
+    redirect_uri: REDIRECT_URI,
+    code_verifier: verifier,
+  })
+  try {
+    const res = await fetch(`${COGNITO_DOMAIN}/oauth2/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    })
+    if (!res.ok) throw new Error(`token exchange failed: ${res.status}`)
+    const data = await res.json()
+    if (data.access_token) storeToken(data.access_token, data.expires_in || 3600)
+  } finally {
+    sessionStorage.removeItem(PKCE_VERIFIER_KEY)
+    // Clean the ?code= from the URL so a refresh doesn't re-trigger exchange.
+    url.searchParams.delete('code')
+    url.searchParams.delete('state')
+    window.history.replaceState({}, document.title, url.pathname + url.search)
+  }
+  return true
+}
+
+// ---- Authenticated fetch wrapper ----
+
+// Drop-in for fetch(). When auth is enabled, attaches the bearer token and, on a
+// 401 or missing token, redirects to the Hosted UI login.
+export async function authedFetch(input, init = {}) {
+  if (!AUTH_ENABLED) return fetch(input, init)
+
+  const token = getToken()
+  if (!token) {
+    await login()
+    // login() navigates away; return a never-resolving promise to avoid downstream work.
+    return new Promise(() => {})
+  }
+  const headers = { ...(init.headers || {}), Authorization: `Bearer ${token}` }
+  const res = await fetch(input, { ...init, headers })
+  if (res.status === 401) {
+    logout()
+    await login()
+    return new Promise(() => {})
+  }
+  return res
+}

--- a/agentic-atx-platform/ui/src/components/Chat.jsx
+++ b/agentic-atx-platform/ui/src/components/Chat.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import { useState, useRef, useEffect } from 'react'
 
 const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
@@ -38,7 +39,7 @@ export default function Chat({ orchestrate, jobs }) {
           // If job succeeded, try to get result file list
           if (job.status === 'SUCCEEDED' && job.type !== 'create') {
             try {
-              const res = await fetch(`${API_BASE}/orchestrate`, {
+              const res = await authedFetch(`${API_BASE}/orchestrate`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ action: 'direct', op: 'results', job_id: job.id })

--- a/agentic-atx-platform/ui/src/components/CreateCustom.jsx
+++ b/agentic-atx-platform/ui/src/components/CreateCustom.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import { useState } from 'react'
 
 const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
@@ -106,7 +107,7 @@ export default function CreateCustom({ submitAsync, onJobCreated, orchestrate })
     try {
       // Upload the edited definition back to S3
       const normalized = name.trim().toLowerCase().replace(/\s+/g, '-')
-      const accountRes = await fetch(`${API_BASE}/orchestrate`, {
+      const accountRes = await authedFetch(`${API_BASE}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'list_custom' })

--- a/agentic-atx-platform/ui/src/components/JobTracker.jsx
+++ b/agentic-atx-platform/ui/src/components/JobTracker.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import React, { useState, useEffect, useRef } from 'react'
 
 function timeAgo(date) {
@@ -41,7 +42,7 @@ function ResultsSummary({ data }) {
     setPreview(null)
     try {
       const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-      const res = await fetch(`${API}/orchestrate`, {
+      const res = await authedFetch(`${API}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'get_file', bucket, key: file.key })
@@ -61,7 +62,7 @@ function ResultsSummary({ data }) {
   async function downloadFile(file) {
     try {
       const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-      const res = await fetch(`${API}/orchestrate`, {
+      const res = await authedFetch(`${API}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'download_url', bucket, key: file.key })
@@ -83,7 +84,7 @@ function ResultsSummary({ data }) {
     try {
       const API = import.meta.env.VITE_API_ENDPOINT || '/api'
       const prefix = data.results_location?.replace(`s3://${bucket}/`, '') || ''
-      const startRes = await fetch(`${API}/orchestrate`, {
+      const startRes = await authedFetch(`${API}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'download_all', bucket, prefix })
@@ -111,7 +112,7 @@ function ResultsSummary({ data }) {
 
       for (let i = 0; i < 120; i++) {
         await new Promise(r => setTimeout(r, 5000))
-        const pollRes = await fetch(`${API}/orchestrate`, {
+        const pollRes = await authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'download_all', bucket, prefix, download_id: downloadId })
@@ -227,7 +228,7 @@ function FailedJobDetails({ jobId, job, onRetry }) {
     async function loadDetails() {
       try {
         const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-        const res = await fetch(`${API}/orchestrate`, {
+        const res = await authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'status', job_id: jobId })
@@ -328,7 +329,7 @@ function PreviewAndPublish({ job, orchestrate, onPublished }) {
       try {
         const API = import.meta.env.VITE_API_ENDPOINT || '/api'
         const normalized = job.transformation.toLowerCase().replace(/\s+/g, '-')
-        const res = await fetch(`${API}/orchestrate`, {
+        const res = await authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'get_file', definition_name: normalized })
@@ -390,7 +391,7 @@ function ViewDefinitionButton({ name }) {
     setLoading(true)
     try {
       const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-      const res = await fetch(`${API}/orchestrate`, {
+      const res = await authedFetch(`${API}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'get_file', definition_name: name })
@@ -457,7 +458,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
       if (job.type === 'create' || job.type === 'preview') {
         // Create jobs: poll orchestrator result from S3
         const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-        const res = await fetch(`${API}/orchestrate`, {
+        const res = await authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'poll', request_id: jobId })
@@ -502,7 +503,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
 
   function _persistJobUpdate(jobId, updates) {
     const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-    fetch(`${API}/orchestrate`, {
+    authedFetch(`${API}/orchestrate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'direct', op: 'update_job', job_id: jobId, updates })
@@ -539,7 +540,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
     setJobs(prev => prev.filter(j => j.id !== jobId))
     if (expanded === jobId) setExpanded(null)
     const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-    fetch(`${API}/orchestrate`, {
+    authedFetch(`${API}/orchestrate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ action: 'direct', op: 'delete_job', job_id: jobId })
@@ -572,7 +573,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
         }
         setJobs(prev => [newJob, ...prev])
         const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-        fetch(`${API}/orchestrate`, {
+        authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'save_job', job: newJob })
@@ -584,7 +585,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
   async function downloadFile(bucket, key, fileName) {
     try {
       const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-      const res = await fetch(`${API}/orchestrate`, {
+      const res = await authedFetch(`${API}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'download_url', bucket, key })
@@ -661,7 +662,7 @@ export default function JobTracker({ orchestrate, directCall, jobs, setJobs }) {
                   <PreviewAndPublish job={job} orchestrate={orchestrate} onPublished={(pubJob) => {
                     setJobs(prev => prev.map(j => j.id === job.id ? { ...j, type: 'create', status: 'PROCESSING' } : j))
                     const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-                    fetch(`${API}/orchestrate`, {
+                    authedFetch(`${API}/orchestrate`, {
                       method: 'POST',
                       headers: { 'Content-Type': 'application/json' },
                       body: JSON.stringify({ action: 'direct', op: 'update_job', job_id: job.id, updates: { type: 'create', status: 'PROCESSING' } })

--- a/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
+++ b/agentic-atx-platform/ui/src/components/KnowledgeItems.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import { useState, useEffect } from 'react'
 import {
   readCachedKnowledgeItems, refreshKnowledgeItems,
@@ -228,7 +229,7 @@ export default function KnowledgeItems() {
     let cancelled = false
     async function loadCustoms() {
       try {
-        const res = await fetch(`${API_BASE}/orchestrate`, {
+        const res = await authedFetch(`${API_BASE}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'list_custom' }),

--- a/agentic-atx-platform/ui/src/components/Metrics.jsx
+++ b/agentic-atx-platform/ui/src/components/Metrics.jsx
@@ -9,10 +9,13 @@ import { fetchMetrics, fetchExecutions, rankBy, statusSplit, typeSplit } from '.
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend)
 
+// CloudWatch ListMetrics only surfaces metrics active in the last ~14 days, and
+// this dashboard discovers metrics via ListMetrics — so ranges beyond 14 days
+// can't return data. We cap the selector at 14 days to avoid misleading empty views.
 const RANGES = [
   { id: '24h', label: 'Last 24h' },
   { id: '7d', label: 'Last 7 days' },
-  { id: '30d', label: 'Last 30 days' },
+  { id: '14d', label: 'Last 14 days' },
 ]
 
 const COLORS = {
@@ -146,7 +149,8 @@ export default function Metrics() {
         <div>
           <h2 style={{ fontSize: 18 }}>Metrics</h2>
           <p style={{ color: '#8b949e', fontSize: 13, marginTop: 2 }}>
-            From the <code>AWS/TransformCustom</code> CloudWatch namespace.
+            From the <code>AWS/TransformCustom</code> CloudWatch namespace. Reflects
+            activity from roughly the last 14 days (CloudWatch metric discovery window).
           </p>
         </div>
         <div className="filter-bar" style={{ margin: 0, alignItems: 'center', gap: 12 }}>

--- a/agentic-atx-platform/ui/src/components/TransformationForm.jsx
+++ b/agentic-atx-platform/ui/src/components/TransformationForm.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import React, { useState, useEffect } from 'react'
 
 export default function TransformationForm({ orchestrate, onJobCreated }) {
@@ -34,7 +35,7 @@ export default function TransformationForm({ orchestrate, onJobCreated }) {
     async function loadCustom() {
       try {
         const API = import.meta.env.VITE_API_ENDPOINT || '/api'
-        const res = await fetch(`${API}/orchestrate`, {
+        const res = await authedFetch(`${API}/orchestrate`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action: 'direct', op: 'list_custom' })

--- a/agentic-atx-platform/ui/src/components/TransformationList.jsx
+++ b/agentic-atx-platform/ui/src/components/TransformationList.jsx
@@ -1,3 +1,4 @@
+import { authedFetch } from "../auth"
 import React, { useState, useEffect } from 'react'
 import { MANAGED_TRANSFORMATIONS } from '../transformations'
 
@@ -6,7 +7,7 @@ const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 const GITHUB_BASE = 'https://github.com/aws-samples/aws-transform-custom-samples/tree/main/aws-managed-definitions'
 
 async function directCall(op, extra = {}) {
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'direct', op, ...extra })
@@ -23,7 +24,7 @@ function CustomTransformCard({ name, description }) {
     setLoading(true)
     try {
       const normalized = name.toLowerCase().replace(/\s+/g, '-')
-      const res = await fetch(`${API_BASE}/orchestrate`, {
+      const res = await authedFetch(`${API_BASE}/orchestrate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'direct', op: 'get_file', definition_name: normalized })

--- a/agentic-atx-platform/ui/src/knowledgeApi.js
+++ b/agentic-atx-platform/ui/src/knowledgeApi.js
@@ -1,3 +1,4 @@
+import { authedFetch } from "./auth"
 // Knowledge Items API client.
 //
 // Backend: get_knowledge_items.py logic ported into the agentic platform's
@@ -14,7 +15,7 @@ const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 const USE_MOCK = (import.meta.env.VITE_KI_MOCK ?? 'true') !== 'false'
 
 async function ki(payload) {
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'direct', op: 'knowledge_items', ...payload }),

--- a/agentic-atx-platform/ui/src/metricsApi.js
+++ b/agentic-atx-platform/ui/src/metricsApi.js
@@ -1,3 +1,4 @@
+import { authedFetch } from "./auth"
 // Metrics API client for the AWS/TransformCustom CloudWatch namespace.
 //
 // Backend: the metrics logic from scaled-execution-containers PR #41 (get_metrics.py)
@@ -40,7 +41,7 @@ export async function fetchMetrics({ range = '7d' } = {}) {
     return mockMetrics(range)
   }
 
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'direct', op: 'metrics', type: 'all', period: RANGE_HOURS[range] || 168 }),
@@ -60,7 +61,7 @@ export async function fetchExecutions({ range = '7d' } = {}) {
     await new Promise(r => setTimeout(r, 300))
     return mockExecutions()
   }
-  const res = await fetch(`${API_BASE}/orchestrate`, {
+  const res = await authedFetch(`${API_BASE}/orchestrate`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ action: 'direct', op: 'metrics', type: 'transform_detail', period: RANGE_HOURS[range] || 168 }),

--- a/agentic-atx-platform/ui/src/metricsApi.js
+++ b/agentic-atx-platform/ui/src/metricsApi.js
@@ -26,13 +26,15 @@ import { authedFetch } from "./auth"
 const API_BASE = import.meta.env.VITE_API_ENDPOINT || '/api'
 const USE_MOCK = (import.meta.env.VITE_METRICS_MOCK ?? 'true') !== 'false'
 
-// period (hours) for each UI range option
-const RANGE_HOURS = { '24h': 24, '7d': 168, '30d': 720 }
+// period (hours) for each UI range option. Capped at 14 days because CloudWatch
+// ListMetrics (used to discover metrics) only returns metrics active in the last
+// ~14 days — longer windows would always come back empty.
+const RANGE_HOURS = { '24h': 24, '7d': 168, '14d': 336 }
 
 /**
  * Fetch aggregate metrics (type=all) for a UI range.
  * @param {Object} opts
- * @param {string} opts.range - '24h' | '7d' | '30d'
+ * @param {string} opts.range - '24h' | '7d' | '14d'
  * @returns raw get_metrics.py response (see shape above)
  */
 export async function fetchMetrics({ range = '7d' } = {}) {
@@ -124,7 +126,7 @@ export function typeSplit(executions = []) {
 // ---- Mock data (shaped identically to get_metrics.py) ----
 
 function mockMetrics(range) {
-  const scale = range === '24h' ? 0.3 : range === '30d' ? 3 : 1
+  const scale = range === '24h' ? 0.3 : range === '14d' ? 2 : 1
   const r = (n) => Math.round(n * scale)
   return {
     startTime: new Date(Date.now() - (RANGE_HOURS[range] || 168) * 3600_000).toISOString(),

--- a/agentic-atx-platform/ui/vite.config.js
+++ b/agentic-atx-platform/ui/vite.config.js
@@ -1,16 +1,71 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, '')
-      }
-    }
+// Return the scheme+host origin of a URL, or '' if it isn't an absolute URL.
+// Strips any path (e.g. the API endpoint's "/prod"), which CSP source
+// expressions must not include (a trailing path is treated as a path prefix).
+function originOf(url) {
+  try {
+    return new URL(url).origin
+  } catch {
+    return ''
+  }
+}
+
+// Build-time Content-Security-Policy injection.
+//
+// connect-src is scoped to the EXACT origins this build targets — the API Gateway
+// endpoint and (when auth is enabled) the Cognito Hosted UI domain — instead of a
+// broad wildcard like *.amazonaws.com. This tightens the anti-exfiltration boundary:
+// even with script execution, the browser can only reach our own API + Cognito.
+//
+// The CSP replaces the <!--CSP_META--> placeholder in index.html at build time.
+function cspPlugin(env) {
+  return {
+    name: 'inject-csp',
+    transformIndexHtml(html) {
+      const apiOrigin = originOf(env.VITE_API_ENDPOINT)
+      const authEnabled = env.VITE_AUTH_ENABLED === 'true'
+      const cognitoOrigin = authEnabled ? originOf(env.VITE_COGNITO_DOMAIN) : ''
+
+      // 'self' covers the dev proxy (same-origin /api) and same-origin assets.
+      const connectSrc = ["'self'", apiOrigin, cognitoOrigin].filter(Boolean).join(' ')
+
+      const csp = [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data:",
+        `connect-src ${connectSrc}`,
+        "base-uri 'self'",
+        "object-src 'none'",
+        // NOTE: frame-ancestors is intentionally omitted — browsers ignore it in a
+        // <meta> CSP (it only works as an HTTP header). Clickjacking protection is
+        // planned via a CloudFront response-headers policy (see docs/SECURITY.md).
+      ].join('; ')
+
+      const meta = `<meta http-equiv="Content-Security-Policy" content="${csp}" />`
+      return html.replace('<!--CSP_META-->', meta)
+    },
+  }
+}
+
+export default defineConfig(({ mode }) => {
+  // Merge .env-file values with process.env so inline CLI env vars
+  // (VITE_API_ENDPOINT=... npx vite build) and .env files both work.
+  const env = { ...loadEnv(mode, process.cwd(), ''), ...process.env }
+
+  return {
+    plugins: [react(), cspPlugin(env)],
+    server: {
+      port: 3000,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
Adds **secure-by-default authentication** to the agentic ATX platform API.

## Backend
- **API Gateway JWT authorizer** (raw `AWS::ApiGatewayV2` resources so it can be
  attached conditionally): when `EnableAuth=true` the `/orchestrate` route requires a
  valid Cognito JWT and rejects unauthenticated requests with `401` at the gateway edge.
- **Cognito** User Pool + app client + hosted-UI domain (created only when auth is on;
  self-signup disabled, admin-create only).
- **`auth.py`** verifies the JWT in the Lambda as defense-in-depth (JWKS signature,
  issuer, audience, expiry, token_use, client_id) and trusts gateway-validated claims
  when present. Fails closed if enabled-but-misconfigured.
- **CORS** restricted to the configured UI origin; `authorization` header allowed.
- `batch:SubmitJob` scoped to the queue/definition ARNs (List/Describe stay `*` — AWS
  Batch has no resource-level support for those).

## Frontend
- `auth.js`: Cognito Hosted UI login (OAuth2 auth-code + PKCE), token handling, and
  `authedFetch` that attaches the bearer token and redirects on 401. No-op unless
  `VITE_AUTH_ENABLED=true`, so the open blog/demo build is unchanged.
- All `/orchestrate` calls routed through `authedFetch`; App gates render on auth with
  a Sign out control.

## Secure by default
`EnableAuth` defaults to `true`. Deploy with `ENABLE_AUTH=false` for the open
blog/demo walkthrough.

## Tests
33 unittest cases (no pytest dependency): auth on/off, 401 on every HTTP action without
a valid token, gateway-claims trust, fail-closed, and static checks that there are no
unauthenticated endpoints / public function URLs.

## Verified on dev account
- No token / invalid token → 401 (at the gateway)
- Valid Cognito token → 200 with data (list_jobs, metrics)
- Scoped SubmitJob works (KI submit); ListJobs/metrics job-counts work
- OPTIONS preflight → 204

## Docs
README (auth setup, user creation, UI build flags), ARCHITECTURE (auth data flow,
Cognito service), SECURITY (replaces the stale "REST API uses IAM" section with the
real Cognito-JWT model).

## Design note
Auth is enforced at the API Gateway JWT authorizer (edge) with in-Lambda verification
as defense-in-depth. Using raw ApiGatewayV2 resources (not SAM's HttpApi `Auth`
shorthand) is what allows the authorizer to be conditional on `EnableAuth`.
