### PR TITLE
Add tanzu-to-eks custom transformation

### DIFF
--- a/community-sourced-transformations/tanzu-to-eks/BENCHMARKS.md
+++ b/community-sourced-transformations/tanzu-to-eks/BENCHMARKS.md
@@ -1,0 +1,103 @@
+# Benchmark Results - Tanzu / Cloud Foundry to Amazon EKS
+
+## Executive Summary
+
+| Metric | Result |
+|--------|--------|
+| Repositories tested | 2 real upstream Cloud Foundry sample repos, pinned to a commit |
+| Rounds | 2 - round 1 found 2 defects, both fixed in `SKILL.md` and re-validated in round 2 |
+| Transformation success rate (round 2) | **2/2 COMPLETE** |
+| **Source integrity** | **0 files modified outside `eks/` and the report, in both round-2 runs** |
+| Files emitted (round 2) | 5 (`spring-music`) and 5 (`cf-sample-app-nodejs`) |
+| `MIGRATION_REPORT.md` at repository ROOT | **2/2** (the round-1 defect - report inside `eks/` - is fixed) |
+| `.dockerignore` under `eks/`, never at the root | **2/2** (the round-1 defect - root `.dockerignore` - is fixed) |
+| `*.openshift.io` surviving in output | 0 in both runs |
+| `TODO(migration)` markers | 4 and 5, all paired with report entries |
+| Invented credentials in stubs | 0 |
+| `kubectl apply --dry-run=client` | clean in both runs |
+| Total agent minutes (round 2) | 88.74 (47.85 + 40.89) |
+| Total estimated cost (round 2) | ~US$ 3.11 (at US$ 0.035 / agent minute) |
+| Cumulative incl. round 1 | ~179.36 agent minutes, ~US$ 6.28 |
+
+### Methodology
+
+The fixtures are **real public repositories**, not hand-written ones, pinned to a commit so the
+result stays reproducible:
+
+| Repo | Language | Commit |
+|---|---|---|
+| `cloudfoundry-samples/spring-music` | Java 17 / Spring Boot | `8f364e93a29eeb9d17e5682119de617b9fde32f0` |
+| `cloudfoundry-samples/cf-sample-app-nodejs` | Node.js | `18cc56ed2f4cda9a987ff09a53724e42e1fa9d96` |
+
+The pair covers the two dominant CF workload shapes: a JVM application (where the `memory` field
+carries the HIGH-risk buildpack-derived JVM sizing) and a Node.js application (where the platform
+supplied nearly everything, so most findings are about absence).
+
+Each repo was committed as a baseline, then transformed via:
+
+```bash
+atx custom def exec -n tanzu-to-eks -p . -x -t \
+  --configuration file://cfg.json --limit 70
+```
+
+with `additionalPlanContext` carrying `migration_target: eks-standard`,
+`build_strategy: buildpacks`, a registry URI and a namespace.
+
+Assertions are **invariants**, not expected findings, because a real repository has no answer key:
+source integrity by `git diff` against the baseline, report at the root, no other file created or
+modified at the root, zero OpenShift `apiVersion` leakage, YAML validity, `--dry-run=client`, and
+`TODO`/report pairing. Validator: `assert_def_run.py`.
+
+---
+
+## At-a-Glance Results (round 2, 2026-08-28)
+
+| # | Repository | Status | Files emitted | Report at root | Root untouched | Source changed | TODOs | Agent Min | Cost |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | `spring-music` | COMPLETE | 5 (294 lines) | PASS (11.1 KB) | PASS | **0** | 4 | 47.85 | $1.67 |
+| 2 | `cf-sample-app-nodejs` | COMPLETE | 5 | PASS (8.4 KB) | PASS | **0** | 5 | 40.89 | $1.43 |
+| | **TOTALS** | **2/2** | **10** | **2/2** | **2/2** | **0** | **9** | **88.74** | **$3.11** |
+
+---
+
+## Round 1 → Round 2: the two defects and their fixes
+
+Round 1 (2026-08-21, 90.62 agent minutes across the same two repos) surfaced two contract
+violations, both fixed in `SKILL.md` and re-validated in round 2 on both repos:
+
+| # | Round-1 defect | Fix in SKILL.md | Round-2 evidence |
+|---|---|---|---|
+| 1 | `MIGRATION_REPORT.md` emitted inside `eks/` | "**`MIGRATION_REPORT.md` goes at the repository ROOT**, matching the convention of the other definitions in this collection" | Report at the root in 2/2 runs |
+| 2 | `.dockerignore` created/modified at the repository root (`cf-sample-app-nodejs`) | "**Never create or modify a file at the repository root** other than `MIGRATION_REPORT.md`" - emit `eks/.dockerignore` + a report entry saying it must be moved before the first build | `eks/.dockerignore` + move instruction in 2/2 runs; root byte-identical |
+
+An incidental defect in the `spring-music` run self-corrected: a `.DS_Store` was committed at the
+root in Step 1 and removed by the run's own Step 2 fix - the final tree is clean and the source
+integrity assertion passes against the baseline.
+
+## Exit Criteria Compliance (per SKILL.md)
+
+| # | Exit criterion | spring-music | cf-sample-app-nodejs |
+|---|---|---|---|
+| 1 | Every manifest field, present or absent, in the report inventory | PASS | PASS |
+| 2 | Originals byte-identical; output under `eks/`; report at root; no other root file | PASS | PASS |
+| 3 | Secret stubs with empty values + `TODO(migration)` | PASS (no invented credential) | PASS |
+| 4 | Emitted YAML parses; `--dry-run=client` clean | PASS (2 YAML) | PASS (3 YAML) |
+| 5 | Every REPORT-ONLY construct has a report entry | PASS | PASS |
+| 6 | Every `TODO(migration)` paired with a report entry, and vice versa | PASS (4/4, `TODO(migration) Checklist` section) | PASS (5/5, `TODO(migration) Cross-Reference` table) |
+| 7 | `memory` translation carries the HIGH-risk JVM note when a JVM language is detected | PASS (Java 17 detected, OOMKill-loop risk documented) | N/A (Node.js) |
+
+## Known variance (open, needs a SKILL.md decision before the next publish)
+
+1. **The manual-action section name is not pinned by the contract.** Three runs produced three
+   names: `Manual Action` (round 1), `TODO(migration) Checklist` (spring-music round 2),
+   `TODO(migration) Cross-Reference` (cf round 2). The pairing was correct every time, but
+   `assert_def_run.py` can only gate on a known name - it currently accepts the first two and
+   flags the third. Fix belongs in `SKILL.md` (pin one name), NOT in loosening the validator.
+2. **Em dashes in generated report prose.** The cf round-2 report uses the em dash character
+   (U+2014) as a table separator. No definition in this collection currently forbids it; the
+   ecosystem standard does. Same
+   decision point: add the constraint to `SKILL.md` and re-validate.
+
+Both are report-cosmetic - neither affects source integrity nor the emitted manifests - and both
+require a republish, so they are batched for the next SKILL.md revision rather than shipped as
+an unvalidated edit.

