### PR TITLE
docs: replace non-existent `cdk output` command and finish the Sonnet 4.5 rename

### DIFF
--- a/agentic-atx-platform/ARCHITECTURE.md
+++ b/agentic-atx-platform/ARCHITECTURE.md
@@ -27,7 +27,7 @@ AI-powered code transformation platform built on Amazon Bedrock AgentCore and AW
 ┌──────────────────────────────────────────────────────────────┐
 │  Bedrock AgentCore Runtime                                    │
 │                                                               │
-│  Orchestrator Agent (Strands + Claude Sonnet 4)                  │
+│  Orchestrator Agent (Strands + Claude Sonnet 4.5)                │
 │  ├── find_transform_agent (sub-agent)                        │
 │  │   ├── list_transformations (static catalog)               │
 │  │   ├── search_transformations (keyword search)             │
@@ -51,7 +51,7 @@ AI-powered code transformation platform built on Amazon Bedrock AgentCore and AW
           ▼            ▼            ▼
      Amazon S3    AWS Batch    Amazon Bedrock
    (definitions   (Fargate +   (Claude
-    + results)    ATX CLI)     Sonnet 4)
+    + results)    ATX CLI)     Sonnet 4.5)
 ```
 
 ## Data Flows
@@ -106,7 +106,7 @@ UI → /orchestrate (direct, get_file) → Lambda → S3 get (definition preview
   without an AI selection step — saves one Bedrock call. For large repos, AI picks files with
   a budget-aware max count calculated from average file size vs the 400K context budget.
 
-- **400K character context limit**: ~100K tokens, leaving headroom in Claude Sonnet 4's 200K
+- **400K character context limit**: ~100K tokens, leaving headroom in Claude Sonnet 4.5's 200K
   token context window for the system prompt, requirements, and output generation (8K tokens).
 
 - **Direct tool calls vs nested agent**: The create_transform_agent uses direct Bedrock API
@@ -205,7 +205,7 @@ the JWT authorizer can be attached conditionally via !If on EnableAuth.
 | Service | Purpose |
 |---------|---------|
 | Bedrock AgentCore | Orchestrator runtime |
-| Bedrock (Claude Sonnet 4) | AI reasoning + YAML generation |
+| Bedrock (Claude Sonnet 4.5) | AI reasoning + YAML generation |
 | AgentCore Memory | Conversation context |
 | AWS Batch (Fargate) | ATX CLI execution |
 | S3 | Definitions, repo snapshots, results, UI hosting, orchestrator results, job tracking |

--- a/agentic-atx-platform/README.md
+++ b/agentic-atx-platform/README.md
@@ -35,7 +35,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed diagrams and data flows.
 > **Windows users:** Use WSL2 (Windows Subsystem for Linux) for the best experience. The deployment scripts are bash-based. Alternatively, run commands in Git Bash or PowerShell with adjustments.
 
 **AWS Account Requirements:**
-- Bedrock model access enabled for Claude Sonnet 4
+- Bedrock model access enabled for Claude Sonnet 4.5
 - Default VPC with public subnets (or configure existing VPC)
 
 ---
@@ -78,7 +78,7 @@ Uses CDK for infrastructure (stable constructs only) and SAM for the AgentCore +
 #### Step 1: Enable Bedrock Model Access
 
 1. Go to [Bedrock console](https://console.aws.amazon.com/bedrock/home) → Model access
-2. Enable **Anthropic Claude Sonnet 4**
+2. Enable **Anthropic Claude Sonnet 4.5**
 
 #### Step 2: Deploy Base Infrastructure via CDK
 
@@ -450,7 +450,7 @@ plan for them:
 | Component | Technology |
 |-----------|------------|
 | AI Orchestration | Amazon Bedrock AgentCore + Strands Agents |
-| AI Model | Claude Sonnet 4 (cross-region inference) |
+| AI Model | Claude Sonnet 4.5 (cross-region inference) |
 | Memory | AgentCore Memory (short-term) |
 | Transformation Engine | AWS Transform CLI (ATX) |
 | Compute | AWS Batch (Fargate) |

--- a/agentic-atx-platform/deployment/config.env.template
+++ b/agentic-atx-platform/deployment/config.env.template
@@ -3,7 +3,8 @@
 #
 # Used by:
 #   - sam/deploy.sh        (reads AWS_REGION, BEDROCK_MODEL_ID)
-#   - cdk/deploy.sh        (reads AWS_REGION)
+#   - cdk/deploy.sh        (does NOT read this file; it takes the region from
+#                          `aws configure get region`, so set your CLI region to match)
 #   - orchestrator/agent.py (reads AWS_REGION, BEDROCK_MODEL_ID at runtime)
 
 # AWS Region (default: us-east-1)

--- a/agentic-atx-platform/docs/TROUBLESHOOTING.md
+++ b/agentic-atx-platform/docs/TROUBLESHOOTING.md
@@ -242,7 +242,7 @@ VITE_API_ENDPOINT=$API_URL npx vite build
    # Check available models
    aws bedrock list-foundation-models --query "modelSummaries[?contains(modelId,'claude')].{id:modelId,status:modelLifecycle.status}" --output table
    
-   # Recommended: Claude Sonnet 4
+   # Recommended: Claude Sonnet 4.5
    BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
    ```
 2. Redeploy the AgentCore stack (Option B) or update the AgentCore runtime (Option A)

