### PR TITLE
Add flux-to-argocd custom transformation

### DIFF
--- a/community-sourced-transformations/flux-to-argocd/BENCHMARKS.md
+++ b/community-sourced-transformations/flux-to-argocd/BENCHMARKS.md
@@ -1,0 +1,83 @@
+# Benchmark Results - Flux CD to Argo CD
+
+## Executive Summary
+
+| Metric | Result |
+|--------|--------|
+| Repository tested | `fluxcd/flux2-kustomize-helm-example` (real upstream, pinned) |
+| Transformation success rate | **1/1 COMPLETE** |
+| **Source integrity** | **0 files modified outside `argocd/` and the report** |
+| Files emitted | 10 (2 app-of-apps roots + 4 child Applications per environment) |
+| `*.toolkit.fluxcd.io` surviving in output | **0** |
+| Unresolved `${...}` substitution literals in output | **0** |
+| Report at repository root, section `## Manual Action Items` present | **PASS** (name pinned by the contract) |
+| Em dash (U+2014) in emitted output | **0** (forbidden by the contract) |
+| sync-wave DAG mapping | waves 0/0/1/2 preserving the Flux `dependsOn` topological order |
+| Invented values | 0 - `destination.server` and the bootstrap repo URL emitted as `TODO(migration)` |
+| **Layer 2: generated Application reconciles on a live cluster** | **PASS** (see below) |
+| Agent minutes | 56.82 |
+| Estimated cost | ~US$ 1.99 (at US$ 0.035 / agent minute) |
+
+### Methodology
+
+The fixture is the canonical real Flux repository, pinned:
+
+| Repo | Licence | Commit |
+|---|---|---|
+| `fluxcd/flux2-kustomize-helm-example` | Apache-2.0 | `4f1a5b1051b469108d1bdf0ebec6c814427e3834` |
+
+It exercises: 4 Flux `Kustomization`s per env with `dependsOn` chains, `HelmRelease` via
+classic `HelmRepository` (podinfo) AND via `OCIRepository` (cert-manager, envoy-gateway),
+kustomize overlays with `patches`, `retryInterval`/`timeout`, plus two constructs that MUST
+degrade to report-only: `ArtifactGenerator` and the `flux-system/` bootstrap.
+
+```bash
+atx custom def exec -n flux-to-argocd -p . -x -t --configuration file://cfg.json --limit 70
+```
+
+Assertions are invariants (`git diff` vs baseline, output location, zero Flux apiVersion,
+zero substitution literals, Application anchor fields, TODO/report pairing).
+
+## Layer 2 - Reconcile Proof (live EKS cluster, 2026-08-29)
+
+Cluster `atx-ack-lab` (EKS 1.33, us-east-1), Argo CD stable installed. The 4 generated staging
+Applications were applied after the operator steps the report prescribes (fill
+`destination.server`, fill the bootstrap repo URL, register OCI repos).
+
+| Application | Result |
+|---|---|
+| `staging-podinfo` (from `HelmRelease/podinfo`) | **Synced, operation Succeeded** - chart resolved to `6.14.1` from the semver range, `podinfo` + `podinfo-redis` Deployments 1/1 Running, HTTPRoute created with the staging overlay hostname (`podinfo.staging`) - proof the overlay `valuesObject` merge survived the conversion |
+| `staging-infra-configs` (from `Kustomization/infra-configs`) | source resolved after the operator filled the `TODO(migration)` repo URL - exactly the designed flow |
+| `staging-cert-manager`, `staging-envoy-gateway` (from OCI `HelmRelease`s) | blocked by a REGISTRY quirk, not by the conversion - see finding below |
+
+### Finding: semver ranges over public OCI registries fail anonymously in Argo CD
+
+Flux resolves `targetRevision: "1.x"` against OCI registries with its own auth flow. Argo CD's
+repo-server hits `GET /v2/<repo>/tags/list` (and `HEAD /manifests/<tag>`) in a way that
+`quay.io` and `docker.io` answer **401 for anonymous clients**, even for public charts, even
+with the repository registered with `enableOCI: "true"` and the URL matching exactly.
+
+Consequences, now part of the definition's report guidance:
+
+1. A converted OCI `HelmRelease` needs either registry credentials in the Argo CD repository
+   secret or a **pinned concrete version** instead of a semver range.
+2. The repository secret `url` must match the Application `repoURL` **byte for byte**
+   (including the `oci://` prefix) or the secret is silently ignored.
+3. CRDs the chart's values depend on (here: Gateway API for the podinfo `HTTPRoute`) must
+   exist before the sync - and the application controller caches API discovery, so CRDs
+   installed after Argo CD require a controller restart or cache expiry. This is the live
+   manifestation of the `dependsOn` semantic gap the report documents.
+
+## Exit Criteria Compliance (per SKILL.md)
+
+| # | Exit criterion | Result |
+|---|---|---|
+| 1 | Every `*.toolkit.fluxcd.io` document in the inventory with a classification | PASS |
+| 2 | Originals byte-identical; output under `argocd/`; report at root; nothing else at root | PASS |
+| 3 | Every Application resolves repoURL + path/chart + destination, or carries `TODO(migration)` | PASS (destination + bootstrap URL as TODO) |
+| 4 | YAML parses; zero Flux apiVersion; zero `${...}` literals | PASS |
+| 5 | Every REPORT-ONLY construct has a report entry | PASS (ArtifactGenerator, OCIRepository-as-artifact, flux-system, interval) |
+| 6 | TODO(migration) paired with Manual Action Items, and vice versa | PASS |
+| 7 | Namespace-ownership table for the cutover | PASS |
+
+Evidence file: `layer2-evidence.txt` (kubectl snapshots per phase).

