### PR TITLE
eks-version-upgrade-readiness: add EKS Version Rollback readiness

### DIFF
--- a/community-sourced-transformations/eks-version-upgrade-readiness/BENCHMARKS.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/BENCHMARKS.md
@@ -10,7 +10,7 @@
 | Automatic transformations | 19/19 applied correctly |
 | Flag-only items (PSP) | 2/2 correctly flagged, NOT auto-migrated |
 | Control resources (already compatible) | 0 modified (correct - no false positives) |
-| Rollback findings (run 4) | 6/6 reported with correct insight severity |
+| Rollback findings (run 4) | 6/6 reported with the correct classification |
 | Validation | `terraform validate` PASS, `helm template` PASS, YAML parse PASS, `kubeconform` PASS against both 1.34 and 1.33 schemas, `kubectl apply --dry-run=server` PASS against a live EKS 1.35 cluster (6/6 transformed resources accepted) |
 | `MIGRATION_REPORT.md` generated | 4/4 runs |
 | Total agent minutes | ~156.4 |
@@ -209,12 +209,20 @@ flagging it is the correct behaviour.
   happened) - the audit therefore ran against the working tree rather than `git diff baseline HEAD`.
   The reference set roughly doubled in size with the rollback material, so **budget 90-120 agent
   minutes** for this TD rather than 60.
-- **Addon matrix gap:** the report states a v2.8.0+ minimum for the AWS Load Balancer Controller on
-  1.34. The matrix in `references/eks-specific-changes.md` only has columns for 1.30+ and 1.32+, so
-  that figure is an extrapolation, not documented guidance. Worth adding an explicit 1.34+ column.
-- **Wording nit:** the report labels the VolumeAttributesClass adoption with insight severity
-  `ERROR`. It is an API-compatibility finding that *would* surface as an ERROR insight, but the
-  table conflates the skill's own classification with the cluster insight severity.
+- **Addon matrix gap (fixed 2026-08-20):** the report stated a v2.8.0+ minimum for the AWS Load
+  Balancer Controller on 1.34, extrapolated from the 1.30+ and 1.32+ columns. The root cause was the
+  matrix itself, which mixed AWS-published per-version data with community floors in a single table
+  and so invited projection. Adding a "1.34+" column would have made it worse, because AWS publishes
+  no floor for the LB Controller at any Kubernetes version — only a general "2.7.2 or later"
+  recommendation. `references/eks-specific-changes.md` now splits the two: an exact
+  per-Kubernetes-version table for the three EKS-managed add-ons (cited to the AWS docs) and a
+  floors table for self-managed add-ons carrying a source-of-truth link per row plus an explicit
+  instruction not to extrapolate to versions with no column.
+- **Severity labelling (fixed 2026-08-20):** the report labelled the VolumeAttributesClass adoption
+  with insight severity `ERROR`, conflating this skill's own risk rating with a cluster insight
+  severity — no insight exists for a repository finding. `references/rollback-readiness.md` now
+  states where severity is *quoted* (disruption controls and managed add-ons, per the Auto Mode
+  docs) and where it is *rated* by the skill (everything in the additions tables).
 
 ---
 

--- a/community-sourced-transformations/eks-version-upgrade-readiness/BENCHMARKS.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/BENCHMARKS.md
@@ -4,16 +4,17 @@
 
 | Metric | Result |
 |--------|--------|
-| Total repositories tested | 3 (Kubernetes manifests, Terraform, Helm chart) |
-| Transformation success rate | 100% (3/3) |
+| Total repositories tested | 4 (Kubernetes manifests, Terraform, Helm chart, mixed rollback-readiness fixture) |
+| Transformation success rate | 100% (4/4) |
 | Deprecated APIs detected | 9/9 planted incompatibilities detected (100%) |
-| Automatic transformations | 8/8 applied correctly |
-| Flag-only items (PSP) | 1/1 correctly flagged, NOT auto-migrated |
+| Automatic transformations | 19/19 applied correctly |
+| Flag-only items (PSP) | 2/2 correctly flagged, NOT auto-migrated |
 | Control resources (already compatible) | 0 modified (correct - no false positives) |
-| Validation | `terraform validate` PASS, `helm template` PASS, YAML parse PASS, `kubectl apply --dry-run=server` PASS against a live EKS 1.35 cluster (6/6 transformed resources accepted) |
-| `MIGRATION_REPORT.md` generated | 3/3 runs |
-| Total agent minutes | ~95.2 |
-| Total estimated cost | ~$3.33 (at $0.035/agent-minute) |
+| Rollback findings (run 4) | 6/6 reported with correct insight severity |
+| Validation | `terraform validate` PASS, `helm template` PASS, YAML parse PASS, `kubeconform` PASS against both 1.34 and 1.33 schemas, `kubectl apply --dry-run=server` PASS against a live EKS 1.35 cluster (6/6 transformed resources accepted) |
+| `MIGRATION_REPORT.md` generated | 4/4 runs |
+| Total agent minutes | ~156.4 |
+| Total estimated cost | ~$5.47 (at $0.035/agent-minute) |
 
 ### Methodology
 
@@ -39,7 +40,8 @@ Agent minutes = active agent work (planning, reasoning, code modification). Clie
 | 1 | k8s-manifests (4 files, 7 resources) | 1.21 -> 1.32 | ✅ SUCCESS | 5/5 | 4/4 | 1/1 (PSP) | YAML parse PASS | 38.5 | $1.35 |
 | 2 | terraform-eks (2 files, cluster + 2 node groups + 4 addons) | 1.28 -> 1.33 | ✅ SUCCESS | 7/7 | 7/7 | - | `terraform validate` PASS | 39.1 | $1.37 |
 | 3 | helm-chart (1 chart, 2 templates) | 1.21 -> 1.30 | ✅ SUCCESS | 2/2 | 2/2 | - | `helm template` PASS | 17.7 | $0.62 |
-| | **TOTALS** | | **3/3** | **14/14** | **13/13** | **1/1** | **3/3 PASS** | **~95.2** | **~$3.33** |
+| 4 | rollback-readiness fixture (18 files: 13 manifests + Terraform + Helm chart) | 1.33 -> 1.34 | ✅ SUCCESS | 14/14 | 11/11 | 1/1 (PSP) | `terraform validate` + `helm template` + `kubeconform` (1.34 and 1.33) PASS | 61.2 | $2.14 |
+| | **TOTALS** | | **4/4** | **28/28** | **24/24** | **2/2** | **4/4 PASS** | **~156.4** | **~$5.47** |
 
 ---
 
@@ -122,18 +124,114 @@ Agent minutes = active agent work (planning, reasoning, code modification). Clie
 
 ---
 