--- a/scaled-execution-containers/api/README.md
+++ b/scaled-execution-containers/api/README.md
@@ -10,8 +10,8 @@ REST API for triggering, monitoring, and managing AWS Transform CLI jobs on AWS 
 
 _If using CDK:_
 ```bash
-cd cdk
-npx cdk output AtxApiStack.ApiEndpoint
+aws cloudformation describe-stacks --stack-name AtxApiStack \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" --output text
 # Or check the output printed during deployment
 ```
 

--- a/scaled-execution-containers/cdk/README.md
+++ b/scaled-execution-containers/cdk/README.md
@@ -315,12 +315,17 @@ Stacks are deployed in order automatically.
 After deployment, get outputs:
 
 ```bash
-# All outputs
-npx cdk output --all
+# All outputs for a stack
+aws cloudformation describe-stacks --stack-name AtxApiStack \
+  --query "Stacks[0].Outputs" --output table
 
 # Specific output
-npx cdk output AtxApiStack.ApiEndpoint
+aws cloudformation describe-stacks --stack-name AtxApiStack \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" --output text
 ```
+
+> Outputs are also printed at the end of `cdk deploy`, and
+> `cdk deploy --outputs-file outputs.json` writes them to a file.
 
 **Key outputs:**
 - `AtxContainerStack.ImageUri` - Container image URI
@@ -336,7 +341,8 @@ After successful deployment, test the API:
 
 ```bash
 # Get API endpoint
-export API_ENDPOINT=$(npx cdk output AtxApiStack.ApiEndpoint --json | jq -r '.AtxApiStack.ApiEndpoint')
+export API_ENDPOINT=$(aws cloudformation describe-stacks --stack-name AtxApiStack \
+  --query "Stacks[0].Outputs[?OutputKey=='ApiEndpoint'].OutputValue" --output text)
 
 # Option 1: Run comprehensive test suite (recommended)
 cd ../test


### PR DESCRIPTION
*Issue #, if available:* n/a

## Description

Three documentation errors that each send a reader down a path that cannot work.

### 1. `cdk output` is not a CDK CLI command

Four snippets in `scaled-execution-containers` tell users to run `npx cdk output` to retrieve stack outputs. The CLI answers `Unknown command: output` and exits non-zero. This also silently empties the Next Steps snippet, since `export API_ENDPOINT=$(npx cdk output ...)` assigns an empty string and the subsequent API calls fail with a confusing error rather than an obvious one.

Replaced with `aws cloudformation describe-stacks` queries against the real output keys (`AtxApiStack` / `ApiEndpoint`, verified against `lib/api-stack.ts`), plus a note that outputs are printed by `cdk deploy` and that `cdk deploy --outputs-file` is available. `cdk deploy --all` elsewhere in the docs is valid and was left alone.

### 2. Eight prose references still say Claude Sonnet 4

#46 moved the orchestrator default to Claude Sonnet 4.5 "across the SAM template default, `config.env.template`, code fallbacks, and docs", but eight prose mentions were missed. The prerequisites and setup steps are the damaging ones: a reader who follows them enables only **Claude Sonnet 4** in the Bedrock console, which does not grant access to `us.anthropic.claude-sonnet-4-5-20250929-v1:0` — a separately gated model. The result is a deploy that appears to succeed, followed by `AccessDeniedException` on every orchestrator invocation.

Note for reviewers: `"Claude Sonnet 4"` is a substring of `"Claude Sonnet 4.5"`, so a naive grep over-reports. Only genuinely stale mentions were changed; occurrences that already read 4.5 were left untouched.

### 3. `config.env.template` documents a consumer that does not read it

The header lists `cdk/deploy.sh (reads AWS_REGION)`. It never sources the file — it derives the region from `aws configure get region`. Setting `AWS_REGION` there therefore sends the CDK stacks to one region while `sam/deploy.sh`, which does read the file, looks for the output bucket in another, producing a confusing "Output bucket not found" failure. The comment now describes the actual behaviour.

## Testing

- `cdk output --all` run against aws-cdk 2.x: `Unknown option(s): --all` / `Unknown command: output`, non-zero exit.
- Output keys cross-checked against the `CfnOutput` declarations in `cdk/lib/api-stack.ts` and `cdk/lib/infrastructure-stack.ts`, and stack names against `cdk/bin/cdk.ts`.
- Model references verified by grepping for `Sonnet 4` while excluding `4.5` / `4-5`; 8 stale mentions before, 0 after. The 13 code/config defaults were already correct and are unchanged.
- `cdk/deploy.sh` confirmed to contain no reference to `config.env`.

Documentation only — no code or infrastructure changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