--- a/community-sourced-transformations/tanzu-to-eks/README.md
+++ b/community-sourced-transformations/tanzu-to-eks/README.md
@@ -1,0 +1,189 @@
+# Tanzu / Cloud Foundry to Amazon EKS
+
+Transforms a Cloud Foundry application - **VMware Tanzu Application Service (TAS)**, **Pivotal Cloud Foundry (PCF)** or **open-source Cloud Foundry** - into Kubernetes manifests for Amazon EKS. Converts the `manifest.yml` fields that map deterministically, scaffolds the container build and the credential injection, and reports every part of the platform contract that cannot be reconstructed from the repository.
+
+**Not for Tanzu Kubernetes Grid (TKG)** - TKG is already Kubernetes, so moving it to EKS is a cluster migration with a different shape.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Problem](#the-problem)
+- [What This Skill Does](#what-this-skill-does)
+- [Skill Architecture](#skill-architecture)
+- [Paired Readiness Assessment](#paired-readiness-assessment)
+- [Getting Started](#getting-started)
+- [Benchmarks](#benchmarks)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [Repository Structure](#repository-structure)
+
+## Overview
+
+The three products share the one thing that matters here: the **Cloud Foundry application
+contract**. `manifest.yml`, buildpacks, `VCAP_SERVICES` and the org/space model are identical
+across TAS, PCF and open-source CF, which is why one definition covers all three.
+
+## The Problem
+
+`manifest.yml` is **thin** - name, memory, instances, buildpack, routes, services, env. The
+Kubernetes equivalent is not a translation of those fields, it is a **reconstruction of what the
+platform did implicitly**:
+
+- the **buildpack** built the container, so there is no `Dockerfile` to carry over
+- **`VCAP_SERVICES`** injected credentials as JSON the application parses at startup, so making it
+  work on Kubernetes is a **code change**, not a manifest change
+- the **route** was created by the platform from a shared domain that will not exist on EKS
+- **ephemeral disk** was the only storage, so there is no volume to migrate because there never was one
+- **CPU** was derived from the memory allocation, so the repository contains no CPU information at all
+
+So most findings are about **absence**: the artifact Kubernetes needs is missing because the
+platform supplied it. That is the opposite shape from an OpenShift migration, where the artifact
+exists and has the wrong `apiVersion`.
+
+This is why the definition is deliberately **mostly a scaffolder and a reporter**, and only a small
+part of it is a translator. Generating a plausible `Dockerfile` from a buildpack contract, or a
+Secret from a binding the repository never described, produces manifests that apply cleanly and are
+wrong - the worst possible outcome.
+
+## What This Skill Does
+
+| Phase | Action |
+|---|---|
+| 0 | Reads `additionalPlanContext`: `migration_target`, `build_strategy`, `registry`, `namespace` |
+| 1 | Parses every `manifest.yml`, `manifest-*.yml` and `vars-*.yml`, inventorying every field **present and absent**, each classified MECHANICAL / SCAFFOLD / REPORT-ONLY |
+| 2 | Converts the mechanical set: one `Deployment` per `applications[]` entry, one more per non-web `Procfile` process type, plus Service, route object, probes and resources |
+| 3 | Emits scaffolds: a `project.toml` (Paketo) or `Dockerfile` skeleton, Secret **stubs with empty values**, and a documented `VCAP_SERVICES` option set |
+| 4 | Validates: YAML parses, `kubectl apply --dry-run`, `helm template`, and asserts **no fabricated credential value** survives |
+| 5 | Writes `MIGRATION_REPORT.md`, cross-referenced to the assessment's question ids |
+
+## Skill Architecture
+
+```text
+SKILL.md                            spine: scope, constraints, 6 phases, exit criteria
+references/01-manifest-mapping.md   every manifest field, its classification, and what absence means
+```
+
+### Key Design Decisions
+
+**Absence is a first-class case.** On Cloud Foundry an omitted field meant a platform default
+applied. Kubernetes has no such default, so an absent `health-check-type` is a finding, not a
+non-event. Each mapping row states what absence means.
+
+**Secret stubs carry no values.** A stub with a fabricated connection string is a defect, not a
+convenience: it applies cleanly and fails at runtime looking like a networking problem.
+
+**Three artifacts per gap.** An ambiguity produces a `TODO(migration)` at the site, a report entry,
+and where applicable a scaffold. The code shows where, the report shows why.
+
+**Paketo is the default build path.** It descends from the Cloud Foundry buildpacks and detects the
+same language signals, so runtime behaviour changes least. A hand-authored `Dockerfile` gives more
+control and carries more behavioural risk - JVM memory calculation, entrypoint and signal handling
+all become yours.
+
+**`memory` carries a mandatory risk note for JVM workloads.** On CF that value also drove the
+buildpack's JVM heap sizing. Copying it verbatim into `limits.memory` is the most common cause of
+an OOMKill loop after a CF migration, and it looks like a faithful translation.
+
+## Paired Readiness Assessment
+
+This definition transforms **one** application. Deciding **which** applications move, in what
+order, and what blocks each is answered by a companion assessment scoring a repository against 31
+questions across the buildpack contract, service bindings, routing, credentials and operations.
+
+For a 1.000-application estate the assessment comes first: it produces the waves. This definition
+runs on the applications those waves clear.
+
+## Getting Started
+
+### Prerequisites
+
+- AWS Transform Custom access and the `atx` CLI
+- `kubectl` and `helm` for local validation (optional)
+
+### Getting Started with AWS Transform Custom
+
+Follow the AWS Transform Custom documentation to install and authenticate the `atx` CLI.
+
+### Cloning the Repo and Publishing the Transformation
+
+```bash
+git clone <this-repo>
+cd community-sourced-transformations/tanzu-to-eks
+
+atx custom def publish -n tanzu-to-eks --sd .
+```
+
+`publish` accepts `SKILL.md`, `references/` and `scripts/`. A `README.md` at the definition root
+aborts the publish, so publish from a staged copy containing only those.
+
+### Running the Transformation
+
+Pass the configuration as a file - **commas separate `key=value` pairs** in the inline form, so an
+inline value containing a comma is rejected:
+
+```bash
+cat > config.json <<'JSON'
+{
+  "additionalPlanContext": "migration_target: eks-standard\nbuild_strategy: buildpacks\nregistry: 111122223333.dkr.ecr.us-east-1.amazonaws.com\nnamespace: music"
+}
+JSON
+
+atx custom def exec -n tanzu-to-eks -p . -x -t \
+  --configuration file://config.json --limit 70
+```
+
+| Key | Values | Effect |
+|---|---|---|
+| `migration_target` | `eks-standard`, `eks-auto-mode`, `eks-fargate` | Fargate rounds to fixed CPU/memory combinations, so an arbitrary `memory: 1200M` becomes a stated rounding decision |
+| `build_strategy` | `buildpacks` (default), `dockerfile` | Which build scaffold is emitted |
+| `registry` | an ECR base URI | Where the built image will live. Omit it and the image reference gets a `TODO` |
+| `namespace` | a namespace name | Usually derived from the CF space |
+
+### Expected Output
+
+```text
+eks/                      Deployments, Services, route objects, Secret stubs, build scaffold
+MIGRATION_REPORT.md       inventory (present AND absent fields), scaffolds, manual actions, risk
+<originals>               byte-identical
+```
+
+## Benchmarks
+
+The paired assessment has been validated against two real Cloud Foundry sample repositories
+(`cloudfoundry-samples/spring-music`, `cloudfoundry-samples/cf-sample-app-nodejs`), both pinned:
+31/31 question coverage, counts reconciled, read-only verified, and every cited evidence file
+confirmed to exist. `BENCHMARKS.md` for this transformation is added when its own runs complete.
+
+## Known Limitations
+
+1. **The container build cannot be fully automated.** There is no `Dockerfile` and no image in a
+   buildpack-built application. A `project.toml` or `Dockerfile` skeleton is emitted with the
+   detected language as comments; choosing and validating the builder is a human decision.
+2. **`VCAP_SERVICES` is a code change.** Every call site is located and reported, and an option set
+   is documented, but application logic is never rewritten.
+3. **Bound services are not provisioned.** Each binding is a cost, version and networking decision.
+   The likely AWS counterpart is named and explicitly **not** asserted as equivalent.
+4. **Tasks and route services are reported, not converted.** Both live outside the manifest, which
+   is why they are the most commonly lost parts of a CF migration.
+5. **No CPU value exists to migrate.** CF derived CPU from memory. The emitted request carries a
+   `TODO` pointing at observed production usage - a guess would be worse than the marker.
+6. **Tanzu Kubernetes Grid is out of scope.** Already Kubernetes.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Invalid configuration format. Must be file:// URL, JSON string, or key=value pairs` | An inline `--configuration` value contained a comma. Use `file://config.json` |
+| Secret stubs have no values | Intentional. A fabricated connection string applies cleanly and fails at runtime |
+| A `Procfile` worker process produced a second Deployment you did not expect | Correct: each non-web process type is its own workload. Losing it is the failure mode |
+| Report flags `memory` as HIGH risk on a Java app | Intentional. The CF value drove the JVM heap calculation; the heap has to be re-derived |
+
+## Repository Structure
+
+```text
+tanzu-to-eks/
+├── README.md                          this file
+├── SKILL.md                           the transformation definition
+└── references/
+    └── 01-manifest-mapping.md         every field, its classification, and what absence means
+```

--- a/community-sourced-transformations/tanzu-to-eks/README.md
+++ b/community-sourced-transformations/tanzu-to-eks/README.md
@@ -149,10 +149,16 @@ MIGRATION_REPORT.md       inventory (present AND absent fields), scaffolds, manu
 
 ## Benchmarks
 
-The paired assessment has been validated against two real Cloud Foundry sample repositories
-(`cloudfoundry-samples/spring-music`, `cloudfoundry-samples/cf-sample-app-nodejs`), both pinned:
+See [`BENCHMARKS.md`](BENCHMARKS.md). Summary: two rounds against two real Cloud Foundry sample
+repositories (`cloudfoundry-samples/spring-music`, `cloudfoundry-samples/cf-sample-app-nodejs`),
+both pinned. Round 1 surfaced 2 contract defects, both fixed in `SKILL.md` and re-validated in
+round 2 on both repos. Round 2: 2/2 COMPLETE, source integrity 0 files modified outside `eks/`
+and the report, `MIGRATION_REPORT.md` at the repository root in 2/2 runs,
+`kubectl apply --dry-run=client` clean, every `TODO(migration)` paired with a report entry.
+
+The paired assessment has been validated separately against the same two repositories:
 31/31 question coverage, counts reconciled, read-only verified, and every cited evidence file
-confirmed to exist. `BENCHMARKS.md` for this transformation is added when its own runs complete.
+confirmed to exist.
 
 ## Known Limitations
 
@@ -184,6 +190,7 @@ confirmed to exist. `BENCHMARKS.md` for this transformation is added when its ow
 tanzu-to-eks/
 ├── README.md                          this file
 ├── SKILL.md                           the transformation definition
+├── BENCHMARKS.md                      measured results
 └── references/
     └── 01-manifest-mapping.md         every field, its classification, and what absence means
 ```

--- a/community-sourced-transformations/tanzu-to-eks/SKILL.md
+++ b/community-sourced-transformations/tanzu-to-eks/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: tanzu-to-eks
+description: >-
+  Transforms a Cloud Foundry application - VMware Tanzu Application Service (TAS), Pivotal
+  Cloud Foundry (PCF) or open-source Cloud Foundry - into Kubernetes manifests for Amazon EKS.
+  Converts the manifest.yml fields that map mechanically, scaffolds the container build and the
+  credential injection, and reports every part of the platform contract that cannot be
+  reconstructed from the repository. Not for Tanzu Kubernetes Grid (TKG).
+  Trigger: Cloud Foundry migration, TAS to EKS, PCF to EKS, manifest.yml, VCAP_SERVICES, cf push.
+type: custom
+version: 0.1.0
+---
+
+# Tanzu / Cloud Foundry to Amazon EKS
+
+## Objective
+
+Convert what a Cloud Foundry repository **does** contain into Kubernetes, and report precisely
+what it does **not** contain because the platform supplied it. The paired Lens
+`tanzu-to-eks-migration-readiness` decides which applications to run this on.
+
+## Why the scope is deliberately narrow
+
+`manifest.yml` is thin. Most of what Kubernetes needs was never in the repository: the buildpack
+built the container, `VCAP_SERVICES` injected credentials, the platform created the route, and
+ephemeral disk meant there was no volume. So this definition is **mostly a scaffolder and a
+reporter**, and only a small part of it is a translator.
+
+That is a design decision, not a limitation. Generating a plausible `Dockerfile` from a buildpack
+contract, or a Secret from a service binding that was never described in the repository, produces
+manifests that apply cleanly and are wrong - the worst outcome. This is the same rule that made
+`ack-resource-adoption-from-iac` degrade an unmapped CloudFormation type to report-only rather
+than invent a Kind.
+
+## Scope
+
+### MECHANICAL - converted
+
+| `manifest.yml` field | Kubernetes output |
+|---|---|
+| `name` | `metadata.name`, and the label set |
+| `instances` | `spec.replicas` |
+| `memory` | `resources.requests.memory` **and** `limits.memory`, with a report note (see below) |
+| `disk_quota` | an `emptyDir` `sizeLimit`, plus a report note that CF disk was ephemeral |
+| `env` | `env[]`, and any value that looks like a credential goes to a Secret stub instead |
+| `command` | `command`/`args` |
+| `routes` / `domain` + `host` | `Service` + `HTTPRoute` (or `Ingress`), plus a DNS action item |
+| `health-check-type: http` + endpoint | `readinessProbe` and `livenessProbe` with that path |
+| `health-check-type: port` (or absent) | a TCP `readinessProbe` on `containerPort`, marked as a **reconstruction** of the platform default |
+| `Procfile` non-web process types | one additional `Deployment` per process type |
+| `.cfignore` | `.dockerignore` |
+
+**`memory` is not a faithful copy.** On Cloud Foundry that value also drove the buildpack's JVM
+memory calculation. Emit it as both request and limit, and emit a HIGH-risk report entry stating
+that a JVM workload needs its heap settings re-derived - copying the number verbatim is the most
+common cause of an OOMKill loop after a CF migration.
+
+### SCAFFOLD - emitted incomplete, clearly marked
+
+1. **Container build.** A `project.toml` for Paketo / Cloud Native Buildpacks when
+   `build_strategy: buildpacks` (closest to the source, since Paketo descends from the CF
+   buildpacks), or a `Dockerfile` skeleton when `build_strategy: dockerfile`. Either way the
+   language and version detected from the repository go in as **comments**, never as asserted
+   values.
+2. **Credential injection.** For every entry in `services:`, a Secret **stub** with the key names
+   the application is likely to read and **no values**, plus a `TODO(migration)` and a report
+   entry naming the AWS service that has to be provisioned. Never invent a connection string.
+3. **`VCAP_SERVICES` shim.** When the application parses `VCAP_SERVICES`, emit a documented option
+   set (adapt the code to read individual env vars, or project a `VCAP_SERVICES`-shaped value from
+   a Secret as a bridge) and mark it a **code change**, not a manifest change.
+
+### REPORT-ONLY - never transformed
+
+| Construct | Why |
+|---|---|
+| Bound service provisioning | Each binding is a provisioning decision with cost, version and networking implications. Naming an RDS instance as "the equivalent" of a `p-mysql` plan hides a version and failover difference |
+| Route services (`cf bind-route-service`) | Rate limiting, auth or WAF that is invisible in the application code and would silently disappear |
+| Tasks (`cf run-task`) | Defined outside the manifest, in automation or a scheduler service. The most commonly lost part of a CF migration |
+| Application Security Groups | Central egress control the repository does not describe. Downstream partners may allow-list the foundation's NAT address |
+| Org / space role model | `SpaceDeveloper` and friends have no direct RBAC counterpart |
+| Blue-green scripts | They encode verification steps between the swap that a plain RollingUpdate does not have |
+| Application code reading `VCAP_*` | Flagged with every call site, never rewritten |
+
+## Constraints
+
+- **Additive, and that includes files at the repository root.** Originals untouched; converted
+  output under `eks/`. **`MIGRATION_REPORT.md` goes at the repository ROOT**, matching the
+  convention of the other definitions in this collection - not inside `eks/`.
+- **Never create or modify a file at the repository root** other than `MIGRATION_REPORT.md`.
+  This includes build-context files: a `.dockerignore` belongs at the build context root to be
+  useful, but writing it there **modifies the source tree**, and a repository that already has one
+  would be overwritten. Emit it as `eks/.dockerignore` with a report entry stating it must be moved
+  to the build context root before the first image build. A useless-but-safe artifact plus an
+  instruction beats a useful artifact that mutated the source.
+- **Never invent a credential, a connection string, an image tag or a hostname.** Emit a stub plus
+  `TODO(migration)` plus a report entry. Three artifacts for one gap, on purpose: the code shows
+  where, the TODO shows what, the report shows why.
+- **Absence is reported, not filled.** If the repository has no health check, no CPU value and no
+  Dockerfile, say so for each - do not quietly supply defaults that look like decisions someone made.
+- Stay on the current branch; do not commit.
+
+## Workflow
+
+```text
+Phase 0  Read additionalPlanContext: migration_target, build_strategy, registry, namespace
+Phase 1  Parse every manifest.yml / manifest-*.yml and vars-*.yml. Inventory EVERY field
+         present AND every field absent. Classify MECHANICAL / SCAFFOLD / REPORT-ONLY.
+Phase 2  Convert the MECHANICAL set (table above). One Deployment per application entry,
+         one more per non-web Procfile process type.
+Phase 3  Emit scaffolds: build (project.toml or Dockerfile), Secret stubs, VCAP shim options.
+Phase 4  Validate: YAML parses, kubectl apply --dry-run=client, helm template if a chart was
+         emitted, and assert no invented credential value survives (grep for placeholder
+         markers, and that every Secret stub has empty values).
+Phase 5  MIGRATION_REPORT.md, cross-referenced to the Lens question ids.
+```
+
+## Exit Criteria
+
+1. Every manifest field, present or absent, appears in the report inventory with a classification.
+2. Originals byte-identical. All converted output under `eks/`; `MIGRATION_REPORT.md` at the
+   repository root. **No other file created or modified at the root** - a `.dockerignore` at
+   the root is a defect even though that is where it would be useful.
+3. Every Secret stub has **empty values** and a `TODO(migration)`. A stub with a fabricated value
+   is a defect, not a convenience.
+4. Emitted YAML parses; `--dry-run=client` clean; charts render under `helm template`.
+5. Every REPORT-ONLY construct has a report entry naming the construct, the reason, and the path.
+6. Every `TODO(migration)` has a report entry, and vice versa.
+7. The `memory` translation carries its HIGH-risk JVM note whenever a JVM language is detected.
+
+## Non-Goals
+
+1. Provisioning AWS services. This produces manifests, never infrastructure.
+2. Rewriting application code. `VCAP_SERVICES` call sites are located and reported.
+3. **Tanzu Kubernetes Grid.** Already Kubernetes; a cluster migration with a different shape.
+4. Executing the migration or applying to a cluster.

--- a/community-sourced-transformations/tanzu-to-eks/references/01-manifest-mapping.md
+++ b/community-sourced-transformations/tanzu-to-eks/references/01-manifest-mapping.md
@@ -1,0 +1,117 @@
+# Manifest Mapping: Cloud Foundry to Amazon EKS
+
+> Loaded in Phase 1. Every `manifest.yml` field, **and every field that is absent**, resolves to
+> exactly one classification. The classification is fixed here, not decided per run.
+
+| Classification | Meaning |
+|---|---|
+| **MECHANICAL** | The field has a deterministic Kubernetes equivalent. Convert it |
+| **SCAFFOLD** | The platform supplied the artifact implicitly. Emit an incomplete, clearly marked stub |
+| **REPORT-ONLY** | Not reconstructible from the repository, or the substitute changes the guarantee |
+
+**Absence is a first-class case.** On Cloud Foundry an omitted field meant a platform default
+applied. Kubernetes has no such default, so an absent field is usually a finding rather than a
+non-event. Each MECHANICAL row below states what absence means.
+
+---
+
+## MECHANICAL
+
+| Field | Kubernetes output | If absent |
+|---|---|---|
+| `name` | `metadata.name` + the label set | required by CF; if absent the manifest is malformed |
+| `instances` | `spec.replicas` | CF default is 1 → emit `replicas: 1` and note it was implicit |
+| `memory` | `resources.requests.memory` **and** `limits.memory` | CF default is foundation-specific (commonly 1G) → **do not guess**, emit `TODO` |
+| `disk_quota` | `emptyDir.sizeLimit` on a `/tmp` volume | default 1G → emit it, note CF disk was ephemeral |
+| `env` | `env[]`; any value matching a credential pattern goes to a Secret stub instead | nothing to do |
+| `command` | `command` / `args` | **finding**: the buildpack chose the start command implicitly and it is not in the repo. `TODO` + report |
+| `routes` / `domain` + `host` | `Service` + `HTTPRoute` (or `Ingress`) + a DNS action item | `random-route: true` means no stable hostname existed → say so, nothing downstream depends on it |
+| `health-check-type: http` + `health-check-http-endpoint` | `readinessProbe` + `livenessProbe` with that path | **finding**: CF defaulted to a TCP port check; Kubernetes has **no** default probe |
+| `health-check-type: port` | TCP `readinessProbe` on `containerPort`, marked a **reconstruction** | as above |
+| `health-check-invocation-timeout` | `timeoutSeconds` | default 1s |
+| `instances` + App Autoscaler rules | `replicas` + an HPA | report that custom-metric rules need a metrics source |
+| `Procfile` `web:` | the main container `command` | - |
+| `Procfile` non-web process types | **one additional `Deployment` per process type** | easy to lose entirely: the app appears migrated while a background consumer no longer exists |
+| `.cfignore` | `.dockerignore` | note that an image build with no `.dockerignore` inflates the context |
+| `stack: cflinuxfs3` / `cflinuxfs4` | the builder or base image choice | report that `cflinuxfs3` is EOL |
+
+### `memory` is not a faithful copy
+
+On Cloud Foundry the `memory` value also drove the **buildpack's JVM memory calculation** -
+heap, metaspace and thread stack were derived from it. Copying the number into a Kubernetes
+`limits.memory` reproduces the ceiling without the derivation, and a JVM that sized itself for a
+CF container will exceed it.
+
+Emit the value as both request and limit, **and** emit a HIGH-risk report entry whenever a JVM
+language is detected (`pom.xml`, `build.gradle`, a `.jar` artifact). This is the most common cause
+of an OOMKill loop after a Cloud Foundry migration, and it looks like a faithful translation.
+
+### There is no CPU field to migrate
+
+Cloud Foundry derived CPU share **from the memory allocation**. The repository therefore contains
+no CPU information at all. Emit `resources.requests.cpu` with a `TODO(migration)` and a report
+entry stating that the value has to come from observed production usage - not from a guess, and
+not omitted, because a pod with no CPU request gets no guarantee.
+
+---
+
+## SCAFFOLD
+
+### Container build
+
+There is no `Dockerfile` in a buildpack-built application, and no image.
+
+| `build_strategy` | Emit | Why |
+|---|---|---|
+| `buildpacks` (default) | `project.toml` for Paketo / Cloud Native Buildpacks | Closest to the source: Paketo descends from the CF buildpacks and detects the same language signals, so runtime behaviour changes least |
+| `dockerfile` | a multi-stage `Dockerfile` skeleton | More control, more behavioural risk: JVM memory calculation, entrypoint and signal handling, and layer caching all become yours |
+
+Detected language and version go in as **comments**, never as asserted values. If the manifest
+already uses `docker:`, the image exists and only the deployment wrapper is missing - say so.
+
+### Credential injection
+
+For every entry in `services:`, emit a Secret **stub**:
+
+- the key names the application is likely to read, derived from the service type
+- **no values** - a stub with a fabricated connection string is a defect, not a convenience
+- a `TODO(migration)` and a report entry naming the AWS service to provision
+
+Flag user-provided services (`cups`) separately: they are arbitrary credentials with no
+marketplace analogue, so even the key names are unknown.
+
+### `VCAP_SERVICES` shim
+
+When the application parses `VCAP_SERVICES`, emit a documented option set rather than a choice:
+
+1. **Adapt the code** to read individual env vars or mounted files. Cleanest, and it is a code change.
+2. **Project a `VCAP_SERVICES`-shaped JSON** from a Secret as a bridge. No code change, keeps the
+   platform-specific shape alive.
+
+Report **the number of distinct call sites** and whether a library (`java-cfenv`,
+`spring-cloud-connectors`) mediates them. A single library boundary is a bounded change; inline
+parsing in five places is not.
+
+---
+
+## REPORT-ONLY
+
+| Construct | Why not transformed | What to report |
+|---|---|---|
+| `services:` provisioning | Each binding is a provisioning decision with cost, version and failover implications | The likely AWS counterpart, explicitly **not** asserted as equivalent. A `p-mysql` plan and an RDS instance differ in version, backup policy and failover |
+| `cf bind-route-service` | Rate limiting, auth or WAF invisible in the application code | That the control in front of the app disappears silently while traffic keeps flowing |
+| `cf run-task`, scheduler bindings | Defined outside the manifest | The most commonly lost part of a CF migration: the web workload migrates and looks healthy while a nightly job no longer runs |
+| Application Security Groups (`cf bind-security-group`) | Central egress control the repository does not describe | Both silent consequences: egress that an ASG permitted without the app declaring it, and partners allow-listing the foundation's NAT address |
+| Org / space roles | `SpaceDeveloper`, `OrgManager` have no direct RBAC counterpart | That space → namespace is clean but each role becomes a deliberate Role definition |
+| Blue-green scripts (`cf rename` + `cf map-route`, `autopilot`) | They encode verification steps between the swap | That a plain RollingUpdate does not have those gates |
+| Volume Services (`volume_mounts`) | A storage decision (EBS zonal vs EFS shared), not a translation | That CF gave ephemeral disk only, so an app writing to local disk loses data on every rollout |
+| Application code reading `VCAP_*` | Rewriting application logic is out of scope | Every call site, with the file and line |
+| Syslog / metrics drains | Platform-side configuration absent from the repository | That an app logging to stdout ports for free, but the drain to the SIEM does not |
+
+---
+
+## The portable set: do not touch
+
+If the repository already contains Kubernetes manifests, a `Dockerfile`, or a Helm chart, they are
+**not** in scope for conversion. A repository mid-migration is the common case, and rewriting the
+Kubernetes work someone already did is damage disguised as progress.


### PR DESCRIPTION
Transforms a Cloud Foundry application (VMware Tanzu Application Service, Pivotal Cloud Foundry, or open-source CF) into Kubernetes manifests for Amazon EKS: converts the manifest.yml fields that map mechanically, scaffolds the container build (Cloud Native Buildpacks project.toml) and credential injection (empty Secret stubs), and reports every part of the platform contract that cannot be reconstructed from the repository.

Follows the same README.md / SKILL.md / BENCHMARKS.md / references/ structure as eks-version-upgrade-readiness.

Validation (see BENCHMARKS.md): executed end-to-end via `atx custom def exec` against 2 real pinned Cloud Foundry repos (cloudfoundry-samples/spring-music and cf-sample-app-nodejs) across 2 rounds - round 1 surfaced 2 contract defects, both fixed and re-validated in round 2 on both repos. Source integrity 0 files changed, kubectl --dry-run clean, every TODO(migration) paired with a report entry.