--- a/community-sourced-transformations/flux-to-argocd/README.md
+++ b/community-sourced-transformations/flux-to-argocd/README.md
@@ -1,0 +1,114 @@
+# Flux CD to Argo CD
+
+Transforms a Flux CD (v2) GitOps repository into Argo CD equivalents - converting `Kustomization` and `HelmRelease` to `Application`, joining `GitRepository` / `HelmRepository` / `OCIRepository` sources into each Application, scaffolding the cluster entry-point as an app-of-apps root with sync-wave ordering, and reporting every Flux capability Argo CD does not have.
+
+**Additive by design: the original manifests are never modified. Output lands under `argocd/`.**
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Problem](#the-problem)
+- [What This Skill Does](#what-this-skill-does)
+- [Getting Started](#getting-started)
+- [Benchmarks](#benchmarks)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [Repository Structure](#repository-structure)
+
+## Overview
+
+Flux and Argo CD disagree on where reconciliation logic lives. Flux composes small controllers
+driven by CRs in the cluster - sources are standalone objects, ordering is an explicit
+`dependsOn` DAG, and `postBuild` rewrites manifests with cluster-side variables. Argo CD
+centralizes around the `Application`, reads only from the repository, and orders with
+sync-waves inside one Application tree.
+
+This transformation converts what maps mechanically, scaffolds what needs a human decision,
+and reports what has no counterpart - each construct classified in advance, not decided per run.
+
+## The Problem
+
+Three failure modes make a naive conversion wrong in ways that **apply cleanly**:
+
+1. **Flux resolves sources by reference; Argo embeds them.** A `GitRepository` referenced by
+   many `Kustomization`s must be JOINed into every `Application` - and if the source object
+   lives only in the bootstrap, the join has no value to copy and must surface as a TODO.
+2. **`postBuild.substitute` has no Argo equivalent.** Manifests that depend on it sync
+   "successfully" with literal `${VAR}` strings applied to the cluster. Nothing fails.
+3. **`dependsOn` is a DAG across Kustomizations; sync-waves order inside one Application.**
+   Same word, different scope - and waves do not gate on health the way `dependsOn` +
+   `healthChecks` did.
+
+## What This Skill Does
+
+| Phase | Action |
+|---|---|
+| 0 | Reads `additionalPlanContext`: `argocd_namespace`, `project`, optional `destination_server` |
+| 1 | Inventories every `*.toolkit.fluxcd.io` document, builds the sourceRef JOIN table and the `dependsOn` DAG, classifies **MECHANICAL / SCAFFOLD / REPORT-ONLY** |
+| 2 | Converts the mechanical set: `Kustomization` → `Application` (path, targetNamespace, prune, patches, retry), `HelmRelease` + repo source → Helm `Application` (chart, semver, `valuesObject`) |
+| 3 | Emits scaffolds: app-of-apps root per cluster entry-point, sync-wave annotations preserving the DAG order, `AppProject` stubs where tenancy was present |
+| 4 | Validates: YAML parses, zero Flux `apiVersion` in output, zero unresolved `${...}` literals, every Application has repoURL + path/chart + destination |
+| 5 | Writes `MIGRATION_REPORT.md` at the repository root: inventory, JOIN table, DAG/wave mapping, namespace-ownership table for the cutover, `## Manual Action Items` |
+
+Every emitted `Application` carries `migration.flux/source: <Kind>/<ns>/<name>` so the operator
+can diff tool-by-tool during the cutover window.
+
+## Getting Started
+
+```bash
+atx custom def exec -n flux-to-argocd -p . -x -t \
+  --configuration file://config.json --limit 70
+```
+
+```json
+{"additionalPlanContext": "argocd_namespace: argocd\nproject: default"}
+```
+
+Use `--configuration file://` - a comma inside an inline `key=value` breaks the CLI parser.
+Assert the artifact count after every run: a low `--limit` truncates the bundle silently.
+
+## Benchmarks
+
+Full evidence in [`BENCHMARKS.md`](BENCHMARKS.md). Summary: validated on the canonical real
+repository `fluxcd/flux2-kustomize-helm-example` (pinned commit) - source integrity 0 files
+changed, 10 Applications emitted, zero Flux apiVersion leakage, zero substitution literals,
+DAG preserved as waves 0/0/1/2. **Layer 2:** the generated `staging-podinfo` Application was
+applied to a live EKS cluster running Argo CD and reconciled to Running workloads
+(`podinfo` + `podinfo-redis` Deployments 1/1, HTTPRoute with the staging overlay hostname),
+proving the conversion end to end, not just structurally.
+
+## Known Limitations
+
+- **`postBuild.substitute` / `substituteFrom`** - report-only. No Argo equivalent; listed per
+  variable and consuming file.
+- **`HelmRelease.spec.valuesFrom`** - report-only. Argo cannot read values from in-cluster
+  objects.
+- **OCI manifests (`OCIRepository` as artifact, `ArtifactGenerator`)** - report-only. Argo
+  sources are git, Helm repos and OCI Helm charts.
+- **Semver ranges over public OCI registries** fail anonymously in Argo CD (`tags/list` 401 on
+  quay.io/docker.io) - converted OCI HelmReleases need registry credentials or a pinned
+  version. Documented in the report's Manual Action Items.
+- **Image automation and notifications** - separate Argo components with different config;
+  flagged with guidance, never translated.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Invalid configuration format` before the run starts | A comma inside an inline `--configuration key=value` | Use `--configuration file://config.json` |
+| Run completes but fewer artifacts than expected | Low `--limit` truncates the bundle silently | Re-run with `--limit 70`; always assert the artifact count |
+| Applied Application stuck `Unknown` with `ComparisonError ... tags/list ... 401` | Semver range over a public OCI registry - Argo CD's anonymous tag listing is refused by quay.io/docker.io | Pin a concrete chart version, or add registry credentials to the Argo CD repository secret |
+| OCI repository secret seems ignored | Secret `url` does not match the Application `repoURL` byte for byte | Include the `oci://` prefix in the secret `url` |
+| Sync fails `failed to discover server resources for group version ...` for a CRD that exists | The application controller caches API discovery; the CRD was installed after Argo CD | Restart `argocd-application-controller` (or wait for the cache to expire), then sync again |
+| `destination.server: TODO(migration)` rejected on apply | The cluster URL is an operational value the repository does not carry - emitted as TODO by design | Fill it per environment before applying (in-cluster: `https://kubernetes.default.svc`) |
+| Manifests apply with literal `${VAR}` strings | The source repo used Flux `postBuild.substitute`, which has no Argo equivalent | See the report's REPORT-ONLY section - the variables must move into overlays or a plugin |
+
+## Repository Structure
+
+```text
+atx-td-flux-to-argocd/
+├── SKILL.md                        # orchestration spine (discovery → convert → scaffold → validate → report)
+├── BENCHMARKS.md                   # validation evidence (structural + live reconcile)
+└── references/
+    └── 01-construct-mapping.md     # before/after YAML per mapping + field table + validation greps
+```

--- a/community-sourced-transformations/flux-to-argocd/README.md
+++ b/community-sourced-transformations/flux-to-argocd/README.md
@@ -106,7 +106,8 @@ proving the conversion end to end, not just structurally.
 ## Repository Structure
 
 ```text
-atx-td-flux-to-argocd/
+flux-to-argocd/
+├── README.md                       # this file
 ├── SKILL.md                        # orchestration spine (discovery → convert → scaffold → validate → report)
 ├── BENCHMARKS.md                   # validation evidence (structural + live reconcile)
 └── references/

--- a/community-sourced-transformations/flux-to-argocd/SKILL.md
+++ b/community-sourced-transformations/flux-to-argocd/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: flux-to-argocd
+description: >-
+  Transforms a Flux CD (v2) GitOps repository into Argo CD equivalents - converting
+  Kustomization and HelmRelease to Application, joining GitRepository / HelmRepository /
+  OCIRepository sources into each Application's source block, scaffolding the cluster
+  entry-point as an app-of-apps root, and reporting every Flux capability that Argo CD
+  does not have (postBuild substitution, valuesFrom, image automation, SOPS decryption).
+  Trigger: Flux to Argo, FluxCD migration, Kustomization to Application, HelmRelease to
+  Application, GitOps tool migration, flux2.
+type: custom
+version: 0.1.0
+---
+
+# Flux CD to Argo CD
+
+## Objective
+
+Convert what maps mechanically between the two GitOps models, scaffold what needs a human
+decision, and report precisely which Flux behaviours have **no Argo CD counterpart** - because
+the two tools disagree on where reconciliation logic lives. Flux composes small controllers
+driven by CRs in the cluster; Argo CD centralizes around the `Application` and reads only from
+the source repository.
+
+## Why this is not a field rename
+
+Three structural differences make a naive conversion wrong in ways that apply cleanly:
+
+1. **Flux resolves sources as separate objects; Argo embeds them.** A `GitRepository` is one CR
+   referenced by many `Kustomization`s. The conversion must JOIN the source into every
+   `Application` - and if the source object is missing from the repository (created by
+   bootstrap), the join fails and must be reported, never guessed.
+2. **Flux `postBuild.substitute` rewrites manifests with cluster-side variables.** Vanilla
+   kustomize (what Argo runs) has no substitution step. Manifests that depend on it produce
+   `${VAR}` literals after a "successful" Argo sync - the property is silently gone.
+3. **Flux `dependsOn` is an explicit DAG across Kustomizations.** Argo sync-waves order
+   resources INSIDE one Application; ordering ACROSS Applications needs the app-of-apps
+   pattern plus waves on the child Application manifests. Same word, different scope -
+   converting one to the other changes semantics and is therefore a SCAFFOLD, not MECHANICAL.
+
+## Scope
+
+### MECHANICAL - converted
+
+| Flux construct | Argo CD output |
+|---|---|
+| `Kustomization` (kustomize.toolkit.fluxcd.io) | `Application` - `spec.source.path` from `spec.path`, `destination.namespace` from `targetNamespace` |
+| `Kustomization.spec.sourceRef` → `GitRepository` | `Application.spec.source.repoURL` + `targetRevision` (branch/tag/semver from the `ref` block) |
+| `Kustomization.spec.prune: true` | `syncPolicy.automated.prune: true` |
+| `Kustomization.spec.patches` | `spec.source.kustomize.patches` (Argo CD >= 2.5) |
+| `Kustomization.spec.retryInterval` | `syncPolicy.retry` (limit + backoff), with a report note that the semantics are attempt-based, not interval-based |
+| `HelmRelease` + `HelmRepository` (HTTP) | `Application` with a Helm source - `repoURL` from the `HelmRepository.spec.url`, `chart` and `targetRevision` from `HelmRelease.spec.chart.spec` |
+| `HelmRelease.spec.values` (inline) | `spec.source.helm.valuesObject` |
+| `HelmRelease` + `HelmRepository` `type: oci` / `OCIRepository` as a **Helm chart** source | `Application` Helm source with the `oci://` registry as `repoURL` |
+| `Kustomization.spec.suspend: true` | annotation to skip automated sync (`syncPolicy` omitted) + report entry - suspended state is a decision the operator must re-take |
+| `interval` | dropped, with ONE report note: Argo reconciliation cadence is a global controller setting (`timeout.reconciliation`), not per-Application |
+
+### SCAFFOLD - emitted incomplete, clearly marked
+
+1. **Cluster entry-point.** The `clusters/<env>/*.yaml` Flux Kustomizations become an
+   **app-of-apps root `Application`** per environment, pointing at a generated
+   `argocd/<env>/` directory that contains the child Applications. Emitted with
+   `TODO(migration)` on `destination.server` - the cluster URL is an operational value the
+   repository does not carry.
+2. **`dependsOn` ordering.** Child Applications receive `argocd.argoproj.io/sync-wave`
+   annotations that PRESERVE the Flux DAG's topological order, plus a report entry stating
+   the semantic difference (waves order syncs; they do not gate on health the way
+   `dependsOn` + `healthChecks` did - Argo health gating needs the root app sync policy
+   reviewed by a human).
+3. **Multi-tenancy.** When a Flux `Kustomization` carries `serviceAccountName`, emit an
+   `AppProject` stub restricting destinations and source repos, with empty allow-lists and
+   `TODO(migration)` - the tenancy boundary is a security decision.
+
+### REPORT-ONLY - never transformed
+
+| Construct | Why |
+|---|---|
+| `postBuild.substitute` / `substituteFrom` | No Argo equivalent in vanilla kustomize. Manifests depending on it BREAK SILENTLY (literal `${VAR}` applied). Each variable and consuming file is listed |
+| `HelmRelease.spec.valuesFrom` (ConfigMap/Secret) | Argo CD cannot read Helm values from cluster objects. Needs a repo-side values file or a plugin - a design decision |
+| `OCIRepository` consumed as a **kustomize/manifest artifact** (non-Helm), incl. `ArtifactGenerator` | Argo CD sources are git, Helm repos and OCI Helm charts. Arbitrary OCI artifacts as manifest sources have no counterpart |
+| `flux-system/` bootstrap (`gotk-components.yaml`, `gotk-sync.yaml`) | That is the PLATFORM, not an application. Its Argo counterpart is installing Argo CD itself, which this definition never does |
+| Image automation (`ImageRepository`, `ImagePolicy`, `ImageUpdateAutomation`) | Argo CD Image Updater is a separate optional component with different config |
+| Notification stack (`Alert`, `Provider`, `Receiver`) | Argo CD Notifications exists but is configured via ConfigMap/triggers - a re-design, not a translation |
+| `Kustomization.spec.decryption` (SOPS) | Argo CD has no native SOPS. Secrets management strategy must be re-decided (e.g. External Secrets) |
+| `healthChecks` / `wait` | Argo has built-in health assessment; custom checks become Lua in `argocd-cm` - global config, not per-app |
+| Any `kind` not in the mapping reference | Degrade to report-only guidance, never invent an Argo equivalent - same rule as the other definitions in this collection |
+
+## Constraints
+
+- **Additive, and that includes files at the repository root.** Originals untouched; converted
+  output under `argocd/`. **`MIGRATION_REPORT.md` goes at the repository ROOT**, matching the
+  convention of the other definitions in this collection - not inside `argocd/`.
+- **Never create or modify a file at the repository root** other than `MIGRATION_REPORT.md`.
+- **Never invent a cluster URL, a repo URL, a credential or a version.** If the value is not in
+  the repository, emit the field with `TODO(migration)` plus a report entry.
+- **Every emitted `Application` must name the Flux CR it came from** (annotation
+  `migration.flux/source: <kind>/<namespace>/<name>`), so the operator can diff tool-by-tool
+  during the cutover window.
+- **The report must state the cutover risk explicitly:** running both tools against the same
+  namespaces causes fight-over-ownership; the report lists which namespaces each emitted
+  Application will manage, so the operator can suspend the corresponding Flux Kustomizations
+  first.
+- **The manual-action section of the report is named exactly `## Manual Action Items`.**
+- **No em dash (U+2014) anywhere in emitted output** - use a hyphen.
+- Stay on the current branch; do not commit.
+
+## Workflow
+
+```text
+Phase 0  Read additionalPlanContext: destination_server (optional), argocd_namespace
+         (default argocd), project (default default).
+Phase 1  Discovery. Inventory every *.toolkit.fluxcd.io document: Kustomizations, sources,
+         HelmReleases, image/notification CRs. Build the sourceRef JOIN table and the
+         dependsOn DAG. Classify every construct MECHANICAL / SCAFFOLD / REPORT-ONLY.
+Phase 2  Convert the MECHANICAL set. One Application per Flux Kustomization / HelmRelease,
+         under argocd/<env-or-path>/, each carrying the migration.flux/source annotation.
+Phase 3  Emit scaffolds: app-of-apps root per cluster entry-point, sync-wave ordering from
+         the DAG, AppProject stubs where tenancy was present.
+Phase 4  Validate: YAML parses, kubectl apply --dry-run=client with the Application CRD
+         schema unavailable locally is acceptable (validate=false), assert zero
+         *.toolkit.fluxcd.io apiVersion in argocd/, assert every Application has repoURL +
+         path|chart + destination, assert no ${VAR} literal survived into emitted manifests.
+Phase 5  MIGRATION_REPORT.md at the root: inventory (present AND absent), the JOIN table,
+         the DAG and its wave mapping, every REPORT-ONLY construct with reason and path,
+         Manual Action Items, TODO(migration) cross-reference.
+```
+
+## Exit Criteria
+
+1. Every `*.toolkit.fluxcd.io` document appears in the report inventory with a classification.
+2. Originals byte-identical. All converted output under `argocd/`; `MIGRATION_REPORT.md` at the
+   repository root; no other file created or modified at the root.
+3. Every emitted `Application` resolves to a concrete `repoURL` + (`path` or `chart`) +
+   `destination`, or carries `TODO(migration)` on the missing field plus a report entry.
+4. Emitted YAML parses. Zero `*.toolkit.fluxcd.io` apiVersions under `argocd/`. Zero
+   unresolved `${...}` substitution literals in emitted manifests.
+5. Every REPORT-ONLY construct has a report entry naming the construct, the reason and the path.
+6. Every `TODO(migration)` has an entry in the report's Manual Action Items, and vice versa.
+7. The report contains the namespace-ownership table for the cutover.
+
+## Non-Goals
+
+1. Installing or configuring Argo CD. This produces manifests, never platform components.
+2. Migrating the Flux bootstrap. `flux-system/` is reported, not converted.
+3. Image automation and notifications - flagged with guidance, never translated.
+4. Executing the migration or applying to a cluster.

--- a/community-sourced-transformations/flux-to-argocd/references/01-construct-mapping.md
+++ b/community-sourced-transformations/flux-to-argocd/references/01-construct-mapping.md
@@ -1,0 +1,231 @@
+# Construct Mapping - Flux CD v2 to Argo CD
+
+Concrete before/after pairs for every MECHANICAL and SCAFFOLD mapping. The rule that governs
+all of them: **if the value is not in the repository, it becomes `TODO(migration)` + a report
+entry - never a guess.**
+
+## 1. Kustomization + GitRepository → Application (the JOIN)
+
+Flux (two objects, source shared by reference):
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  url: https://github.com/org/repo
+  ref:
+    branch: main
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/staging
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: podinfo
+```
+
+Argo CD (one object, source embedded - the JOIN happened at conversion time):
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps
+  namespace: argocd
+  annotations:
+    migration.flux/source: Kustomization/flux-system/apps
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/org/repo   # joined from GitRepository flux-system
+    targetRevision: main                   # from GitRepository .spec.ref.branch
+    path: apps/staging
+  destination:
+    server: https://kubernetes.default.svc  # TODO(migration) if multi-cluster
+    namespace: podinfo                      # from targetNamespace
+  syncPolicy:
+    automated:
+      prune: true        # from prune: true
+      selfHeal: true     # Flux always self-heals; keep parity
+```
+
+`ref` variants: `branch` and `tag` map to `targetRevision` verbatim; `semver` maps to Argo's
+semver constraint syntax for Helm sources only - for a git source, semver has no Argo
+counterpart and becomes `TODO(migration)` + report entry.
+
+## 2. HelmRelease + HelmRepository → Application (Helm source)
+
+Flux:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: podinfo
+spec:
+  url: https://stefanprodan.github.io/podinfo
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: podinfo
+spec:
+  chart:
+    spec:
+      chart: podinfo
+      version: ">=6.0.0 <7.0.0"
+      sourceRef:
+        kind: HelmRepository
+        name: podinfo
+  values:
+    replicaCount: 2
+```
+
+Argo CD:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: podinfo
+  namespace: argocd
+  annotations:
+    migration.flux/source: HelmRelease/podinfo/podinfo
+spec:
+  project: default
+  source:
+    repoURL: https://stefanprodan.github.io/podinfo  # joined from HelmRepository
+    chart: podinfo
+    targetRevision: ">=6.0.0 <7.0.0"   # Argo accepts semver ranges for Helm
+    helm:
+      valuesObject:                     # from HelmRelease .spec.values, verbatim
+        replicaCount: 2
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: podinfo
+```
+
+`HelmRepository` with `type: oci`: `repoURL` becomes the `oci://...` registry path, same join.
+
+**`valuesFrom` is REPORT-ONLY.** Argo cannot read values from in-cluster ConfigMaps/Secrets.
+The report lists each `valuesFrom` entry with the two viable strategies (commit the values file
+to the repo, or a config-management plugin) - choosing one is a design decision.
+
+## 3. dependsOn DAG → sync-waves (SCAFFOLD)
+
+Flux orders ACROSS Kustomizations:
+
+```yaml
+spec:
+  dependsOn:
+    - name: infra-controllers
+```
+
+Argo orders by wave INSIDE one Application tree. Under app-of-apps, annotate the CHILD
+Application manifests with waves that preserve the topological order of the Flux DAG:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"   # infra-controllers (no dependencies)
+---
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"   # infra-configs (dependsOn: infra-controllers)
+---
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"   # apps (dependsOn: infra-configs)
+```
+
+Report entry is mandatory: waves order sync start; they do NOT gate on the health checks that
+Flux `dependsOn` + `healthChecks` enforced. The operator must review whether the root app uses
+automated sync with health-based progression.
+
+## 4. Cluster entry-point → app-of-apps root (SCAFFOLD)
+
+Flux layout `clusters/staging/{infrastructure.yaml,apps.yaml}` (Kustomizations applied by
+bootstrap) becomes one root Application per environment:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: staging-root
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: <same repo>
+    targetRevision: main
+    path: argocd/staging          # the generated directory with child Applications
+  destination:
+    server: https://kubernetes.default.svc  # TODO(migration): staging cluster URL
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+## 5. Field-by-field quick table
+
+| Flux field | Argo CD field | Class |
+|---|---|---|
+| `Kustomization.spec.path` | `source.path` (strip leading `./`) | MECHANICAL |
+| `Kustomization.spec.targetNamespace` | `destination.namespace` | MECHANICAL |
+| `Kustomization.spec.prune` | `syncPolicy.automated.prune` | MECHANICAL |
+| `Kustomization.spec.patches` | `source.kustomize.patches` | MECHANICAL |
+| `Kustomization.spec.retryInterval` | `syncPolicy.retry.backoff` | MECHANICAL + note |
+| `Kustomization.spec.interval` | dropped + single report note | MECHANICAL |
+| `Kustomization.spec.suspend` | omit syncPolicy + report entry | MECHANICAL + note |
+| `Kustomization.spec.dependsOn` | sync-wave annotations on children | SCAFFOLD |
+| `Kustomization.spec.serviceAccountName` | `AppProject` stub | SCAFFOLD |
+| `Kustomization.spec.postBuild.*` | none | REPORT-ONLY |
+| `Kustomization.spec.decryption` | none | REPORT-ONLY |
+| `Kustomization.spec.healthChecks` / `wait` | built-in health / Lua in argocd-cm | REPORT-ONLY |
+| `HelmRelease.spec.values` | `source.helm.valuesObject` | MECHANICAL |
+| `HelmRelease.spec.valuesFrom` | none | REPORT-ONLY |
+| `HelmRelease.spec.chart.spec.version` | `source.targetRevision` | MECHANICAL |
+| `HelmRelease` install/upgrade `remediation` | `syncPolicy.retry` (partial) | SCAFFOLD |
+| `GitRepository.spec.url` / `ref` | `source.repoURL` / `targetRevision` | MECHANICAL (join) |
+| `HelmRepository.spec.url` (http/oci) | `source.repoURL` | MECHANICAL (join) |
+| `OCIRepository` as Helm chart | `source.repoURL: oci://` | MECHANICAL (join) |
+| `OCIRepository` as manifest artifact / `ArtifactGenerator` | none | REPORT-ONLY |
+| `ImageRepository` / `ImagePolicy` / `ImageUpdateAutomation` | Argo CD Image Updater (separate tool) | REPORT-ONLY |
+| `Alert` / `Provider` / `Receiver` | Argo CD Notifications (re-design) | REPORT-ONLY |
+| `flux-system/gotk-*.yaml` | platform bootstrap, out of scope | REPORT-ONLY |
+
+## 6. Validation greps (Phase 4)
+
+```bash
+# zero Flux apiVersion under argocd/
+grep -rE "apiVersion:\s*\S+\.toolkit\.fluxcd\.io" argocd/ && exit 1
+
+# zero unresolved substitution literal
+grep -rE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' argocd/ && exit 1
+
+# every Application has the three anchors
+python3 - <<'EOF'
+import yaml, glob, sys
+bad = []
+for f in glob.glob("argocd/**/*.yaml", recursive=True):
+    for d in yaml.safe_load_all(open(f)):
+        if not d or d.get("kind") != "Application":
+            continue
+        src, dst = d["spec"].get("source", {}), d["spec"].get("destination", {})
+        if not src.get("repoURL") or not (src.get("path") or src.get("chart")) or not dst:
+            bad.append(f)
+sys.exit(1 if bad else 0)
+EOF
+```


### PR DESCRIPTION
Transforms a Flux CD (v2) GitOps repository into Argo CD equivalents: converts Kustomization and HelmRelease to Application, joins GitRepository / HelmRepository / OCIRepository sources into each Application's source block, scaffolds the cluster entry-point as an app-of-apps root with sync-wave ordering derived from the dependsOn DAG, and reports every Flux capability Argo CD does not have (postBuild substitution, valuesFrom, image automation, SOPS decryption).

Follows the same README.md / SKILL.md / BENCHMARKS.md / references/ structure as eks-version-upgrade-readiness.

Validation (see BENCHMARKS.md): executed end-to-end via `atx custom def exec` against the pinned fluxcd/flux2-kustomize-helm-example - source integrity 0 files changed, 10 Applications emitted, zero Flux apiVersion leakage, zero unresolved substitution literals. Additionally the generated staging-podinfo Application was applied to a live EKS cluster running Argo CD and reconciled to Running workloads (Synced / operation Succeeded), proving the conversion end to end.