### PR TITLE
docs: fix 15 broken relative links across four READMEs

### DIFF
--- a/aws-managed-definitions/README.md
+++ b/aws-managed-definitions/README.md
@@ -16,8 +16,8 @@ Out-of-box transformation definitions provided by AWS for common migration and u
 | General | [Codebase Analysis](comprehensive-codebase-analysis/codebase-analysis.md) | Static analysis and documentation for migration planning |
 | Readiness | [Modernization Readiness Analysis](readiness-analysis/modernization-readiness-analysis.md) | Scans portfolios for cloud-native maturity gaps and maps findings to AWS modernization pathways |
 | Readiness | [Agentic Readiness Analysis](readiness-analysis/agentic-readiness-analysis.md) | Evaluates whether systems are ready to be safely called by AI agents — covering APIs, identity, state management, human-in-the-loop, and observability |
-| Readiness | [Portfolio Modernization Readiness](readiness-analysis/portfolio-modernization-readiness.md) | Aggregates per-repo MOD reports into portfolio-level roadmap and cross-cutting analysis |
-| Readiness | [Portfolio Agentic Readiness](readiness-analysis/portfolio-agentic-readiness.md) | Aggregates per-repo ARA reports into portfolio-level cross-cutting analysis |
+| Readiness | [Portfolio Modernization Readiness](readiness-analysis/portfolio-modernization-readiness-analysis.md) | Aggregates per-repo MOD reports into portfolio-level roadmap and cross-cutting analysis |
+| Readiness | [Portfolio Agentic Readiness](readiness-analysis/portfolio-agentic-readiness-analysis.md) | Aggregates per-repo ARA reports into portfolio-level cross-cutting analysis |
 
 ## Directory Structure
 
@@ -44,6 +44,6 @@ aws-managed-definitions/
 └── readiness-analysis/
     ├── modernization-readiness-analysis.md
     ├── agentic-readiness-analysis.md