+### 4. Rollback readiness fixture - mixed repo (1.33 -> 1.34)
+
+**Purpose:** validate the rollback-readiness additions (N-1 classification, Auto Mode disruption
+blockers, Fargate caveat, version scoping). The 1.33 -> 1.34 hop was chosen deliberately: it is the
+boundary where `storage.k8s.io/v1` VolumeAttributesClass graduates, so a *correct* transformation
+is simultaneously a rollback blocker.
+
+**Input:** 18 files - 13 manifests, 1 Terraform config (cluster + node group + Fargate profile),
+1 Helm chart. Cases span forward blockers, rollback blockers, flag-only, negative controls, and one
+deliberately out-of-range case.
+
+| Planted case | Expected | Result |
+|---|---|---|
+| Ingress `extensions/v1beta1` | transform to `networking.k8s.io/v1` | PASS - backend restructured, `pathType: Prefix` added, ingress-class annotation moved to `spec.ingressClassName`, sibling ALB annotation preserved |
+| PDB `policy/v1beta1` | transform to `policy/v1` | PASS |
+| CronJob `batch/v1beta1` | transform to `batch/v1` | PASS |
+| HPA `autoscaling/v2beta2` | transform to `autoscaling/v2` | PASS |
+| Helm chart Ingress `extensions/v1beta1` | transform, keep templating | PASS - `{{ .Release.Name }}` / `{{ .Values... }}` expressions intact |
+| Terraform `version = "1.33"` | update to `"1.34"` | PASS |
+| Terraform `ami_type = "AL2_x86_64"` | update to AL2023 | PASS - `AL2023_x86_64_STANDARD` |
+| `values.yaml` LB controller `v2.6.2` | bump to a 1.34-compatible tag | PASS - `v2.8.1`, values structure preserved |
+| VolumeAttributesClass `storage.k8s.io/v1beta1` | transform to `v1` **and** flag as target-only | PASS - transformed, and annotated in-file with a `ROLLBACK IMPACT` comment naming 1.33 and the EBS CSI sidecar pinning caveat |
+| NodePool budget `nodes: "0"` for `Drifted` | report ERROR-class, fix with TODO | PASS - changed to `nodes: "10%"` with a TODO deferring the rate to the workload owner |
+| PDB `maxUnavailable: 0` | report WARNING-class, fix with TODO | PASS - changed to `1` with a TODO |
+| `karpenter.sh/do-not-disrupt` on a pod template | report-only WARNING, no code change | PASS - reported as manual item 5, file byte-identical |
+| Terraform Fargate profile | report that Fargate cannot roll back | PASS - reported as manual item 6 with the kubelet-skew ERROR explanation |
+| PodSecurityPolicy | flag only, never transform | PASS - file byte-identical, listed as CRITICAL manual item |
+| Correct Service / PDB / Deployment | untouched | PASS - all three byte-identical |
+| Non-canonical IP/CIDR (a **1.36** issue) | must NOT be reported as blocking for 1.34 | PASS - reported as a *future* item, explicitly "Not blocking for 1.34", file byte-identical |
+
+**Pass/Fail checks (validated independently, not from the agent's output):**
+
+```text
+PASS  helm template renders cleanly; rendered Ingress is networking.k8s.io/v1 with pathType,
+      and the rendered output passes kubeconform against 1.34
+PASS  terraform validate -> "Success! The configuration is valid." (provider aws v5.100.0)
+PASS  YAML parse: 13/13 manifests parse; apiVersion inventory confirms every transformation
+PASS  kubeconform v0.8.0 against Kubernetes 1.34 schemas:
+      13 resources / 13 files - Valid 11, Invalid 0, Errors 0, Skipped 2
+      (skipped = Karpenter NodePool, a CRD with no upstream schema, and PodSecurityPolicy)
+PASS  Negative controls byte-identical vs the git baseline: service-ok, pdb-ok, deploy-ok,
+      psp.yaml, netpol.yaml, deploy-ledger.yaml (6/6 UNTOUCHED)
+PASS  No removed-API GroupVersion left anywhere in manifests/ or chart/ (psp.yaml excluded
+      by design)
+PASS  MIGRATION_REPORT.md contains the Rollback Readiness section: eligibility verdict,
+      per-change N-1 column, disruption controls with insight severity, Fargate caveat,
+      Terraform rollbackConfig gap, and a staged recommendation
+```
+
+**Empirical confirmation of the N-1 classification.** The interesting result is running the same
+manifests against the **previous** version's schemas. The skill claimed exactly one change was
+target-only; the schema set agrees, and nothing else regressed:
+
+```text
+kubeconform -kubernetes-version 1.34.0   ->  Valid 11, Invalid 0, Skipped 2
+kubeconform -kubernetes-version 1.33.0   ->  Valid 10, Invalid 0, Skipped 3
+
+The one extra skip on 1.33 is manifests/volumeattributesclass.yaml. Isolated:
+  1.34.0  rc=0  VolumeAttributesClass gp3-fast is valid
+  1.33.0  rc=1  failed validation: could not find schema for VolumeAttributesClass
+
+That is the target-only verdict reproduced against upstream schemas rather than inferred
+from release notes: storage.k8s.io/v1 exists at 1.34 and does not exist at 1.33, so applying
+it does close the rollback window. Every other transformed resource validates on BOTH
+versions, matching its "safe on both" verdict.
+```
+
+Second negative confirmation, this one for the flag-only rule: PodSecurityPolicy has **no schema at
+1.34** (`could not find schema for PodSecurityPolicy`), independently reproducing what run 1 showed
+against a live cluster - the API really is gone, so transforming it would be meaningless and
+flagging it is the correct behaviour.
+
+**Notes and follow-ups from this run:**
+
+- **kubectl `--dry-run` was not used** in this run: the workstation kubeconfig pointed at a
+  decommissioned cluster, so kubectl could not fetch an OpenAPI schema for any file. `kubeconform`
+  against both version schema sets covers the same ground without a cluster, and run 1 already
+  covers live-cluster acceptance. Two resources have no upstream schema (the Karpenter NodePool CRD
+  and PSP) and are reported as skipped rather than passing.
+- **Budget:** the run exceeded a 60 agent-minute limit (61.23 used) and was cut at the agent's own
+  final `terraform validate`. All transformations and `MIGRATION_REPORT.md` were already complete on
+  disk, so the deliverables are intact, but they were left uncommitted (the ATX Bot commit never
+  happened) - the audit therefore ran against the working tree rather than `git diff baseline HEAD`.
+  The reference set roughly doubled in size with the rollback material, so **budget 90-120 agent
+  minutes** for this TD rather than 60.
+- **Addon matrix gap:** the report states a v2.8.0+ minimum for the AWS Load Balancer Controller on
+  1.34. The matrix in `references/eks-specific-changes.md` only has columns for 1.30+ and 1.32+, so
+  that figure is an extrapolation, not documented guidance. Worth adding an explicit 1.34+ column.
+- **Wording nit:** the report labels the VolumeAttributesClass adoption with insight severity
+  `ERROR`. It is an API-compatibility finding that *would* surface as an ERROR insight, but the
+  table conflates the skill's own classification with the cluster insight severity.
+
+---
+
 ## Exit Criteria Compliance (per SKILL.md)
 
-| # | Exit Criterion | Run 1 | Run 2 | Run 3 |
-|---|---|---|---|---|
-| 1 | No removed APIs remain for target version | ✅ | ✅ | ✅ |
-| 2 | Comments/labels/annotations preserved | ✅ | ✅ | ✅ |
-| 3 | No resource deleted | ✅ | ✅ | ✅ |
-| 4 | Ambiguous changes marked with TODO + report | ✅ (PSP) | n/a | n/a |
-| 5 | PSP flagged, never auto-migrated | ✅ | n/a | n/a |
-| 6 | Validators pass (where available) | ✅ YAML | ✅ terraform | ✅ helm |
-| 7 | MIGRATION_REPORT.md complete | ✅ | ✅ | ✅ |
-| 8 | Upgrade Execution Path with every sequential hop | ✅ (11 hops) | ✅ (5 hops) | ✅ (9 hops) |
+| # | Exit Criterion | Run 1 | Run 2 | Run 3 | Run 4 |
+|---|---|---|---|---|---|
+| 1 | No removed APIs remain for target version | ✅ | ✅ | ✅ | ✅ |
+| 2 | Comments/labels/annotations preserved | ✅ | ✅ | ✅ | ✅ |
+| 3 | No resource deleted | ✅ | ✅ | ✅ | ✅ |
+| 4 | Ambiguous changes marked with TODO + report | ✅ (PSP) | n/a | n/a | ✅ (PSP, NodePool, PDB) |
+| 5 | PSP flagged, never auto-migrated | ✅ | n/a | n/a | ✅ |
+| 6 | Validators pass (where available) | ✅ YAML | ✅ terraform | ✅ helm | ✅ terraform + helm + kubeconform (1.34 and 1.33) |
+| 7 | MIGRATION_REPORT.md complete | ✅ | ✅ | ✅ | ✅ |
+| 8 | Upgrade Execution Path with every sequential hop | ✅ (11 hops) | ✅ (5 hops) | ✅ (9 hops) | ✅ (1 hop) |
+| 9 | N-1 verdict per change; target-only annotated in code | n/a | n/a | n/a | ✅ (11/11 rows, confirmed by dual-version kubeconform) |
+| 10 | Disruption controls reported with insight severity; no cluster API called | n/a | n/a | n/a | ✅ (4 findings, zero cluster calls) |
 
 ---
 
@@ -142,6 +240,13 @@ Agent minutes = active agent work (planning, reasoning, code modification). Clie
 ```bash
 # Manifest structural validation
 python3 -c "import yaml,glob; [list(yaml.safe_load_all(open(f))) for f in glob.glob('manifests/*.yaml')]"
+
+# Schema validation without a cluster, against BOTH sides of the upgrade hop.
+# Running the target version proves the manifests are valid after transformation;
+# running N-1 proves which changes are target-only (and therefore rollback-blocking).
+kubeconform -kubernetes-version 1.34.0 -summary -verbose -ignore-missing-schemas manifests/
+kubeconform -kubernetes-version 1.33.0 -summary -verbose -ignore-missing-schemas manifests/
+helm template storefront ./chart | kubeconform -kubernetes-version 1.34.0 -summary -
 
 # Live cluster validation (Amazon EKS 1.35)
 aws eks update-kubeconfig --name <cluster> --region us-east-1

--- a/community-sourced-transformations/eks-version-upgrade-readiness/README.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/README.md
@@ -1,6 +1,6 @@
 # EKS Version Upgrade Readiness
 
-Analyzes and transforms customer code (Kubernetes manifests, Helm charts, Kustomize overlays, Terraform, and CDK) for compatibility with a target Amazon EKS/Kubernetes version — detecting removed/deprecated APIs, updating `apiVersion` fields and resource structures, validating addon compatibility, and producing a migration report with clear manual action items.
+Analyzes and transforms customer code (Kubernetes manifests, Helm charts, Kustomize overlays, Terraform, and CDK) for compatibility with a target Amazon EKS/Kubernetes version — detecting removed/deprecated APIs, updating `apiVersion` fields and resource structures, validating addon compatibility, checking rollback readiness, and producing a migration report with clear manual action items.
 
 **Supports Kubernetes manifests · Helm charts · Kustomize overlays · Terraform · AWS CDK**
 
@@ -11,6 +11,7 @@ Analyzes and transforms customer code (Kubernetes manifests, Helm charts, Kustom
 - [What This Skill Does](#what-this-skill-does)
 - [Skill Architecture](#skill-architecture)
 - [Code Readiness vs. Cluster Upgrade Execution](#code-readiness-vs-cluster-upgrade-execution)
+- [Rollback Readiness](#rollback-readiness)
 - [Getting Started](#getting-started)
 - [Getting Started with AWS Transform Custom](#getting-started-with-aws-transform-custom)
 - [Benchmarks](#benchmarks)
@@ -34,6 +35,7 @@ Teams preparing for an EKS version upgrade face:
 - **EKS-specific breakage not covered by upstream docs**: AL2 AMI discontinuation, StorageClass default annotation removal, new required IAM permissions, anonymous auth restrictions.
 - **Addon version drift**: VPC CNI, CoreDNS, EBS CSI Driver, and other addons have minimum version requirements per EKS release that are easy to miss.
 - **No single source of truth spanning the full upgrade path**: multi-hop upgrades (e.g., 1.28 -> 1.32) accumulate breaking changes from every intermediate version.
+- **A rollback path that the code can silently invalidate**: with EKS Version Rollback, a change that is correct for the target version can be the reason a rollback is refused three days later.
 
 ## What This Skill Does
 
@@ -43,12 +45,15 @@ Teams preparing for an EKS version upgrade face:
    - Structural field changes (renames, new required fields)
    - EKS-specific changes (AMI type deprecation, StorageClass defaults, IAM requirements)
    - Addon version incompatibilities (VPC CNI, EBS CSI, CoreDNS, kube-proxy, and others)
+   - Rollback blockers: target-only APIs, fields and enum values that do not exist in N-1
+   - Disruption controls that stall node replacement (NodePool disruption budgets, `karpenter.sh/do-not-disrupt`, PDBs with `maxUnavailable: 0`)
 3. **Transform** automatically:
    - Update `apiVersion` fields to the replacement API
    - Restructure fields that changed shape (e.g., Ingress backend)
    - Add newly required fields with sensible defaults (e.g., `pathType: Prefix`)
    - Update Terraform `ami_type` from AL2 to AL2023 for 1.33+ targets
    - Update Terraform/CDK cluster version strings
+   - Annotate every target-only change as rollback-blocking
 4. **Validate** transformed output:
    - `kubectl apply --dry-run=client` on manifests (if kubectl is available)
    - `helm template` on charts (if Helm is available)
@@ -59,6 +64,7 @@ Teams preparing for an EKS version upgrade face:
    - Addon compatibility warnings with recommended versions
    - Risk assessment (low/medium/high) per change
    - An **Upgrade Execution Path** section listing every sequential hop required, since EKS does not support skip-version upgrades
+   - A **Rollback Readiness** section: N-1 verdict per change, disruption blockers with their mapped insight severity, the Fargate caveat, and `rollbackConfig` support per IaC tool
 
 ## Skill Architecture
 
@@ -67,6 +73,7 @@ Input: Customer repo + target EKS version (via additionalPlanContext)
   |
   +-- 1. Scan    -> identify all manifests/charts/configs
   +-- 2. Detect  -> map deprecated/removed APIs across the full upgrade path
+  +--               + rollback blockers and disruption controls
   +-- 3. Transform -> update apiVersions, fields, and configs automatically
   +-- 4. Validate  -> dry-run / helm template / terraform validate
   +-- 5. Report    -> MIGRATION_REPORT.md with manual action items
@@ -78,6 +85,7 @@ Input: Customer repo + target EKS version (via additionalPlanContext)
 2. **Never remove, only transform.** Resources are never deleted. Ambiguous transformations are flagged with a TODO comment and documented in the report rather than guessed.
 3. **PodSecurityPolicy is flag-only.** PSP removal (EKS 1.25+) requires a Pod Security Admission design decision that cannot be automated safely — it is always reported, never auto-migrated.
 4. **Sequential-hop awareness.** EKS requires upgrading one minor version at a time. The skill always documents every intermediate hop in the target version string, even when transforming code directly to the final target.
+5. **Rollback is a report dimension, never an action.** The skill classifies each change against N-1 and flags disruption blockers, but it never calls a cluster API and never decides whether to roll back. Rollback tables are also bounded to versions still in support, so the reference material self-prunes instead of growing without limit.
 
 ## Code Readiness vs. Cluster Upgrade Execution
 
@@ -89,6 +97,28 @@ Preparing for an EKS version upgrade has two distinct halves — this skill cove
 | **Cluster upgrade execution** | The **cluster**: control plane + data plane version upgrades, staged rollouts, maintenance windows — see [EKS cluster upgrade best practices](https://docs.aws.amazon.com/eks/latest/best-practices/cluster-upgrades.html) and [EKS Upgrade Insights](https://docs.aws.amazon.com/eks/latest/userguide/cluster-insights.html) |
 
 Used together they provide end-to-end upgrade readiness: code prepared ahead of time, then the cluster upgraded through a sequential, validated process. `MIGRATION_REPORT.md` documents the full sequential Upgrade Execution Path and points to the official EKS upgrade guidance as the execution reference.
+
+## Rollback Readiness
+
+[Amazon EKS Version Rollback](https://docs.aws.amazon.com/eks/latest/userguide/rollback-cluster.html) reverts the control plane one minor version (N to N-1) within 7 days of an in-place upgrade, gated by [`ROLLBACK_READINESS` cluster insights](https://docs.aws.amazon.com/eks/latest/userguide/cluster-insights.html). That makes backward compatibility a **code** requirement: during the window, what is deployed has to be valid on both versions.
+
+Three reasons this belongs in a code-readiness skill:
+
+| | |
+|---|---|
+| **Timing** | Rollback readiness insights only run **after** the upgrade, and only for 7 days. This skill runs **before**, so a blocker can be designed around instead of discovered during an incident. |
+| **Coverage** | The insights check **EKS-managed add-ons only** (CoreDNS, VPC CNI, kube-proxy), and not even those when the version was overridden outside the add-on lifecycle. Karpenter, the AWS Load Balancer Controller, Istio, Argo CD and cluster-autoscaler are the customer's responsibility — and this skill already reads their manifests and Helm values. |
+| **Surface** | Four of the EKS Auto Mode checks are plain YAML the skill already parses: NodePool disruption budgets, `karpenter.sh/do-not-disrupt` on pods, PodDisruptionBudgets, and node annotations. The same controls throttle the **data plane upgrade**, so the check pays off even when no rollback is planned. |
+
+What the report adds:
+
+- **An N-1 verdict per change** — `safe on both` or `target-only (closes the rollback window)`. Target-only changes are still applied; the target version is what was requested. They are annotated in the code, not silently suppressed.
+- **Disruption blockers with the mapped insight severity** — a NodePool budget of `nodes: "0"` covering `Drifted` and a `karpenter.sh/do-not-disrupt` annotation on a node are `ERROR` (they block); a do-not-disrupt annotation on a pod and a PDB with `maxUnavailable: 0` are `WARNING` (they delay). Note that `--force` bypasses insight checks only — disruption controls are always honored.
+- **The Fargate caveat** — Fargate worker nodes cannot roll back; Fargate pods trigger the kubelet skew insight as an `ERROR`.
+- **`rollbackConfig` support per IaC tool** — CloudFormation supports it, CDK exposes it on the L1 `CfnCluster` only, and the Terraform AWS provider has no `rollback_config` argument at all (verified 2026-08-18), so there it is reported rather than transformed.
+- **A staged sequence that preserves the window** — add-ons cross-compatible with N-1/N/N+1, then control plane, then a bake period, then data plane.
+
+Scope boundary: the skill never calls `update-cluster-version`, `list-insights`, `describe-insight`, or `cancel-update`. Full detail, including the per-version table of what was **added** in each release, is in [references/rollback-readiness.md](references/rollback-readiness.md).
 
 ## Getting Started
 
@@ -140,10 +170,10 @@ atx custom def exec \
 
 ```text
 MIGRATION_REPORT.md   # summary, manual action items, addon warnings, risk assessment,
-                       # and Upgrade Execution Path (sequential hops)
+                       # Upgrade Execution Path (sequential hops), and Rollback Readiness
 ```
 
-Plus the transformed manifests/charts/Terraform/CDK files in place, with ambiguous changes marked via `TODO` comments.
+Plus the transformed manifests/charts/Terraform/CDK files in place, with ambiguous changes marked via `TODO` comments and rollback-blocking changes annotated.
 
 ## Benchmarks
 
@@ -159,8 +189,10 @@ End-to-end test results — repositories tested via `atx custom def exec`, what 
 | Validation steps reported as skipped | `kubectl`, `helm`, or `terraform` not installed on the machine running the transformation | Install the missing tool or accept the skip — validation is best-effort and the transform output is unaffected |
 | Helm chart values not updated | By design — `values.yaml` structure and keys are preserved; only addon image tags below the minimum compatible version are bumped | Review the addon warnings section of `MIGRATION_REPORT.md` for manual value updates |
 | PodSecurityPolicy still present after the run | By design — PSP migration requires a Pod Security Admission decision and is never automated | Follow the manual action item in `MIGRATION_REPORT.md` |
+| Rollback Readiness section is empty or says "not applicable" | One or both versions of the hop are outside EKS standard/extended support, so a rollback is not available | Expected — confirm against the [EKS release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) |
+| A change is applied even though it is flagged as rollback-blocking | By design — the target version is what was requested; the finding is informational so the change can be scheduled after the 7-day window | Review the Rollback Readiness section and decide when to land those changes |
 
-
+## Known Limitations
 
 | Limitation | Notes |
 |---|---|
@@ -168,6 +200,10 @@ End-to-end test results — repositories tested via `atx custom def exec`, what 
 | Custom admission webhooks with non-standard defaults | Flagged for manual review, not transformed |
 | Skip-version upgrades | Not supported by EKS itself; the skill always documents the full sequential path |
 | Cluster-level upgrade execution | Out of scope — follow the [EKS cluster upgrade best practices](https://docs.aws.amazon.com/eks/latest/best-practices/cluster-upgrades.html) for orchestration |
+| Rollback execution and live eligibility | Out of scope — no cluster API is ever called. The skill reports the code-side pre-flight only; actual eligibility comes from `ROLLBACK_READINESS` insights on the cluster |
+| Rollback analysis outside the supported-version window | Deliberately not evaluated. A rollback needs both N and N-1 in standard or extended support, so the reference tables only cover that range and rows are removed as versions age out |
+| Node-level rollback blockers | `karpenter.sh/do-not-disrupt` on a **node** is cluster state, not repository code — reported as guidance, not detected |
+| Terraform `rollback_config` | The AWS provider has no such argument (verified 2026-08-18), so the rollback timeout cannot be expressed in Terraform — reported, not transformed |
 
 ## Documentation & References
 
@@ -175,8 +211,9 @@ End-to-end test results — repositories tested via `atx custom def exec`, what 
 |---|---|
 | [SKILL.md](SKILL.md) | Complete skill definition — objective, scope, workflow, and validation criteria |
 | [references/api-removals-by-version.md](references/api-removals-by-version.md) | Complete table of Kubernetes API removals per version (1.16 through 1.36), plus a quick "upgrading from X to Y" lookup |
-| [references/eks-specific-changes.md](references/eks-specific-changes.md) | EKS-specific changes per version, addon compatibility matrix, and Terraform/CDK/Helm update patterns |
-| [references/examples-before-after.md](references/examples-before-after.md) | 8 concrete before/after transformation examples covering Ingress, PDB, CronJob, HPA, FlowSchema, CRDs, Terraform node groups, and webhooks |
+| [references/eks-specific-changes.md](references/eks-specific-changes.md) | EKS-specific changes per version, disruption controls, addon compatibility matrix, and Terraform/CDK/Helm update patterns |
+| [references/rollback-readiness.md](references/rollback-readiness.md) | Inverse lookup of what was **added** per version, Auto Mode disruption blockers with insight severity, add-on cross-compatibility strategy, and `rollbackConfig` support per IaC tool |
+| [references/examples-before-after.md](references/examples-before-after.md) | 12 concrete before/after transformation examples covering Ingress, PDB, CronJob, HPA, FlowSchema, CRDs, Terraform node groups, webhooks, NodePool disruption budgets, rollback-blocking API adoption, and IP/CIDR canonicalization |
 | [BENCHMARKS.md](BENCHMARKS.md) | End-to-end test results: repositories tested, detections, transformations, and pass/fail outcomes |
 
 ## Repository Structure
@@ -188,6 +225,7 @@ eks-version-upgrade-readiness/
 ├── BENCHMARKS.md                          # End-to-end test results with real repositories
 └── references/
     ├── api-removals-by-version.md         # Kubernetes API removals per version (1.16–1.36)
-    ├── eks-specific-changes.md            # EKS-specific changes + addon compatibility matrix
-    └── examples-before-after.md           # 8 before/after transformation examples
+    ├── eks-specific-changes.md            # EKS-specific changes, disruption controls, addon matrix
+    ├── rollback-readiness.md              # What was ADDED per version, Auto Mode blockers, rollbackConfig
+    └── examples-before-after.md           # 12 before/after transformation examples
 ```

--- a/community-sourced-transformations/eks-version-upgrade-readiness/SKILL.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/SKILL.md
@@ -4,17 +4,19 @@ description: >-
   Analyzes and transforms Kubernetes manifests, Helm charts, Kustomize
   overlays, Terraform, and AWS CDK code for Amazon EKS version upgrade
   compatibility. Detects removed and deprecated APIs, updates apiVersions
-  and resource fields, validates addon compatibility, and generates a
+  and resource fields, validates addon compatibility, checks rollback
+  readiness (N-1 compatibility and disruption controls), and generates a
   migration report with manual action items and a sequential upgrade path.
   Trigger: EKS upgrade, Kubernetes version upgrade, API deprecation,
-  apiVersion migration, addon compatibility.
+  apiVersion migration, addon compatibility, EKS version rollback,
+  rollback readiness.
 ---
 
 # EKS Version Upgrade Readiness
 
 ## Objective
 
-Prepare a customer's code (manifests, charts, IaC) for an Amazon EKS/Kubernetes version upgrade by detecting and transforming deprecated or removed APIs, EKS-specific breaking changes, and addon incompatibilities — producing a migration report that documents everything the worker cannot safely automate.
+Prepare a customer's code (manifests, charts, IaC) for an Amazon EKS/Kubernetes version upgrade by detecting and transforming deprecated or removed APIs, EKS-specific breaking changes, and addon incompatibilities — producing a migration report that documents everything the worker cannot safely automate, including which changes would block an EKS Version Rollback.
 
 ## Scope
 
@@ -27,11 +29,14 @@ Analyzes and transforms:
 
 Supports upgrades between any EKS versions from 1.16 through 1.36+.
 
+Rollback readiness analysis is scoped to EKS versions in standard or extended support, because a rollback requires both sides of the hop (N and N-1) to be supported versions.
+
 **Non-Goals** (out of scope for this skill):
 1. Executing the actual cluster upgrade (control plane / data plane) — follow the EKS cluster upgrade best practices (https://docs.aws.amazon.com/eks/latest/best-practices/cluster-upgrades.html) and validate with EKS Upgrade Insights before each sequential hop.
-2. PodSecurityPolicy migration — removed entirely in Kubernetes 1.25. Requires a Pod Security Admission or third-party webhook design decision that cannot be automated safely. Always flagged in the report, never transformed.
-3. Custom admission webhook business logic — only the `admissionregistration.k8s.io` API shape and required defaults are updated; webhook implementation logic is out of scope.
-4. Non-EKS Kubernetes distributions — API removal mapping is upstream Kubernetes, but EKS-specific sections (AMI types, addon matrix, IAM requirements) assume Amazon EKS.
+2. Executing or evaluating a rollback on a live cluster. The skill never calls `update-cluster-version`, `list-insights`, `describe-insight`, or `cancel-update`. It produces the code-side pre-flight; the rollback decision and execution belong to the cluster operator.
+3. PodSecurityPolicy migration — removed entirely in Kubernetes 1.25. Requires a Pod Security Admission or third-party webhook design decision that cannot be automated safely. Always flagged in the report, never transformed.
+4. Custom admission webhook business logic — only the `admissionregistration.k8s.io` API shape and required defaults are updated; webhook implementation logic is out of scope.
+5. Non-EKS Kubernetes distributions — API removal mapping is upstream Kubernetes, but EKS-specific sections (AMI types, addon matrix, IAM requirements, rollback behavior) assume Amazon EKS.
 
 ## Constraints
 
@@ -45,20 +50,29 @@ Supports upgrades between any EKS versions from 1.16 through 1.36+.
 - Terraform/CDK `cluster_version` / `KubernetesVersion` strings are set to the TARGET version in code (the code itself must be forward-compatible), but `MIGRATION_REPORT.md` must always list each intermediate sequential hop required to get there.
 - `MIGRATION_REPORT.md` must include a section "Upgrade Execution Path" listing every hop and pointing to the official EKS upgrade guidance (cluster upgrade best practices + EKS Upgrade Insights) as the execution reference — this skill never executes the upgrade itself.
 
+### Rollback Window Awareness
+- EKS Version Rollback reverts the control plane one minor version (N to N-1) within 7 days of an in-place upgrade. During that window the deployed code must be valid on **both** versions, so forward compatibility alone is not sufficient.
+- Every transformation carries an N-1 verdict: `safe on both` or `target-only (closes the rollback window)`. Classification rules are in `references/rollback-readiness.md`.
+- A target-only change is still applied — the target version is what the customer asked for. It is annotated in the code and reported, never silently suppressed and never silently applied.
+- Disruption controls found in the repository (NodePool disruption budgets, `karpenter.sh/do-not-disrupt` annotations, PodDisruptionBudgets) are reported with the EKS insight severity they map to: `ERROR` blocks a rollback, `WARNING` delays it. These same controls also throttle the data plane upgrade, so they are reported regardless of rollback intent.
+- Rollback checks apply only when both the source and target versions are in EKS standard or extended support. Outside that range, state that rollback is not available rather than evaluating it.
+
 ### Helm-Specific
 - Transform templates but preserve the `values.yaml` structure and keys.
 - Only update addon image tags in values when the current tag is clearly below the minimum compatible version for the target EKS release (see addon compatibility matrix in `references/eks-specific-changes.md`).
+- When the rollback window must stay open, the addon target is a cross-compatible **range** (N-1, N, N+1), not just the minimum floor for N.
 
 ### Reporting
 - Every automatic change and every manual action item must be traceable to a specific file and line.
-- Risk assessment (low/medium/high) is required per change in the report — not just a flat list.
+- Risk assessment (low/medium/high) is required per change — not just a flat list.
 
 ## Workflow
 
 ```text
 Phase 0: Detect source and target versions
   ├── Read additionalPlanContext for explicit source/target versions
-  └── If source not specified, detect from existing cluster_version / apiVersion usage
+  ├── If source not specified, detect from existing cluster_version / apiVersion usage
+  └── Determine whether the hop is rollback-eligible (both versions in support)
 
 Phase 1: Scan
   ├── Identify all manifests, charts, Kustomize overlays, Terraform, CDK files
@@ -68,15 +82,20 @@ Phase 2: Detect incompatibilities
   ├── Map every apiVersion against references/api-removals-by-version.md
   │     for each version between source and target (inclusive)
   ├── Map EKS-specific changes against references/eks-specific-changes.md
-  └── Check addon versions (VPC CNI, CoreDNS, kube-proxy, EBS/EFS CSI,
-        AWS LB Controller, etc.) against the compatibility matrix
+  ├── Check addon versions (VPC CNI, CoreDNS, kube-proxy, EBS/EFS CSI,
+  │     AWS LB Controller, etc.) against the compatibility matrix
+  └── Rollback pre-flight (references/rollback-readiness.md):
+        ├── target-only APIs, fields and enum values that do not exist in N-1
+        ├── disruption controls that block or delay node replacement
+        └── Fargate profiles, which cannot roll back at all
 
 Phase 3: Transform
   ├── Update apiVersion fields to the replacement API
   ├── Restructure fields that changed shape (see references/examples-before-after.md)
   ├── Add newly required fields with sensible defaults
   ├── Update Terraform ami_type (AL2 -> AL2023) for 1.33+ targets
-  └── Update Terraform/CDK cluster version strings to the target version
+  ├── Update Terraform/CDK cluster version strings to the target version
+  └── Annotate every target-only change as rollback-blocking
 
 Phase 4: Validate
   ├── kubectl apply --dry-run=client (if kubectl available)
@@ -90,6 +109,8 @@ Phase 5: Report
         - Addon compatibility warnings with recommended versions
         - Risk assessment (low/medium/high) per change
         - Upgrade Execution Path (sequential hops + official EKS upgrade guidance)
+        - Rollback Readiness (N-1 verdict per change, disruption blockers with
+          insight severity, Fargate caveat, rollbackConfig support per IaC tool)
 ```
 
 ### Configuration
@@ -135,7 +156,7 @@ spec:
                   number: 80
 ```
 
-Full example set (8 transformations covering Ingress, PodDisruptionBudget, CronJob, HorizontalPodAutoscaler, FlowSchema, CustomResourceDefinition, Terraform node groups, and admission webhooks) is in `references/examples-before-after.md`.
+Full example set (12 transformations covering Ingress, PodDisruptionBudget, CronJob, HorizontalPodAutoscaler, FlowSchema, CustomResourceDefinition, Terraform node groups, admission webhooks, Karpenter NodePool disruption budgets, PDBs that stall node replacement, rollback-blocking API adoption, and non-canonical IP/CIDR values) is in `references/examples-before-after.md`.
 
 ## Reference Dispatch
 
@@ -146,6 +167,7 @@ Load reference files on demand based on what the scan finds:
 | Any `apiVersion` field in a manifest, chart template, or Kustomize resource | `references/api-removals-by-version.md` |
 | `aws_eks_cluster`, `aws_eks_node_group`, `ami_type`, EKS CDK constructs, addon image tags | `references/eks-specific-changes.md` |
 | Any detected incompatibility requiring a concrete before/after transformation | `references/examples-before-after.md` |
+| The hop is rollback-eligible, or the repo contains `karpenter.sh/v1` NodePools, PodDisruptionBudgets, `karpenter.sh/do-not-disrupt` annotations, Fargate profiles, or APIs introduced in the target version | `references/rollback-readiness.md` |
 
 ## Validation / Exit Criteria
 
@@ -155,11 +177,16 @@ Load reference files on demand based on what the scan finds:
 4. Ambiguous transformations are marked with a `TODO` comment in code and documented in the report.
 5. PodSecurityPolicy usage, if present, is flagged in the report and NOT auto-migrated.
 6. `kubectl apply --dry-run=client`, `helm template`, and/or `terraform validate` pass for all transformed files (for whichever tools are available on the host).
-7. `MIGRATION_REPORT.md` exists and contains: summary of changes, manual action items, addon compatibility warnings, risk assessment per change, and an Upgrade Execution Path section.
+7. `MIGRATION_REPORT.md` exists and contains: summary of changes, manual action items, addon compatibility warnings, risk assessment per change, an Upgrade Execution Path section, and a Rollback Readiness section.
 8. The Upgrade Execution Path lists every sequential minor-version hop between source and target and references the official EKS cluster upgrade best practices as the execution guidance.
+9. Every transformation in the report carries an explicit N-1 verdict (`safe on both` or `target-only`), and every target-only change is annotated in the code as rollback-blocking.
+10. Every disruption control found in the repository is reported with its mapped insight severity, and no cluster API was called at any point.
 
 ## Tips
 
 - EKS does not support skip-version cluster upgrades — always resolve the full source-to-target version range before scanning for API removals, even if you only need to report on the final target.
 - AL2 AMIs stopped being released starting with EKS 1.33 — any node group or launch template still using `AL2_x86_64`/`AL2_ARM_64` targeting 1.33+ needs an `ami_type` update to AL2023 or Bottlerocket.
 - An empty `policy/v1` PodDisruptionBudget selector (`{}`) selects ALL pods in the namespace — this is a behavior change from `policy/v1beta1` (which selected none) and must be called out explicitly in the report, not just transformed silently.
+- EKS Rollback Readiness Insights only run after an upgrade and only for 7 days, and they cover EKS-managed add-ons only. This skill runs before the upgrade and reads self-managed addon manifests, so its rollback findings are additive to what EKS reports, not a duplicate of it.
+- Not every `apiVersion` bump is rollback-safe. Moving to a GroupVersion that graduated in the target release (for example `storage.k8s.io/v1` VolumeAttributesClass in 1.34) is correct for the target and simultaneously closes the rollback window — apply it, then say so.
+- `--force` on a rollback bypasses insight checks only. PodDisruptionBudgets, NodePool disruption budgets, and do-not-disrupt annotations are always honored, which is why they belong in the code-side report.

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
@@ -128,23 +128,66 @@ Full severity mapping and examples: `rollback-readiness.md`.
 
 ## Addon Compatibility Matrix (common addons)
 
-When upgrading EKS, addon versions must also be compatible:
+Two different questions live here, and merging them into one table is how an invented version
+number gets produced: AWS publishes an exact per-Kubernetes-version list for the add-ons **it**
+manages, and publishes **no** per-version floor for anything else. They are kept apart for that
+reason.
 
-| Addon | Min version for EKS 1.30+ | Min version for EKS 1.32+ |
-|-------|---------------------------|---------------------------|
-| VPC CNI | v1.16.0+ | v1.18.0+ |
-| CoreDNS | v1.11.1+ | v1.11.3+ |
-| kube-proxy | Match cluster version | Match cluster version |
-| EBS CSI Driver | v1.28.0+ | v1.35.0+ |
-| EFS CSI Driver | v2.0.0+ | v2.1.0+ |
-| AWS LB Controller | v2.7.0+ | v2.8.0+ |
-| Cert-Manager | v1.14.0+ | v1.15.0+ |
-| Ingress-NGINX | v1.10.0+ | v1.11.0+ |
-| ArgoCD | v2.10.0+ | v2.12.0+ |
-| Karpenter | v0.35.0+ | v1.0.0+ |
-| Istio | v1.20+ | v1.22+ |
+### EKS-managed add-ons: exact version per Kubernetes version
 
-**Note:** Always verify exact compatibility in addon release notes. This table is approximate guidance.
+AWS publishes the latest EKS add-on build for every supported Kubernetes version. When the report
+needs to name a concrete version for these three, take it from here rather than from a floor.
+
+| Kubernetes version | `kube-proxy` | CoreDNS | VPC CNI |
+|---|---|---|---|
+| 1.36 | `v1.36.0-eksbuild.14` | `v1.14.3-eksbuild.3` | `v1.22.4-eksbuild.3` |
+| 1.35 | `v1.35.3-eksbuild.13` | `v1.14.3-eksbuild.3` | `v1.22.4-eksbuild.3` |
+| 1.34 | `v1.34.6-eksbuild.13` | `v1.13.2-eksbuild.11` | `v1.22.4-eksbuild.3` |
+| 1.33 | `v1.33.10-eksbuild.13` | `v1.12.4-eksbuild.18` | `v1.22.4-eksbuild.3` |
+| 1.32 | `v1.32.13-eksbuild.16` | `v1.11.4-eksbuild.40` | `v1.22.4-eksbuild.3` |
+| 1.31 | `v1.31.14-eksbuild.20` | `v1.11.4-eksbuild.40` | `v1.22.4-eksbuild.3` |
+
+Verified 2026-08-20 against the AWS docs: [kube-proxy versions](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html),
+[CoreDNS versions](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html),
+[VPC CNI versions](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html).
+
+Three things this table does **not** say:
+
+- These are the **latest** published builds, not minimum floors. An older build can be perfectly
+  valid; a build newer than the row simply does not exist for that version.
+- The values move with every EKS patch release, so treat the `-eksbuildN` suffix as guidance for
+  the report, not as an assertion to hard-code.
+- They describe the **EKS add-on** type. A self-managed install of the same component follows the
+  upstream project's own versioning and will not match these strings.
+
+`kube-proxy` must additionally stay within the supported version skew of the control plane, which
+is why "match the cluster version" remains the rule of thumb for it.
+
+VPC CNI is currently the same build across 1.31 to 1.36, so in this window it is effectively
+version-independent and a VPC CNI finding is rarely a per-version upgrade blocker.
+
+### Self-managed add-ons: minimum floors, and where the number comes from
+
+AWS publishes no per-Kubernetes-version compatibility floor for these. The floors below are
+guidance for the ranges shown; the right-hand column is the actual source of truth.
+
+| Addon | Min for EKS 1.30+ | Min for EKS 1.32+ | Source of truth |
+|---|---|---|---|
+| EBS CSI Driver | v1.28.0+ | v1.35.0+ | [aws-ebs-csi-driver releases](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases) |
+| EFS CSI Driver | v2.0.0+ | v2.1.0+ | [aws-efs-csi-driver releases](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases) |
+| AWS LB Controller | v2.7.0+ | v2.8.0+ | [aws-load-balancer-controller releases](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases) |
+| Cert-Manager | v1.14.0+ | v1.15.0+ | [cert-manager supported releases](https://cert-manager.io/docs/releases/) |
+| Ingress-NGINX | v1.10.0+ | v1.11.0+ | [kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx) (retired upstream March 2026) |
+| ArgoCD | v2.10.0+ | v2.12.0+ | [argo-cd releases](https://github.com/argoproj/argo-cd/releases) |
+| Karpenter | v0.35.0+ | v1.0.0+ | [Karpenter compatibility matrix](https://karpenter.sh/docs/upgrading/compatibility/) |
+| Istio | v1.20+ | v1.22+ | [Istio supported releases](https://istio.io/latest/docs/releases/supported-releases/) |
+
+**Do not extrapolate this table.** There is deliberately no column for 1.33, 1.34, 1.35 or 1.36:
+AWS documents no floor for those versions, and projecting the trend yields a number that looks
+sourced and is not. For a target with no column, report that the floor is undocumented, cite the
+source-of-truth link, and — when the repository pins a version — state whether that pin sits inside
+or outside the upstream project's own supported window. Naming an invented minimum is worse than
+naming none, because the reader cannot tell the difference.
 
 ### Reading the matrix when a rollback window matters
 

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
@@ -2,10 +2,66 @@
 
 Changes that are Amazon EKS-specific (not upstream Kubernetes) and affect customer workloads/configs.
 
+Sections are ordered newest first. For the inverse question — "what did I adopt in N that does
+not exist in N-1, and therefore blocks a rollback" — see `rollback-readiness.md`.
+
+## EKS 1.36
+
+- **IPVS mode removed from kube-proxy** - Must use iptables or nftables proxy mode.
+- Action: Update kube-proxy ConfigMap `mode` field. Remove IPVS-related configs.
+- **gogo protobuf removed from K8s API types** - Affects Go clients consuming K8s API types directly.
+- Action: Update Go dependencies using `k8s.io/code-generator` instead of `gogo/protobuf`.
+- **`gitRepo` volume permanently disabled** - The API still accepts Pods with `gitRepo` volumes, but the kubelet refuses to run them and returns an error. Cannot be re-enabled.
+- Action: Migrate to an init container or a git-sync sidecar container before upgrading.
+- **Strict IP/CIDR validation on by default** - `StrictIPCIDRValidation` rejects IP values with extraneous leading zeros (`010.000.000.005`) and CIDRs with ambiguous semantics (`192.168.0.5/24` instead of `192.168.0.0/24`) on create and update. Existing stored objects survive via validation ratcheting. Does not apply to custom resource kinds.
+- Action: Scan manifests, Helm charts, and automation for non-canonical IP/CIDR notation and normalize it. This is a pure text pattern and is one of the cheapest high-confidence detections in the whole skill.
+- **SELinux volume labeling GA** - Faster labeling now defaults to all volumes using `mount -o context` instead of recursive relabeling. Sharing a volume between privileged and unprivileged Pods on the same node may break.
+- Action: On SELinux-enforcing systems, audit `seLinuxChangePolicy` and volume labels on Pods before upgrading.
+- **User Namespaces stable** - `spec.hostUsers` maps container root to an unprivileged host user.
+- **Service `spec.externalIPs` deprecated** - Deprecation warnings on create/update. Removal planned for 1.43.
+- Action: Plan migration to LoadBalancer Services, NodePort, or Gateway API.
+
+## EKS 1.35
+
+- **cgroup v1 support removed** - Kubelet refuses to start on cgroup v1 nodes by default.
+- Action: AL2023 already uses cgroup v2. If manually configured cgroup v1, set `failCgroupV1: false` or migrate to cgroup v2. Bottlerocket 1.35 sets `failCgroupV1: false` for backward compatibility. Fargate continues on cgroup v1.
+- **containerd 1.x last supported** - Must switch to containerd 2.0+ before upgrading to 1.36.
+- Action: Update node AMIs and container runtime configs.
+- **Ingress NGINX retired upstream** (March 2026) - No more security patches.
+- Action: Migrate to Gateway API, AWS ALB Ingress Controller, or other alternatives.
+- **kubelet flag `--pod-infra-container-image` removed** - Custom AMI users must remove from bootstrap scripts.
+- **IPVS mode deprecated** - Will be removed in 1.36. Plan migration to iptables or nftables.
+- **Windows Server 2025 support added**
+- **In-Place Pod Resource Updates GA** - CPU/memory changes without Pod restart.
+- **Service `trafficDistribution: PreferSameNode` (stable)** - New enum value that strictly prefers endpoints on the local node, falling back to remote. Does not exist in 1.34.
+- **StatefulSet `maxUnavailable` (beta)** - `spec.updateStrategy.rollingUpdate.maxUnavailable` allows parallel Pod updates instead of strictly one at a time.
+
+## EKS 1.34
+
+- **AL2 AMIs not released** - No EKS-optimized Amazon Linux 2 AMI for 1.34.
+- Action: Migrate node groups to AL2023 or Bottlerocket.
+- **containerd updated to 2.1** at launch.
+- Action: Review the containerd 2.1 release notes if node behavior changes after the upgrade.
+- **AppArmor deprecated** - Recommendation is to migrate to seccomp or Pod Security Standards.
+- **VolumeAttributesClass GA** - Migrates from `storage.k8s.io/v1beta1` to `storage.k8s.io/v1`.
+- Action: If you self-manage CSI sidecar containers, you may need to pin older sidecars to keep VAC working on pre-1.34 clusters. AWS patched its managed sidecars for the beta API only through the end of 1.33 standard support (2026-07-29).
+- **Dynamic Resource Allocation core APIs GA** - `resource.k8s.io/v1`.
+- **Pod-level resource requests and limits (beta)** - Pod `spec.resources` creates a shared pool for multi-container Pods. New field, absent in 1.33.
+- **Projected ServiceAccount tokens for kubelet image pulls (beta)** - Short-lived credentials instead of long-lived pull secrets.
+- **Mutable CSI Node Allocatable Count (beta)** - `MutableCSINodeAllocatableCount` on by default; CSINode max attachable volume count becomes dynamic.
+- **External JWT signer for ServiceAccount tokens (beta)** - When using an external signer, `--service-account-extend-token-expiration` is no longer fully respected; the API server enforces the lower of the desired extension and the signer's limit.
+- **Deprecation notice - manual cgroup driver configuration** - Moving to automatic detection.
+- Action: Plan to remove `--cgroup-driver` from kubelet configuration in bootstrap scripts and custom AMIs.
+
 ## EKS 1.33
 
 - **AL2 AMIs discontinued** - Amazon Linux 2 AMIs no longer released. Must use AL2023 or Bottlerocket.
 - Action: Update launch templates, Terraform `ami_type`, node group configs from `AL2_x86_64`/`AL2_ARM_64` to `AL2023_x86_64_STANDARD`/`AL2023_ARM_64_STANDARD`
+- **Dynamic Resource Allocation beta API enabled** - `resource.k8s.io/v1beta1`. Not enabled on EKS 1.32.
+- **In-Place Pod Resource Resize (beta)** - CPU/memory updates on existing Pods without restart.
+- **Sidecar containers stable** - Init containers with `restartPolicy: Always`.
+- **Endpoints API deprecated** - Returns warnings. Migrate to EndpointSlices.
+- **EFA traffic allowed in the default cluster security group** - New outbound rule permitting EFA traffic to the same security group.
 
 ## EKS 1.32
 
@@ -14,6 +70,10 @@ Changes that are Amazon EKS-specific (not upstream Kubernetes) and affect custom
 - **AL2 AMI deprecation notice** - Last version with AL2 AMIs. Plan migration to AL2023.
 - **ServiceAccount enforce-mountable-secrets deprecated** - `metadata.annotations[kubernetes.io/enforce-mountable-secrets]` deprecated.
 - Action: Use separate namespaces to isolate access to mounted secrets instead.
+- **`flowcontrol.apiserver.k8s.io/v1beta3` removed** - FlowSchema and PriorityLevelConfiguration must move to `v1`.
+- **Custom Resource Field Selector** - CRDs gain `spec.versions[].selectableFields`. Pruned by 1.31.
+- **StatefulSet PVC automatic cleanup** - Orphaned PVCs from StatefulSets are deleted automatically while preserving data across updates and node maintenance.
+- **Memory Manager GA** - More predictable memory allocation for workloads with specific memory requirements.
 
 ## EKS 1.31
 
@@ -21,6 +81,7 @@ Changes that are Amazon EKS-specific (not upstream Kubernetes) and affect custom
 - Action: Remove from bootstrap scripts, launch templates, and user data.
 - **VolumeAttributesClass beta enabled** - Requires EBS CSI Driver v1.35.0+ for ModifyVolume support.
 - **AppArmor GA** - Migrate from annotations to `securityContext.appArmorProfile.type` field.
+- **PersistentVolume last phase transition time GA** - New `.status.lastTransitionTime` on PersistentVolumeStatus.
 
 ## EKS 1.30
 
@@ -41,25 +102,27 @@ Changes that are Amazon EKS-specific (not upstream Kubernetes) and affect custom
 - **Metrics changes** - Several kube-scheduler and kube-controller-manager metrics renamed/removed.
 - **kubectl events subcommand GA** - `kubectl events` replaces `kubectl get events`.
 
-## EKS 1.35
+---
 
-- **cgroup v1 support removed** - Kubelet refuses to start on cgroup v1 nodes by default.
-- Action: AL2023 already uses cgroup v2. If manually configured cgroup v1, set `failCgroupV1: false` or migrate to cgroup v2.
-- **containerd 1.x last supported** - Must switch to containerd 2.0+ before upgrading to 1.36.
-- Action: Update node AMIs and container runtime configs.
-- **Ingress NGINX retired upstream** (March 2026) - No more security patches.
-- Action: Migrate to Gateway API, AWS ALB Ingress Controller, or other alternatives.
-- **kubelet flag `--pod-infra-container-image` removed** - Custom AMI users must remove from bootstrap scripts.
-- **IPVS mode deprecated** - Will be removed in 1.36. Plan migration to iptables or nftables.
-- **Windows Server 2025 support added**
-- **In-Place Pod Resource Updates GA** - CPU/memory changes without Pod restart.
+## Disruption Controls (affect both upgrade and rollback)
 
-## EKS 1.36
+These live in customer manifests and Helm templates, and they throttle **node replacement** —
+which is what both a data plane upgrade and an Auto Mode rollback depend on. Historically they
+were invisible to upgrade tooling; EKS now surfaces them as rollback readiness insights.
 
-- **IPVS mode removed from kube-proxy** - Must use iptables or nftables proxy mode.
-- Action: Update kube-proxy ConfigMap `mode` field. Remove IPVS-related configs.
-- **gogo protobuf removed from K8s API types** - Affects Go clients consuming K8s API types directly.
-- Action: Update Go dependencies using `k8s.io/code-generator` instead of `gogo/protobuf`.
+| Pattern | Where | Effect |
+|---|---|---|
+| `nodes: "0"` in a NodePool disruption budget covering `Drifted` | `karpenter.sh/v1` NodePool | Blocks drift-based node replacement indefinitely (ERROR insight) |
+| `karpenter.sh/do-not-disrupt: "true"` on a node | Node metadata | Node is never replaced (ERROR insight) |
+| `karpenter.sh/do-not-disrupt: "true"` on a pod | Pod/Deployment template metadata | Delays disruption up to the termination grace period (WARNING) |
+| `maxUnavailable: 0` on a PodDisruptionBudget | `policy/v1` PDB | Delays eviction; slows node replacement significantly (WARNING) |
+| `minAvailable` equal to the replica count | `policy/v1` PDB | Equivalent to `maxUnavailable: 0` in practice |
+
+Note that `--force` on the rollback bypasses insight checks only. Disruption budgets, PDBs, and
+do-not-disrupt annotations are always honored. The only way to speed up node replacement is to
+change these values.
+
+Full severity mapping and examples: `rollback-readiness.md`.
 
 ---
 
@@ -82,6 +145,22 @@ When upgrading EKS, addon versions must also be compatible:
 | Istio | v1.20+ | v1.22+ |
 
 **Note:** Always verify exact compatibility in addon release notes. This table is approximate guidance.
+
+### Reading the matrix when a rollback window matters
+
+A minimum floor is sufficient for a one-way upgrade. If the rollback window must stay open, the
+selected version has to satisfy a **range**: compatible with N-1, N and N+1 simultaneously. Pick
+the highest floor across those three versions and confirm it against the addon's own support
+statement for the oldest of them.
+
+Two consequences worth reporting explicitly:
+
+1. **Upgrade add-ons first**, before the control plane, so they are never the blocking factor in
+   either direction.
+2. **Rollback readiness insights only cover EKS-managed add-ons** (CoreDNS, VPC CNI, kube-proxy),
+   and not even those if the version was overridden outside the EKS add-on lifecycle. Everything
+   else in this table — LB Controller, Karpenter, Istio, ArgoCD, cert-manager, cluster-autoscaler —
+   is validated by nobody unless this skill flags it.
 
 ---
 
@@ -142,3 +221,25 @@ aws-load-balancer-controller:
   image:
     tag: v2.8.1
 ```
+
+### Rollback timeout in IaC
+
+`rollbackConfig.timeoutMinutes` (120 to 10080, default 720) aligns the EKS rollback duration with
+the IaC tool's own timeout. Support is uneven:
+
+```yaml
+# CloudFormation - supported
+Resources:
+  Cluster:
+    Type: AWS::EKS::Cluster
+    Properties:
+      Version: "1.33"
+      RollbackConfig:
+        TimeoutMinutes: 1440
+```
+
+- **CDK:** only on the L1 `CfnCluster` (`RollbackConfigProperty`), not on the L2 `eks.Cluster`.
+  Reach it with an escape hatch.
+- **Terraform:** `aws_eks_cluster` has **no** `rollback_config` argument (verified 2026-08-18).
+  Report it and initiate the rollback through the CLI or API instead.
+- Neither CloudFormation nor Terraform supports `CancelUpdate`.

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/eks-specific-changes.md
@@ -135,8 +135,30 @@ reason.
 
 ### EKS-managed add-ons: exact version per Kubernetes version
 
-AWS publishes the latest EKS add-on build for every supported Kubernetes version. When the report
-needs to name a concrete version for these three, take it from here rather than from a floor.
+AWS publishes the latest EKS add-on build for every supported Kubernetes version.
+
+**Resolve these at runtime, not from the table below.** The authoritative source is the API,
+and it never goes stale:
+
+```bash
+aws eks describe-addon-versions --kubernetes-version <target> \
+  --query 'addons[?addonName==`kube-proxy`||addonName==`coredns`||addonName==`vpc-cni`].{addon:addonName,latest:addonVersions[0].addonVersion}' \
+  --output table
+```
+
+When the CLI is unavailable, fall back to the snapshot below - but read the staleness warning
+first, because it is not a theoretical concern.
+
+> **Measured drift: this snapshot was verified against the AWS docs on 2026-08-20 and
+> 17 of its 18 cells were already wrong on 2026-08-21.** One day. Two of the changes were
+> **minor** version bumps, not build-suffix bumps: CoreDNS for Kubernetes 1.33 moved
+> `v1.12.4-eksbuild.18` to `v1.13.2-eksbuild.17`, and VPC CNI moved `v1.22.4-eksbuild.3` to
+> `v1.23.0-eksbuild.1` across every row. Only `kube-proxy` for 1.36 was unchanged.
+>
+> A hand-verified version table cannot be maintained at this cadence, so treat the snapshot as
+> a shape reference and the API as the value. A report that repeats a stale exact version is
+> worse than one that says "resolve at analysis time", because the reader cannot tell that the
+> number is a year-old artifact of the document rather than a fact about their cluster.
 
 | Kubernetes version | `kube-proxy` | CoreDNS | VPC CNI |
 |---|---|---|---|

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/examples-before-after.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/examples-before-after.md
@@ -393,3 +393,191 @@ webhooks:
 - `sideEffects` is REQUIRED (only `None` or `NoneOnDryRun`)
 - `failurePolicy` defaults to `Fail` (was `Ignore`)
 - `timeoutSeconds` defaults to 10s (was 30s)
+---
+
+## 9. Karpenter NodePool: disruption budget that blocks rollback
+
+A budget of `nodes: "0"` covering `Drifted` prevents drift-based node replacement. On an EKS Auto
+Mode cluster this blocks the node rollback phase indefinitely and raises an `ERROR` rollback
+readiness insight. It also throttles the data plane upgrade.
+
+### Before (blocks node replacement)
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+      - nodes: "0"
+        reasons:
+          - Drifted
+```
+
+### After
+
+```yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    budgets:
+      # TODO: confirm this rate with the workload owner. "0" blocked both the data plane
+      # upgrade and any Auto Mode rollback (ERROR rollback readiness insight).
+      - nodes: "10%"
+        reasons:
+          - Drifted
+```
+
+**Changes:**
+- `nodes: "0"` replaced with a non-zero rate so drift can make progress
+- `TODO` added: the concurrency rate is a workload availability decision, not a mechanical one
+- Report as **high** risk when `nodes: "0"` covers `Drifted` or has no `reasons` filter (an
+  unfiltered budget covers every disruption reason, including drift)
+
+---
+
+## 10. PodDisruptionBudget that stalls node replacement
+
+`maxUnavailable: 0` never permits an eviction, so every node hosting a matching Pod waits out the
+full termination grace period. This raises a `WARNING` insight — it does not block a rollback, but
+on a large fleet it is the difference between minutes and days, and it can push node rollback past
+the timeout.
+
+### Before
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-pdb
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: payments
+```
+
+### After
+
+```yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payments-pdb
+spec:
+  # TODO: maxUnavailable: 0 stalls every voluntary eviction, including upgrades and rollbacks.
+  # Confirm the real availability requirement with the workload owner.
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: payments
+```
+
+**Changes:**
+- `maxUnavailable: 0` flagged and replaced with a value that permits progress
+- Equivalent pattern to detect: `minAvailable` equal to the Deployment/StatefulSet replica count
+- The same finding applies to `karpenter.sh/do-not-disrupt: "true"` on a Pod template. On a **node**
+  it is an `ERROR` instead of a `WARNING`, but node annotations are cluster state, not repository
+  code, so they are report-only
+
+---
+
+## 11. VolumeAttributesClass: a transformation that closes the rollback window
+
+Not every "update the apiVersion" is safe. `storage.k8s.io/v1` VolumeAttributesClass only exists
+from 1.34; 1.33 serves the beta group version. Moving to the stable API is correct for the target
+version and simultaneously makes the cluster unable to roll back until it is reverted.
+
+### Before (target 1.34, source 1.33)
+
+```yaml
+apiVersion: storage.k8s.io/v1beta1
+kind: VolumeAttributesClass
+metadata:
+  name: gp3-high-throughput
+driverName: ebs.csi.aws.com
+parameters:
+  type: gp3
+  throughput: "500"
+```
+
+### After
+
+```yaml
+# ROLLBACK IMPACT: storage.k8s.io/v1 does not exist on EKS 1.33. Applying this manifest
+# closes the 7-day rollback window until it is reverted to v1beta1. Self-managed EBS CSI
+# sidecars on pre-1.34 clusters must be pinned to a version that still speaks the beta API.
+apiVersion: storage.k8s.io/v1
+kind: VolumeAttributesClass
+metadata:
+  name: gp3-high-throughput
+driverName: ebs.csi.aws.com
+parameters:
+  type: gp3
+  throughput: "500"
+```
+
+**Changes:**
+- `apiVersion` updated to the version that is valid on the target
+- Annotated as a **rollback-blocking adoption**, not a neutral bump
+- Report guidance: land this change **after** the rollback window closes, or accept that the
+  window is closed while it is deployed. Same class of finding for `resource.k8s.io/v1` (DRA, GA in
+  1.34), Pod-level `spec.resources` (1.34), and `trafficDistribution: PreferSameNode` (1.35)
+
+---
+
+## 12. Non-canonical IP/CIDR values (breaks on 1.36)
+
+From 1.36 `StrictIPCIDRValidation` is on by default: IP values with extraneous leading zeros and
+CIDRs with host bits set are rejected on create and update. Objects already stored survive via
+validation ratcheting, so this only surfaces on the next apply — which is exactly what a GitOps
+sync does. It does not apply to custom resource kinds.
+
+### Before (rejected on 1.36)
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internal
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - ipBlock:
+            cidr: 192.168.0.5/24
+        - ipBlock:
+            cidr: 010.000.010.000/24
+```
+
+### After
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-internal
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+        - ipBlock:
+            # TODO: host bits were set (192.168.0.5/24). Confirm the intended network was
+            # 192.168.0.0/24 and not a single-host rule (192.168.0.5/32).
+            cidr: 192.168.0.0/24
+        - ipBlock:
+            cidr: 10.0.10.0/24
+```
+
+**Changes:**
+- Leading zeros stripped to canonical form (`010.000.010.000` to `10.0.10.0`)
+- Host bits masked off, with a `TODO` because `192.168.0.5/24` is genuinely ambiguous: the author
+  may have meant the whole subnet or a single host. Never resolve that silently
+- This is forward-only: it blocks the upgrade to 1.36 and is safe on a rollback

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/rollback-readiness.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/rollback-readiness.md
@@ -58,6 +58,22 @@ when updating this file, and update the review date above.
 
 ---
 
+## Severity: quoted for the cluster, rated by this skill
+
+`ERROR` and `WARNING` in this file are **EKS cluster insight** severities, and they are only
+meaningful for findings EKS actually evaluates: the disruption controls in the data plane section
+below, and EKS-managed add-ons. In those rows the severity is *quoted* from the Auto Mode rollback
+documentation, not chosen here.
+
+Everything in the additions tables works differently. A target-only API adoption has **no
+corresponding insight** — EKS does not read the repository — so the `Impact` column (High / Medium /
+Low) is this skill's own risk *rating*. Report it that way in `MIGRATION_REPORT.md`: a
+rollback-blocking change with a risk rating, and no insight severity attached. Writing "insight
+severity: ERROR" beside a manifest finding implies EKS will surface it, which it will not, and sends
+the reader hunting for an insight that never appears.
+
+---
+
 ## Additions by version (inverse lookup)
 
 What exists in N but **not** in N-1. Adopting any of these closes the rollback door until it

--- a/community-sourced-transformations/eks-version-upgrade-readiness/references/rollback-readiness.md
+++ b/community-sourced-transformations/eks-version-upgrade-readiness/references/rollback-readiness.md
@@ -1,0 +1,249 @@
+# Rollback Readiness
+
+Amazon EKS Version Rollback lets a cluster administrator revert the control plane by **one**
+minor version (N to N-1) within **7 days** of an in-place upgrade. EKS evaluates
+`ROLLBACK_READINESS` cluster insights before allowing it.
+
+**Why this matters for code:** forward-compatible is no longer sufficient. During the rollback
+window, the code deployed on the cluster must be valid on **both** N and N-1. AWS states it
+plainly: if you adopt new APIs or features from the newer version, you must revert those
+changes before rolling back.
+
+**Why this skill matters:** Rollback Readiness Insights only exist **after** the upgrade, and
+only for 7 days. This skill runs **before** the upgrade, so it can surface the same class of
+blocker while there is still time to design around it — and it covers self-managed add-ons,
+which the insights explicitly do not check.
+
+---
+
+## Maintenance rule: supported-version window
+
+A rollback requires **both** N and N-1 to be EKS-supported versions. A row for a version
+outside support can therefore never be used. So the additions table below covers **only
+versions currently in standard or extended support**.
+
+- When a version leaves extended support, **delete its row**.
+- Do **not** backfill versions older than the window. That is unbounded maintenance for
+  scenarios the API rejects anyway.
+- This is the opposite of `api-removals-by-version.md`, which is deliberately historical
+  (1.16+) because a customer can be sitting on very old manifests today.
+
+**Window at last review: 2026-08-18 — EKS 1.31 through 1.36.**
+
+| Version | Support status | End of standard | End of extended |
+|---|---|---|---|
+| 1.36 | Standard | 2027-08-02 | 2028-08-02 |
+| 1.35 | Standard | 2027-03-27 | 2028-03-27 |
+| 1.34 | Standard | 2026-12-02 | 2027-12-02 |
+| 1.33 | Extended | 2026-07-29 | 2027-07-29 |
+| 1.32 | Extended | 2026-03-23 | 2027-03-23 |
+| 1.31 | Extended | 2025-11-26 | 2026-11-26 |
+
+Re-check against the [EKS Kubernetes release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)
+when updating this file, and update the review date above.
+
+---
+
+## Rollback rules that constrain code
+
+| Rule | Consequence for the repository |
+|---|---|
+| One minor version only (N to N-1) | There is no "roll back two hops". Code only needs dual validity across a single boundary |
+| 7-day window from upgrade completion | Anything adopting target-only APIs should be gated behind a change that lands **after** the window closes |
+| Only clusters upgraded **in-place** can roll back | A cluster created at N cannot roll back to N-1 — blue/green migrations have no rollback path |
+| Rollback to an extended-support version resumes extended-support charges | Cost note for the report, not a code change |
+| Insights with `ERROR` or `UNKNOWN` block the rollback; `WARNING` is advisory | Drives the severity assigned to each finding |
+| `--force` bypasses insight checks only | It does **not** override PDBs, NodePool budgets, or do-not-disrupt annotations |
+| Insights check EKS-managed add-ons only (CoreDNS, VPC CNI, kube-proxy) | Self-managed add-ons, and managed add-ons whose version was overridden outside the add-on lifecycle, are the customer's responsibility — this skill's addon check is the only pre-flight for them |
+
+---
+
+## Additions by version (inverse lookup)
+
+What exists in N but **not** in N-1. Adopting any of these closes the rollback door until it
+is reverted.
+
+`Kind` legend: **resource** = GroupVersion/kind absent in N-1 · **field** = field absent or
+pruned in N-1 · **enum** = new allowed value on an existing field · **gated** = field exists
+in N-1 but the feature gate is off, so the value is silently ignored · **behavior** = no
+manifest surface.
+
+### Added in 1.36 (blocks rollback to 1.35)
+
+| Item | Kind | Impact | Detect in code |
+|---|---|---|---|
+| DRA Partitionable Devices, Consumable Capacity, Device Binding Conditions (Beta, on by default) | field | **High** — new fields on `resource.k8s.io` objects | `DeviceClass`/`ResourceClaim`/`ResourceSlice` using partition, consumable-capacity, or binding-condition fields |
+| Resource Health Status (Beta) | behavior | Low — Pod `status` only, not authored | n/a |
+| User Namespaces (Stable) | gated | Low — `spec.hostUsers` exists since 1.25 and is beta from 1.30 | `hostUsers: false` in Pod specs |
+
+### Added in 1.35 (blocks rollback to 1.34)
+
+| Item | Kind | Impact | Detect in code |
+|---|---|---|---|
+| Service `spec.trafficDistribution: PreferSameNode` (Stable) | **enum** | **High** — the value does not exist in 1.34; the Service is rejected or the field pruned | `trafficDistribution: PreferSameNode` in Service manifests |
+| StatefulSet `spec.updateStrategy.rollingUpdate.maxUnavailable` (Beta) | gated | Medium — silently ignored after rollback, updates revert to one Pod at a time | `maxUnavailable` under a StatefulSet `rollingUpdate` |
+| In-Place Pod Resource Updates (Stable) | gated | Low — `resizePolicy` predates 1.35 | `resizePolicy` in container specs |
+
+### Added in 1.34 (blocks rollback to 1.33)
+
+| Item | Kind | Impact | Detect in code |
+|---|---|---|---|
+| `storage.k8s.io/v1` VolumeAttributesClass (GA) | **resource** | **High** — 1.33 only serves `storage.k8s.io/v1beta1`. Also requires pinning older EBS CSI sidecars on pre-1.34 clusters | `apiVersion: storage.k8s.io/v1` + `kind: VolumeAttributesClass` |
+| `resource.k8s.io/v1` DRA core APIs (GA) | **resource** | **High** — 1.33 serves the beta group version only | `apiVersion: resource.k8s.io/v1` on any DRA kind |
+| Pod-level resource requests and limits (Beta) | **field** | **High** — Pod `spec.resources` does not exist in 1.33 | `spec.resources` at Pod level (not `spec.containers[].resources`) |
+| Mutable CSI Node Allocatable Count (Beta) | behavior | Low — CSINode status, driver-side | n/a |
+| External JWT signer for SA tokens (Beta) | behavior | Low — cluster configuration, not repo code | n/a |
+
+### Added in 1.33 (blocks rollback to 1.32)
+
+| Item | Kind | Impact | Detect in code |
+|---|---|---|---|
+| DRA beta API enabled (`resource.k8s.io/v1beta1`) | **resource** | **High** — not enabled on EKS 1.32, so the objects stop being served after rollback | `apiVersion: resource.k8s.io/v1beta1` (`ResourceClaim`, `ResourceClaimTemplate`, `DeviceClass`, `ResourceSlice`) |
+| In-Place Pod Resource Resize (Beta) | gated | Medium — resize requests are ignored after rollback | `resizePolicy` in container specs |
+| Sidecar containers (Stable) | gated | Low — available since 1.29 | `initContainers[].restartPolicy: Always` |
+| Endpoints API deprecation | behavior | Low — warning only, still served | `kind: Endpoints` |
+
+### Added in 1.32 (blocks rollback to 1.31)
+
+| Item | Kind | Impact | Detect in code |
+|---|---|---|---|
+| Custom Resource Field Selector (`spec.versions[].selectableFields`) | **field** | **High** — pruned by 1.31, so any consumer filtering on that field breaks | `selectableFields` in a CRD |
+| StatefulSet automatic PVC cleanup (GA) | gated | Low — `persistentVolumeClaimRetentionPolicy` is served and enabled well before 1.32 | `persistentVolumeClaimRetentionPolicy` in StatefulSets |
+| Memory Manager (GA) | behavior | Low — kubelet-side | n/a |
+
+### Forward-only blockers (upgrade, not rollback)
+
+These break the **upgrade** and are safe on the way back down. They belong in the upgrade
+findings, not the rollback section, and must not be reported as rollback blockers.
+
+| Item | Introduced | Effect |
+|---|---|---|
+| `StrictIPCIDRValidation` on by default | 1.36 | IP/CIDR values with leading zeros (`010.000.000.005`) or ambiguous CIDRs (`192.168.0.5/24`) are rejected on create/update. Stored objects survive via validation ratcheting |
+| `gitRepo` volume permanently disabled | 1.36 | The API still accepts the Pod; the kubelet refuses to run it. Migrate to an init container or git-sync sidecar |
+| SELinux volume labeling GA | 1.36 | Defaults to `mount -o context` for all volumes. Sharing a volume between privileged and unprivileged Pods can break |
+| Service `spec.externalIPs` deprecated | 1.36 | Deprecation warning now, removal planned for 1.43 |
+
+---
+
+## Data plane blockers (EKS Auto Mode)
+
+Auto Mode rolls the **nodes back first**, then the control plane, using Karpenter drift. Every
+disruption control the customer authored in the repository is honored — including under
+`--force`. These four checks are the highest-value addition to this skill, because they all
+live in YAML the skill already reads, and the same controls also throttle the **upgrade**.
+
+| Finding | Insight severity | Effect |
+|---|---|---|
+| NodePool disruption budget with `nodes: "0"` covering `Drifted` | **ERROR** (blocks) | Rollback never makes progress |
+| `karpenter.sh/do-not-disrupt` annotation on a **node** | **ERROR** (blocks) | That node is never replaced; must be removed first |
+| `karpenter.sh/do-not-disrupt` annotation on a **pod** | WARNING | Delays node disruption up to the termination grace period |
+| PodDisruptionBudget with `maxUnavailable: 0` (or an equivalent `minAvailable`) | WARNING | Delays eviction; does not permanently block |
+
+A restrictive-but-nonzero budget (`nodes: "1"`) is legal and makes forward progress, but on a
+large fleet it can push node rollback past the timeout. Report it as a duration risk.
+
+```yaml
+# Blocks rollback indefinitely - ERROR insight
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    budgets:
+      - nodes: "0"
+        reasons:
+          - Drifted
+```
+
+```yaml
+# Allows drift-based replacement to proceed
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  disruption:
+    budgets:
+      - nodes: "10%"
+        reasons:
+          - Drifted
+```
+
+**Non-Auto-Mode data plane:** Managed Node Groups roll back via `UpdateNodegroupVersion`.
+Self-managed and hybrid nodes are fully manual. **Fargate cannot roll back at all** — Fargate
+pods running the pre-rollback version trigger the kubelet skew insight as an `ERROR`, so the
+pods must be deleted first or the insight bypassed with `--force`. Detect Fargate usage from
+`aws_eks_fargate_profile` in Terraform, `FargateProfile` in CDK, or workloads scheduled by a
+Fargate profile selector.
+
+---
+
+## Add-on strategy that preserves the rollback window
+
+The rollback window only stays open if the add-ons are compatible with **both** versions.
+Upgrade add-ons to a version cross-compatible with N-1, N and N+1 **before** the control
+plane, so they are never the blocking factor in either direction.
+
+This inverts how the add-on matrix in `eks-specific-changes.md` is used: a minimum floor is
+enough for a one-way upgrade, but a rollback needs a **range** that covers N-1 as well.
+
+Known interaction: to keep VolumeAttributesClass working on EKS 1.31 to 1.33 (beta API),
+self-managed EBS CSI sidecars must be pinned to a version that still speaks the beta API.
+AWS patched its own managed sidecars for this only through the end of 1.33 standard support
+(2026-07-29), which has now passed.
+
+---
+
+## IaC support for `rollbackConfig`
+
+`rollbackConfig.timeoutMinutes` bounds how long EKS attempts the rollback: 120 to 10080
+minutes, default 720 (12 hours). It exists because a 7-day rollback collides with IaC
+timeouts (CloudFormation 36 hours per resource, Terraform Cloud/Enterprise around 24 hours).
+
+| Tool | `rollbackConfig` support | What to do |
+|---|---|---|
+| AWS CLI / API | Yes — `--rollback-config timeoutMinutes=N` | Preferred path when disruption budgets are restrictive |
+| CloudFormation | Yes — `AWS::EKS::Cluster` `RollbackConfig` | Set `TimeoutMinutes` under the stack's own timeout |
+| AWS CDK | L1 only — `CfnCluster.RollbackConfigProperty`. Not exposed on the L2 `eks.Cluster` | Use an escape hatch on the L1 construct |
+| Terraform (`hashicorp/aws`) | **No** — `aws_eks_cluster` has no `rollback_config` argument (verified 2026-08-18) | Report only. Initiate the rollback via CLI/API |
+
+Neither CloudFormation nor Terraform supports the `CancelUpdate` API. If an IaC run times out
+mid-rollback, the API must be called directly. CloudFormation treats its own timeout as a
+no-op, which leaves the template drifted from the real cluster version.
+
+---
+
+## Staged sequence that preserves the window
+
+The window is only useful if the control plane and data plane are not advanced in the same
+continuous run. Once a node's kubelet has moved to N, rolling the control plane back to N-1
+requires rolling the data plane back first.
+
+```text
+1. Add-ons  -> upgrade to a version cross-compatible with N-1 / N / N+1
+2. Control plane -> upgrade to N, then BAKE (~1 week per environment)
+3. Data plane -> recycle nodes to N only after the bake period
+```
+
+Regression response during or after step 3:
+
+- Data plane only: roll nodes back to N-1 kubelet, leave the control plane at N.
+- Both: roll the data plane back first, then the control plane.
+
+Trade-off to state in the report: this lengthens a full upgrade cycle, but it keeps the
+rollback window open during the riskiest period and lets control plane versions advance
+quickly across a fleet (which reduces extended-support cost exposure).
+
+---
+
+## Out of scope for this skill
+
+This skill reads and transforms code. It never touches a cluster. It does **not**:
+
+- call `update-cluster-version`, `list-insights`, `describe-insight`, or `cancel-update`
+- assess the live rollback eligibility of a real cluster
+- decide whether a rollback should happen
+
+It produces the **pre-flight**: which findings in the repository would become rollback
+blockers, so the decision is informed before the upgrade rather than during an incident.


### PR DESCRIPTION
## Summary

Amazon EKS [Version Rollback](https://aws.amazon.com/blogs/containers/announcing-amazon-eks-rollback-for-safe-and-reliable-management-of-cluster-upgrades/) (announced 2026-07-01) reverts the control plane one minor version within 7 days of an in-place upgrade. That changes what "upgrade-ready code" means: during the window, the deployed code has to be valid on **both** versions, so forward compatibility alone is no longer sufficient.

This PR adds rollback readiness to `eks-version-upgrade-readiness` as a **detection and report dimension**. The skill still never touches a cluster — it does not call `update-cluster-version`, `list-insights`, `describe-insight` or `cancel-update`, and that boundary is now written into the Non-Goals.

## Why this belongs in a code-readiness skill

| | |
|---|---|
| **Timing** | `ROLLBACK_READINESS` insights only run **after** the upgrade, and only for 7 days. This skill runs before, so a blocker can be designed around instead of discovered during an incident. |
| **Coverage** | Per the [cluster insights docs](https://docs.aws.amazon.com/eks/latest/userguide/cluster-insights.html), the insights check **EKS-managed add-ons only** (CoreDNS, VPC CNI, kube-proxy), and not even those when the version was overridden outside the add-on lifecycle. Karpenter, the AWS Load Balancer Controller, Istio, Argo CD and cluster-autoscaler are the customer's responsibility, and this skill already reads their manifests and Helm values. |
| **Surface** | Four of the [Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/rollback-automode.html) checks are plain YAML the skill already parses: NodePool disruption budgets, `karpenter.sh/do-not-disrupt`, PodDisruptionBudgets, node annotations. The same controls throttle the **data plane upgrade**, so the check pays off even with no rollback planned. |

## What changed

| File | Change |
|---|---|
| `references/rollback-readiness.md` | **New.** Inverse per-version lookup (what was *added* in N that does not exist in N-1), classified as resource / field / enum / gated / behavior with a rollback impact per row. Plus Auto Mode disruption blockers with their mapped insight severity, add-on cross-compatibility strategy, the staged CP-bake-DP sequence, `rollbackConfig` support per IaC tool, and an explicit statement of where severity is *quoted* from the EKS docs versus *rated* by the skill. |
| `references/eks-specific-changes.md` | **Adds the missing 1.34 section** (it was absent entirely), completes 1.35 and 1.36, reorders newest-first (1.35/1.36 were appended after 1.28), and adds a Disruption Controls section. The add-on compatibility matrix is now **split by who publishes the version**: an exact per-Kubernetes-version table for the three EKS-managed add-ons, and a floors table for self-managed add-ons with a source-of-truth link per row. No existing bullet was removed. |
| `references/examples-before-after.md` | 4 new examples (9-12): NodePool budget that blocks rollback, PDB that stalls node replacement, a correct `apiVersion` bump that closes the rollback window, and non-canonical IP/CIDR values. |
| `SKILL.md` | New "Rollback Window Awareness" constraint, N-1 verdict per transformation, rollback phase in the workflow, reference dispatch row, two exit criteria, updated Non-Goals. |
| `README.md` | New Rollback Readiness section, new limitations, updated design decisions. Also **restores the missing `## Known Limitations` heading** — the ToC links to `#known-limitations` but the heading was never in the file, so that anchor is currently a 404. |
| `BENCHMARKS.md` | Adds run 4, measured against this content (see below), plus two new exit criteria rows. |

### Content gaps fixed along the way

While cross-checking the release notes, three things turned out to be missing from `eks-specific-changes.md` independently of rollback:

- **No 1.34 section at all** — so AL2 AMIs not being released for 1.34, containerd 2.1, VolumeAttributesClass GA, DRA GA and the cgroup-driver deprecation were undocumented.
- **1.36 was incomplete** — missing `gitRepo` volume disablement, `StrictIPCIDRValidation` on by default, SELinux volume labeling GA, and the `Service.spec.externalIPs` deprecation.
- **1.35 was incomplete** — missing `trafficDistribution: PreferSameNode` and StatefulSet `maxUnavailable`.

## Maintenance: bounded on purpose

The inverse table is the one part of this that could grow without limit, so it is **scoped to EKS versions in standard or extended support** (currently 1.31 through 1.36). A rollback requires both sides of the hop to be supported, so a row outside that range describes something the API rejects anyway. When a version leaves extended support its row is deleted rather than kept, and the file carries the review date plus a link to the release calendar. This is deliberately the opposite of `api-removals-by-version.md`, which stays historical from 1.16 because customers really do sit on very old manifests.

## Testing

- Every version-specific claim was cross-checked against the AWS docs rather than release-note memory: the [standard-support](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html) and [extended-support](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-extended.html) release notes, the [release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html), [cluster insights](https://docs.aws.amazon.com/eks/latest/userguide/cluster-insights.html), and [Auto Mode rollback](https://docs.aws.amazon.com/eks/latest/userguide/rollback-automode.html).
- Severity mapping (`nodes: "0"` and node-level do-not-disrupt are ERROR; pod-level do-not-disrupt and `maxUnavailable: 0` are WARNING) is taken from the Auto Mode rollback page, not inferred.
- `rollbackConfig` bounds (120 to 10080 minutes, default 720) confirmed against the EKS API reference and `AWS::EKS::Cluster RollbackConfig`.
- Terraform: no `rollback_config` argument exists in `hashicorp/terraform-provider-aws` (searched `internal/service/eks`, zero hits), so the file says report-only instead of showing HCL that would not plan. CDK exposes it on the L1 `CfnCluster` only.
- Add-on versions in the managed table are quoted from the AWS docs pages for [kube-proxy](https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html), [CoreDNS](https://docs.aws.amazon.com/eks/latest/userguide/managing-coredns.html) and [VPC CNI](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html), verified 2026-08-20.
- Markdown: all fenced blocks balanced and language-tagged; example numbering is sequential 1-12; no existing content dropped (verified by diffing the pre-change bullet inventory).

### End-to-end run

`BENCHMARKS.md` now carries a fourth run measured against this content. Fixture: 18 files (13 manifests, Terraform including a Fargate profile, one Helm chart), upgrading 1.33 to 1.34. That hop was chosen deliberately — it is the boundary where `storage.k8s.io/v1` VolumeAttributesClass graduates, so a *correct* transformation is simultaneously a rollback blocker.

14/14 planted cases behaved as specified, including the negative controls (6 files byte-identical against the git baseline), the flag-only rule (PodSecurityPolicy untouched), and one deliberately out-of-range case: a 1.36 IP/CIDR issue that must **not** be reported as blocking for a 1.34 target, and was reported as future and explicitly non-blocking.

The N-1 classification was confirmed empirically rather than asserted, by validating the same manifests against both versions' schemas:

```text
kubeconform -kubernetes-version 1.34.0  ->  Valid 11, Invalid 0, Skipped 2
kubeconform -kubernetes-version 1.33.0  ->  Valid 10, Invalid 0, Skipped 3

The one extra skip on 1.33 is the VolumeAttributesClass: valid at 1.34,
"could not find schema" at 1.33. Every other transformed resource validates
on BOTH versions, matching its "safe on both" verdict.
```

That is the target-only verdict reproduced against upstream schemas with no cluster involved, which is why the validation commands now include running the schema check against both sides of the hop. `kubectl --dry-run` was not used in this run (the workstation kubeconfig pointed at a decommissioned cluster); run 1 already covers live-cluster acceptance against EKS 1.35. The same command independently reproduced that PodSecurityPolicy has no schema at 1.34, confirming the flag-only design from a second angle.

Two follow-ups the run surfaced are fixed here rather than deferred:

- **The add-on matrix invited extrapolation.** The generated report stated a `v2.8.0+` LB Controller minimum for 1.34, projected from the 1.30+ and 1.32+ columns. Adding a "1.34+" column would have made it worse, because AWS publishes no per-Kubernetes-version floor for the LB Controller at all — only a general "2.7.2 or later" recommendation. The table is now split by who publishes the number, and the self-managed half says explicitly not to extrapolate to a version with no column: report the floor as undocumented and cite the upstream source instead.
- **Severity was conflated.** The report attached insight severity `ERROR` to a manifest finding. No insight exists for a repository finding, so that label sends a reader hunting for something EKS will never surface. `rollback-readiness.md` now separates quoted severity from the skill's own risk rating.

Budget note for maintainers: the reference set roughly doubled with the rollback material, so this transformation wants 90-120 agent minutes rather than 60. Run 4 measured 61.2 and was cut at its own final `terraform validate` under a 60-minute cap, with all deliverables already complete on disk.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