-    ├── portfolio-modernization-readiness.md
-    └── portfolio-agentic-readiness.md
+    ├── portfolio-modernization-readiness-analysis.md
+    └── portfolio-agentic-readiness-analysis.md
 ```

--- a/community-sourced-transformations/jboss-to-springboot/README.md
+++ b/community-sourced-transformations/jboss-to-springboot/README.md
@@ -301,17 +301,17 @@ These are loaded on-demand by the agent when specific patterns are encountered d
 
 | Reference | Trigger Patterns | Description |
 |---|---|---|
-| [phase0-detection-flags.md](References/phase0-detection-flags.md) | Phase 0 library flag detection, pom.xml scanning | Full detection rules for all library flags (HAS_JODA_TIME, HAS_JACKSON_V1, HAS_C3P0, etc.) |
-| [jaxrs-spring-mvc-migration.md](References/jaxrs-spring-mvc-migration.md) | @Path, @ApplicationPath, @QueryParam, JAX-RS Response, SSE | Detailed JAX-RS → Spring MVC mapping: @ApplicationPath folding, @QueryParam required=false, UriInfo translation, ExceptionMapper→@ControllerAdvice, SSE→SseEmitter |
-| [jaxws-websocket-migration.md](References/jaxws-websocket-migration.md) | @WebService, @ServerEndpoint, @OnMessage | JAX-WS SOAP and WebSocket migration patterns |
-| [spring-batch5-migration.md](References/spring-batch5-migration.md) | jakarta.batch, META-INF/batch-jobs/, ItemWriter | Spring Batch 5 specifics: Chunk API, @StepScope, @BatchProperty→@Value |
-| [hibernate6-behavior-changes.md](References/hibernate6-behavior-changes.md) | @Embeddable, @Lob on array fields, CriteriaQuery | Hibernate 6 nulls handling, behavior changes, CriteriaQuery updates |
-| [test-configuration-patterns.md](References/test-configuration-patterns.md) | Arquillian, test context, H2, JUnit 4→5, *IT.java | Core test migration patterns: @SpringBootTest setup, H2 config, JUnit 5 assertion reordering, failsafe integration |
-| [test-mockito-advanced.md](References/test-mockito-advanced.md) | @InjectMocks, Mockito, STRICT_STUBS, @MockBean | Advanced Mockito patterns: ReflectionTestUtils for @PersistenceContext/@Value, UnnecessaryStubbingException, lenient stubs |
-| [jsf-backing-bean-migration.md](References/jsf-backing-bean-migration.md) | .xhtml, @ViewScoped, @FlowScoped, JSF backing beans | JSF backing bean → Spring @Controller patterns, Thymeleaf template conversion |
-| [common-pitfalls-extended.md](References/common-pitfalls-extended.md) | Build errors, runtime exceptions, JUL→SLF4J | Full troubleshooting reference: build errors, startup failures, configuration issues, JUL→SLF4J migration |
-| [worked-examples-conditional.md](References/worked-examples-conditional.md) | MDB→@JmsListener, JBoss Security examples | Worked before/after examples for conditional phases (JMS, Security) |
-| [verify-legacy-imports.md](References/verify-legacy-imports.md) | Post-migration verification | Legacy import verification procedure with copy-paste-ready grep commands, MIGRATION comment validation |
+| [phase0-detection-flags.md](references/phase0-detection-flags.md) | Phase 0 library flag detection, pom.xml scanning | Full detection rules for all library flags (HAS_JODA_TIME, HAS_JACKSON_V1, HAS_C3P0, etc.) |
+| [jaxrs-spring-mvc-migration.md](references/jaxrs-spring-mvc-migration.md) | @Path, @ApplicationPath, @QueryParam, JAX-RS Response, SSE | Detailed JAX-RS → Spring MVC mapping: @ApplicationPath folding, @QueryParam required=false, UriInfo translation, ExceptionMapper→@ControllerAdvice, SSE→SseEmitter |
+| [jaxws-websocket-migration.md](references/jaxws-websocket-migration.md) | @WebService, @ServerEndpoint, @OnMessage | JAX-WS SOAP and WebSocket migration patterns |
+| [spring-batch5-migration.md](references/spring-batch5-migration.md) | jakarta.batch, META-INF/batch-jobs/, ItemWriter | Spring Batch 5 specifics: Chunk API, @StepScope, @BatchProperty→@Value |
+| [hibernate6-behavior-changes.md](references/hibernate6-behavior-changes.md) | @Embeddable, @Lob on array fields, CriteriaQuery | Hibernate 6 nulls handling, behavior changes, CriteriaQuery updates |
+| [test-configuration-patterns.md](references/test-configuration-patterns.md) | Arquillian, test context, H2, JUnit 4→5, *IT.java | Core test migration patterns: @SpringBootTest setup, H2 config, JUnit 5 assertion reordering, failsafe integration |
+| [test-mockito-advanced.md](references/test-mockito-advanced.md) | @InjectMocks, Mockito, STRICT_STUBS, @MockBean | Advanced Mockito patterns: ReflectionTestUtils for @PersistenceContext/@Value, UnnecessaryStubbingException, lenient stubs |
+| [jsf-backing-bean-migration.md](references/jsf-backing-bean-migration.md) | .xhtml, @ViewScoped, @FlowScoped, JSF backing beans | JSF backing bean → Spring @Controller patterns, Thymeleaf template conversion |
+| [common-pitfalls-extended.md](references/common-pitfalls-extended.md) | Build errors, runtime exceptions, JUL→SLF4J | Full troubleshooting reference: build errors, startup failures, configuration issues, JUL→SLF4J migration |
+| [worked-examples-conditional.md](references/worked-examples-conditional.md) | MDB→@JmsListener, JBoss Security examples | Worked before/after examples for conditional phases (JMS, Security) |
+| [verify-legacy-imports.md](references/verify-legacy-imports.md) | Post-migration verification | Legacy import verification procedure with copy-paste-ready grep commands, MIGRATION comment validation |
 
 ## Known Limitations
 
@@ -339,7 +339,7 @@ These are loaded on-demand by the agent when specific patterns are encountered d
 | Build fails with "invalid flag: --release" | Maven on Java 8 targeting Java 17. Add compiler fork profile or use Maven Wrapper. |
 | Dependency conflicts after migration | Remove explicit versions managed by Spring Boot parent POM. Run mvn dependency:tree. |
 
-See [References/common-pitfalls-extended.md](References/common-pitfalls-extended.md) for the full troubleshooting reference.
+See [references/common-pitfalls-extended.md](references/common-pitfalls-extended.md) for the full troubleshooting reference.
 
 ## Repository Structure
 
@@ -347,7 +347,7 @@ See [References/common-pitfalls-extended.md](References/common-pitfalls-extended
 ├── SKILL.md                        # Skill definition (6-phase conditional pipeline)
 ├── README.md                       # This file — overview, architecture, getting started, benchmarks
 ├── BENCHMARKS.md                   # Detailed benchmark results (24 repos)
-├── References/                     # On-demand reference documents (11 files)
+├── references/                     # On-demand reference documents (11 files)
 │   ├── phase0-detection-flags.md   # Phase 0 library flag detection rules
 │   ├── jaxrs-spring-mvc-migration.md   # JAX-RS → Spring MVC mapping
 │   ├── jaxws-websocket-migration.md    # JAX-WS SOAP & WebSocket migration

--- a/community-sourced-transformations/kubernetes-readiness-migration/README.md
+++ b/community-sourced-transformations/kubernetes-readiness-migration/README.md
@@ -342,7 +342,7 @@ These are loaded on-demand by the agent when specific patterns are encountered:
 | [go-patterns.md](references/go-patterns.md) | go.mod present | Viper env helpers, gRPC probes, S3 mock testing, GOMEMLIMIT ConfigMap rules |
 | [nodejs-patterns.md](references/nodejs-patterns.md) | package.json present | process.env timing, ioredis pub/sub, NestJS WebSocket, Bull/BullMQ graceful shutdown |
 | [php-patterns.md](references/php-patterns.md) | composer.json present | Laravel queue routing, supervisord, PHP-FPM non-root, S3 ACL patterns |
-| [java-maven-patterns.md](references/java-maven-patterns.md) | pom.xml or build.gradle present | Spring @Value bridging, Quartz JDBC clustering, Liquibase Job, EF efbundle |
+| [java-jvm-patterns.md](references/java-jvm-patterns.md) | pom.xml or build.gradle present | Spring @Value bridging, Quartz JDBC clustering, Liquibase Job, EF efbundle |
 | [python-patterns.md](references/python-patterns.md) | requirements.txt / setup.py / pyproject.toml | pydantic-settings, APScheduler, gunicorn preload_app, Celery Beat writable paths |
 | [ruby-rails-patterns.md](references/ruby-rails-patterns.md) | Gemfile present | ActionCable Redis, ActiveStorage, whenever→Sidekiq-Cron, Puma graceful shutdown |
 | [dotnet-patterns.md](references/dotnet-patterns.md) | .csproj / .sln present | IConfiguration bridge, EF Core efbundle Job, SignalR Redis backplane, Kestrel port config |
@@ -389,7 +389,7 @@ These are loaded on-demand by the agent when specific patterns are encountered:
 │   ├── go-patterns.md                         # Go-specific patterns
 │   ├── nodejs-patterns.md                     # Node.js-specific patterns
 │   ├── php-patterns.md                        # PHP-specific patterns
-│   ├── java-maven-patterns.md                 # Java/Maven/Gradle-specific patterns
+│   ├── java-jvm-patterns.md                   # Java/Maven/Gradle-specific patterns
 │   ├── python-patterns.md                     # Python-specific patterns
 │   ├── ruby-rails-patterns.md                 # Ruby/Rails-specific patterns
 │   └── dotnet-patterns.md                     # C#/.NET-specific patterns


### PR DESCRIPTION
*Issue #, if available:* n/a

## Description

Three unrelated path errors leave 15 markdown links pointing at files that do not exist. On GitHub and on any case-sensitive filesystem these render as 404s, which cuts readers off from the reference documents the skills load at runtime.

| File | Problem |
|---|---|
| `aws-managed-definitions/README.md` | The two portfolio readiness links omit the `-analysis` suffix the actual files carry (`portfolio-modernization-readiness.md` vs `portfolio-modernization-readiness-analysis.md`). |
| `community-sourced-transformations/jboss-to-springboot/README.md` | 12 links use `References/` while the tracked directory is `references/`. These resolve on case-insensitive filesystems (macOS, Windows) but 404 on GitHub and on Linux. |
| `community-sourced-transformations/kubernetes-readiness-migration/README.md` | Links `java-maven-patterns.md`, which was renamed to `java-jvm-patterns.md`. `SKILL.md` already uses the new name, so only the README lagged behind. |

The directory trees in the same files are updated to match. No other content was touched.

## Testing

Walked every tracked `.md` file, extracted each relative markdown link (after stripping fenced and inline code), and resolved it against `git ls-files` — case-sensitively, so the macOS filesystem cannot mask the `References/` mismatch.

- Before: **16** broken links
- After: **1**

The one remaining is `scaled-execution-containers/README.md` -> `docs/PUBLIC_ECR.md`. I left it alone deliberately: that file was never committed, so it needs content rather than a path correction. Happy to open a separate issue for it if useful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
