### PR TITLE
Add openshift-to-eks custom transformation

### DIFF
--- a/community-sourced-transformations/openshift-to-eks/BENCHMARKS.md
+++ b/community-sourced-transformations/openshift-to-eks/BENCHMARKS.md
@@ -1,0 +1,121 @@
+# Benchmark Results - OpenShift to Amazon EKS
+
+## Executive Summary
+
+| Metric | Result |
+|--------|--------|
+| Repositories tested | 2 real upstream OpenShift sample repos, pinned to a commit |
+| Transformation success rate | **2/2** |
+| **Source integrity** | **0 files modified outside `eks/` and the report, in both runs** |
+| Files emitted | 33 (`nodejs-ex`) and 17 (`cakephp-ex`) |
+| Helm charts emitted | 4 and 3 - **all 7 render under `helm template`** |
+| `*.openshift.io` surviving in output | **0** in both runs |
+| `TODO(migration)` markers | 15 and 15, all covered by the report's Manual Action section |
+| `MIGRATION_REPORT.md` | 12.6 KB and 11.6 KB |
+| Total agent minutes | 141.67 |
+| Total estimated cost | ~US$ 4.96 (at US$ 0.035 / agent minute) |
+
+### Methodology
+
+The fixtures are **real public repositories**, not hand-written ones, pinned to a commit so the
+result stays reproducible:
+
+| Repo | Licence | Commit |
+|---|---|---|
+| `sclorg/nodejs-ex` | Apache-2.0 | `5506d732f447c7c48dc89619af3b8ee8f125cf90` |
+| `sclorg/cakephp-ex` | CC0-1.0 | `9573e973a9ffd5b6e1d2183643de2acbdfd02dd3` |
+
+Real repositories were chosen deliberately over a hand-authored fixture. A fixture written by the
+author of the mapping carries the author's bias: it contains the constructs the mapping already
+knows about. A real repository contains what the world contains, including what the author did not
+think of - and `nodejs-ex` proved the point by carrying its OpenShift constructs in **two** forms,
+Template JSON *and* a Helm chart, exercising a path the hand-written fixture never touched.
+
+Each repo was committed as a baseline, then transformed via:
+
+```bash
+atx custom def exec -n openshift-to-eks -p . -x -t \
+  --configuration file://config.json --limit 70
+```
+
+Assertions are **invariants**, not expected findings, because a real repository has no answer key:
+source integrity, output existence, zero OpenShift `apiVersion` leakage, YAML validity, chart
+rendering, and `TODO`/report pairing.
+
+---
+
+## At-a-Glance Results
+
+| # | Repository | Status | Files emitted | Charts | Source files changed | OCP leak | TODOs | Agent Min | Cost |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | `sclorg/nodejs-ex` (45 files) | PASS | 33 | 4/4 render | **0** | 0 | 15 | 70.71 | $2.47 |
+| 2 | `sclorg/cakephp-ex` (93 files) | PASS | 17 | 3/3 render | **0** | 0 | 15 | 70.96 | $2.48 |
+| | **TOTALS** | **2/2** | **50** | **7/7** | **0** | **0** | **30** | **141.67** | **$4.96** |
+
+---
+
+## Exit Criteria Compliance (per SKILL.md)
+
+| # | Exit criterion | nodejs-ex | cakephp-ex |
+|---|---|---|---|
+| 1 | Every construct in the inventory appears in the report with its classification | PASS | PASS |
+| 2 | Originals byte-identical; all output under `eks/` | PASS | PASS |
+| 3 | Zero `*.openshift.io` apiVersions in emitted output | PASS | PASS |
+| 4 | Emitted YAML parses; charts render | PASS (30 YAML, 4 charts) | PASS (16 YAML, 3 charts) |
+| 5 | Every REPORT-ONLY construct has a report entry | PASS | PASS |
+| 6 | Every ambiguity carries a `TODO(migration)` and a report entry | PASS (15) | PASS (15) |
+| 7 | Report cross-references the Lens question ids | PASS | PASS |
+
+---
+
+## What the first run got right, and what it cost to find out
+
+The transformation passed on its first real execution. What did **not** pass on the first attempt
+was the tooling around it, and both failures are recorded because they cost real time:
+
+**1. The run failed before starting, twice, on a CLI parsing rule.** `--configuration` was passed
+inline as
+`additionalPlanContext=migration_target: eks-standard, ingress_strategy: gateway-api, registry: ...`
+and rejected with `Invalid configuration format`. **Commas separate `key=value` pairs** in the
+inline form, so `ingress_strategy: gateway-api` parsed as a key with no `=`. Zero agent minutes
+were consumed - the CLI rejected the input up front - but the run produced no output and looked
+like a transformation failure. The fix is `--configuration file://config.json`, and it is now the
+documented invocation in the README.
+
+**2. The assertion script reported 19 of 30 emitted YAML files as invalid.** They were **Helm
+templates**: `{{ .Values.name | quote }}` is not valid standalone YAML by design, and
+`helm template` rendered all 4 charts without error. The check was wrong, not the output. Files
+under a chart's `templates/` directory containing `{{` are now validated with `helm template`
+instead of a YAML parser.
+
+**3. The assertion script reported 3 `TODO(migration)` markers with no report entry.** They were
+documented - keyed on the **source** file (`nodeshift/route.yml`) rather than the emitted file
+(`httproute.yaml`), which is the correct behaviour for a report describing what the original
+contained. The check matched on the wrong basename.
+
+Two of these three were false failures produced by the verifier. That is worth stating plainly:
+a validator that cries wolf trains its reader to ignore it, so its own defects belong in the
+benchmark alongside the definition's.
+
+---
+
+## Reproducing
+
+```bash
+# 1. fetch the pinned fixtures (asserts licence, commit, and construct presence)
+./fetch-samples.sh
+
+# 2. baseline
+cd upstream/nodejs-ex && git init -q && git add -A && git commit -qm baseline
+
+# 3. publish from a staged copy (SKILL.md + references/ only; a README at the
+#    definition root aborts the publish)
+atx custom def publish -n openshift-to-eks --sd <staged>
+
+# 4. transform
+atx custom def exec -n openshift-to-eks -p . -x -t \
+  --configuration file://config.json --limit 70
+
+# 5. assert the invariants
+python3 assert_def_run.py <repo-dir>
+```

--- a/community-sourced-transformations/openshift-to-eks/README.md
+++ b/community-sourced-transformations/openshift-to-eks/README.md
@@ -1,0 +1,193 @@
+# OpenShift to Amazon EKS
+
+Transforms a Red Hat OpenShift application repository into portable Kubernetes for Amazon EKS - converting `DeploymentConfig`, `ImageStream` references, `Route` and OpenShift `Template`, scaffolding `SecurityContextConstraints` to Pod Security Admission, and reporting every construct that has no safe equivalent.
+
+**Additive by design: the original manifests are never modified. Output lands under `eks/`.**
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Problem](#the-problem)
+- [What This Skill Does](#what-this-skill-does)
+- [Skill Architecture](#skill-architecture)
+- [Paired Readiness Assessment](#paired-readiness-assessment)
+- [Getting Started](#getting-started)
+- [Benchmarks](#benchmarks)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [Repository Structure](#repository-structure)
+
+## Overview
+
+An OpenShift application repository is not portable Kubernetes. It carries objects that exist only
+on OpenShift (`DeploymentConfig`, `Route`, `BuildConfig`, `ImageStream`,
+`SecurityContextConstraints`), image references that resolve through an indirection layer with no
+registry host, and node selectors pointing at labels EKS does not have.
+
+This transformation converts what maps deterministically, scaffolds what is partly automatable,
+and reports what cannot be automated safely - each construct classified in advance, not decided
+per run.
+
+## The Problem
+
+Three failure modes make a hand migration expensive, and all three are silent:
+
+1. **An `ImageStreamTag` reference carries no registry host.** `image: payments-api:latest` is
+   valid on OpenShift and unresolvable anywhere else. It fails at pull time, which reads as a
+   permissions problem.
+2. **A `reencrypt` Route converted to `edge` drops in-cluster TLS.** Nothing fails. The endpoint
+   still answers HTTPS. The property is simply gone.
+3. **A `ClusterResourceQuota` replaced by per-namespace quotas looks like a faithful
+   conversion** and is not: it produces a sum of maximums rather than a shared ceiling, so every
+   namespace can reach its own limit simultaneously.
+
+A transformation that guesses on any of these produces manifests that apply cleanly and are
+wrong, which is worse than an annotated gap.
+
+## What This Skill Does
+
+| Phase | Action |
+|---|---|
+| 0 | Reads `additionalPlanContext`: `migration_target`, `ingress_strategy`, `registry`, `namespace` |
+| 1 | Inventories every construct and classifies it **MECHANICAL / SCAFFOLD / REPORT-ONLY** before transforming anything |
+| 2 | Converts the mechanical set: `DeploymentConfig` → `Deployment`, `ImageStreamTag` → a fully qualified registry URI, `Route` → `HTTPRoute` or `Ingress`, `Template` → Helm chart, PVC `storageClassName` → `gp3`/`efs` |
+| 3 | Emits scaffolds: SCC → Pod Security Admission labels (plus Kyverno **only** for the residue PSA cannot express), `BuildConfig` → a build skeleton, `PerformanceProfile` → a Karpenter `NodePool` with the observed constraints as comments |
+| 4 | Validates: YAML parses, `kubectl apply --dry-run`, `helm template`, and asserts zero `*.openshift.io` survives in the output |
+| 5 | Writes `MIGRATION_REPORT.md` with the full inventory, the risk per change, and every manual action item |
+
+## Skill Architecture
+
+Lean `SKILL.md` orchestration spine plus references loaded on demand:
+
+```text
+SKILL.md                            spine: scope, constraints, 6 phases, exit criteria
+references/01-construct-mapping.md  every construct, its classification, and the mapping
+references/02-report-template.md    the migration report structure
+```
+
+### Key Design Decisions
+
+**Classification is fixed in the reference, not decided per run.** Leaving it to judgement is what
+produced inconsistent results in the paired assessment: the same repository resolved the same
+question differently across runs. Every construct has one classification, written down.
+
+**Additive output.** Originals stay byte-identical and everything lands under `eks/`, so the diff
+is reviewable and a rejected migration costs nothing to revert.
+
+**Never invent a mapping.** A construct with no equivalent is reported, never approximated. When
+`registry` is not supplied, the transformation emits `TODO(migration)` rather than guessing an
+account id - a fabricated ECR URI fails in a way that looks like an IAM problem.
+
+**Three artifacts per gap.** An ambiguity produces a `TODO(migration)` at the site, a report
+entry, and (where applicable) a scaffold. The code shows where, the report shows why.
+
+**Pod Security Admission before a policy engine.** An SCC using only `anyuid` needs a namespace
+label and nothing else. Mapping every SCC to Kyverno imports a platform component the customer
+does not need.
+
+## Paired Readiness Assessment
+
+This definition transforms **one** repository. Deciding **which** repositories to run it on, in
+what order, and what blocks each is a different question answered by a companion assessment that
+scores a repository against 38 questions and assigns a migration readiness tier.
+
+Use the assessment first on an estate; use this definition on the applications it clears.
+`MIGRATION_REPORT.md` cross-references the assessment's question ids so the two join.
+
+## Getting Started
+
+### Prerequisites
+
+- AWS Transform Custom access and the `atx` CLI
+- `kubectl` and `helm` for local validation (optional; the transformation degrades gracefully)
+
+### Getting Started with AWS Transform Custom
+
+Follow the AWS Transform Custom documentation to install and authenticate the `atx` CLI.
+
+### Cloning the Repo and Publishing the Transformation
+
+```bash
+git clone <this-repo>
+cd community-sourced-transformations/openshift-to-eks
+
+atx custom def publish -n openshift-to-eks --sd .
+```
+
+`publish` accepts `SKILL.md`, `references/` and `scripts/`. A `README.md` at the definition root
+aborts the publish, so publish from a staged copy containing only those.
+
+### Running the Transformation
+
+Because the configuration has several keys, pass it as a file. **Commas separate `key=value`
+pairs in the inline form**, so an inline value containing a comma is rejected:
+
+```bash
+cat > config.json <<'JSON'
+{
+  "additionalPlanContext": "migration_target: eks-standard\ningress_strategy: gateway-api\nregistry: 111122223333.dkr.ecr.us-east-1.amazonaws.com\nnamespace: payments-prod"
+}
+JSON
+
+atx custom def exec -n openshift-to-eks -p . -x -t \
+  --configuration file://config.json --limit 70
+```
+
+| Key | Values | Effect |
+|---|---|---|
+| `migration_target` | `eks-standard`, `eks-auto-mode`, `eks-hybrid` | Under Auto Mode, node customisation becomes REPORT-ONLY rather than a `NodePool` scaffold |
+| `ingress_strategy` | `gateway-api` (default), `alb-ingress` | Which object a `Route` becomes |
+| `registry` | an ECR base URI | Required to rewrite `ImageStreamTag` references. Omit it and every image reference gets a `TODO` |
+| `namespace` | a namespace name | When the target differs from the OpenShift project |
+
+### Expected Output
+
+```text
+eks/                      converted manifests, charts and scaffolds
+MIGRATION_REPORT.md       inventory, automatic changes, scaffolds, manual actions, risk
+<originals>               byte-identical
+```
+
+## Benchmarks
+
+See [`BENCHMARKS.md`](BENCHMARKS.md). Summary: two runs against pinned upstream OpenShift sample
+repositories, source integrity perfect in both, all emitted charts rendering under
+`helm template`, zero `*.openshift.io` surviving in the output.
+
+## Known Limitations
+
+1. **`BuildConfig` with `sourceStrategy` (S2I) cannot be fully automated.** The build logic lives
+   in the builder image's `assemble`/`run` contract, not in the repository. A `Dockerfile`
+   skeleton is emitted with the S2I steps as comments; reproducing the builder behaviour is a
+   human decision. `dockerStrategy` ports almost directly.
+2. **`ClusterResourceQuota` is not converted at all.** No Kubernetes equivalent preserves a shared
+   aggregate ceiling. The report ranks the options by whether they preserve the guarantee.
+3. **SR-IOV, Multus, `PerformanceProfile` and `MachineConfig`** produce a `NodePool` scaffold with
+   the constraints as comments, never as asserted equivalents. Under `eks-auto-mode` they become
+   REPORT-ONLY, since the node cannot be customised.
+4. **Operators are reported, not migrated.** Availability is per operator, in three buckets:
+   community (a Helm chart exists), certified-with-upstream (validate parity), and OpenShift-only
+   (genuinely blocking).
+5. **`spec.host` on a Route** is usually an internal wildcard domain that will not exist on EKS.
+   It becomes a DNS action item rather than an emitted hostname that cannot resolve.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| `Invalid configuration format. Must be file:// URL, JSON string, or key=value pairs` | An inline `--configuration` value contained a comma. Use `file://config.json` |
+| Every image reference has a `TODO(migration)` | `registry` was not supplied in `additionalPlanContext` |
+| Emitted Helm templates do not parse as YAML | Expected. Helm templates contain Go templating; validate with `helm template`, not a YAML parser |
+| Report says a construct is REPORT-ONLY and you expected a conversion | Check its classification in `references/01-construct-mapping.md`. The classification is deliberate |
+
+## Repository Structure
+
+```text
+openshift-to-eks/
+├── README.md                          this file
+├── SKILL.md                           the transformation definition
+├── BENCHMARKS.md                      measured results
+└── references/
+    ├── 01-construct-mapping.md        classification and mapping for every construct
+    └── 02-report-template.md          migration report structure
+```

--- a/community-sourced-transformations/openshift-to-eks/SKILL.md
+++ b/community-sourced-transformations/openshift-to-eks/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: openshift-to-eks
+description: >-
+  Transforms Red Hat OpenShift application manifests, Helm charts, Kustomize overlays
+  and Templates into portable Kubernetes suitable for Amazon EKS. Converts
+  DeploymentConfig, ImageStream references, Routes and OpenShift Templates, resolves
+  SecurityContextConstraints to Pod Security Admission, and produces a migration report
+  covering everything that cannot be automated safely.
+  Trigger: OpenShift migration, OpenShift to EKS, DeploymentConfig, Route, SCC, BuildConfig.
+type: custom
+version: 0.1.0
+---
+
+# OpenShift to Amazon EKS
+
+## Objective
+
+Convert a repository built for Red Hat OpenShift into portable Kubernetes that applies on
+Amazon EKS, and document in `MIGRATION_REPORT.md` everything the transformation cannot do
+safely. The paired assessment `openshift-to-eks-migration-readiness` decides **which** repos to
+run this on and what blocks them; this definition executes the change on **one** repo.
+
+## Scope
+
+Transforms:
+
+- OpenShift manifests (`apps.openshift.io`, `image.openshift.io`, `route.openshift.io`,
+  `template.openshift.io`)
+- Helm charts whose templates emit OpenShift kinds
+- Kustomize overlays referencing OpenShift kinds
+- OpenShift `Template` objects (`objects:` + `parameters:`)
+
+**Non-Goals** - always reported, never transformed:
+
+1. **BuildConfig and S2I.** There is no in-cluster build on EKS by default. Converting a build
+   pipeline requires choosing a target (CodeBuild, GitHub Actions, Kaniko, Buildpacks) and an
+   S2I `assemble`/`run` contract cannot be mechanically turned into a `Dockerfile` without
+   inventing behaviour. Emits a scaffold plus a report item.
+2. **ClusterResourceQuota.** No Kubernetes equivalent exists. Per-namespace quotas are a
+   different guarantee (sum of maximums, not a shared pool) and substituting them silently would
+   remove a control the customer believes they still have.
+3. **SR-IOV, Multus, PerformanceProfile, MachineConfig, Tuned.** Node and hardware coupling.
+   Emits a Karpenter `NodePool` scaffold with the observed constraints as comments; never
+   asserts equivalence.
+4. **Operators and OLM.** Availability has to be checked per operator. Reported by bucket.
+5. **EgressIP and EgressFirewall.** Deterministic egress is a VPC and firewall design decision,
+   not a manifest translation.
+6. **Application code.** Anything reading `VCAP_SERVICES`-style platform env, or the OpenShift
+   OAuth proxy, is flagged, not rewritten.
+7. **Executing the migration.** This produces code. It never applies to a cluster.
+
+## Constraints
+
+### Correctness
+
+- **Never delete a resource.** Transform in place, or leave it and report it.
+- **Preserve every comment, label and annotation** that is not OpenShift-specific. An annotation
+  that only OpenShift consumes (`haproxy.router.openshift.io/*`) moves into the report so its
+  intent is not lost.
+- **If a transformation is ambiguous, do not guess.** Add a `TODO(migration)` comment at the
+  exact site and a report entry. A wrong manifest is worse than an annotated gap, because it
+  applies cleanly and fails later.
+- **Never invent a mapping.** A construct with no equivalent is reported, not approximated.
+  This is the same rule that made `ack-resource-adoption-from-iac` degrade an unmapped
+  CloudFormation type to report-only instead of fabricating a Kind.
+
+### Source integrity
+
+- The original OpenShift manifests are **left in place**, untouched. Converted output is written
+  alongside under `eks/`, so the diff is additive and reviewable.
+- Stay on the current branch. Do not create, switch or checkout a branch.
+
+### Reporting
+
+- Every automatic change and every manual action item traceable to file and line.
+- Risk per change (low / medium / high), never a flat list.
+- The report states what was **not** converted and why, by construct.
+
+## Workflow
+
+```text
+Phase 0: Read additionalPlanContext
+  ├── migration_target: eks-standard | eks-auto-mode | eks-hybrid   (default eks-standard)
+  ├── ingress_strategy: gateway-api | alb-ingress                   (default gateway-api)
+  ├── registry: the ECR registry base URI to rewrite images to      (required for APP mappings)
+  └── namespace: target namespace if it differs from the OpenShift project
+
+Phase 1: Inventory
+  ├── Every manifest, chart, overlay and Template, with its kinds and apiVersions
+  ├── Classify each: MECHANICAL / SCAFFOLD / REPORT-ONLY (see references/01-construct-mapping.md)
+  └── Record the inventory in the report BEFORE transforming, so nothing is silently skipped
+
+Phase 2: Transform the MECHANICAL set
+  ├── DeploymentConfig -> Deployment (lifecycle hooks -> report + TODO)
+  ├── ImageStreamTag reference -> fully qualified registry URI
+  ├── Route -> HTTPRoute + Gateway, or Ingress + ALB annotations
+  ├── Template -> Helm chart (values from parameters) or Kustomize
+  ├── PVC storageClassName -> gp3, or efs when accessModes includes ReadWriteMany
+  └── OpenShift-only node labels -> the target NodePool's labels
+
+Phase 3: Emit SCAFFOLDS for the partly-automatable set
+  ├── SCC -> Pod Security Admission namespace labels, plus a Kyverno policy ONLY for the
+  │     capabilities PSA cannot express (never a blanket policy engine dependency)
+  ├── BuildConfig -> a buildspec or Dockerfile skeleton, clearly marked incomplete
+  └── PerformanceProfile / MachineConfig -> Karpenter NodePool with observed constraints
+        as comments
+
+Phase 4: Validate what can be validated locally
+  ├── every emitted YAML parses
+  ├── kubectl apply --dry-run=client (server-side if a cluster is reachable)
+  ├── helm template / kustomize build when charts or overlays were emitted
+  └── no OpenShift apiVersion survives in eks/ (grep assertion)
+
+Phase 5: MIGRATION_REPORT.md
+  ├── Inventory with the classification of every construct found
+  ├── Automatic changes, per file
+  ├── Manual action items, per construct, with the reason it could not be automated
+  ├── Risk per change
+  └── Residual blockers, cross-referenced to the readiness Lens question ids
+```
+
+## Exit Criteria
+
+1. Every construct in the Phase 1 inventory appears in the report with its classification.
+   Nothing silently skipped.
+2. Original OpenShift manifests byte-identical; all output under `eks/`.
+3. Zero `*.openshift.io` apiVersions in the emitted output.
+4. Every emitted YAML parses; `--dry-run=client` clean.
+5. Every REPORT-ONLY construct has a report entry naming the construct, the reason, and the
+   recommended path.
+6. Every ambiguity carries a `TODO(migration)` at the site **and** a report entry. One without
+   the other is a defect.
+7. `MIGRATION_REPORT.md` cross-references the Lens question ids, so an estate that ran the
+   assessment can join the two.

--- a/community-sourced-transformations/openshift-to-eks/references/01-construct-mapping.md
+++ b/community-sourced-transformations/openshift-to-eks/references/01-construct-mapping.md
@@ -1,0 +1,175 @@
+# Construct Mapping: OpenShift to Amazon EKS
+
+> Loaded in Phase 1. Every construct found in the repository resolves to exactly one of three
+> classifications. **The classification is fixed here, not decided per run** - leaving it to
+> judgement is what produced inconsistent results in the paired Lens.
+
+| Classification | Meaning | What the transformation does |
+|---|---|---|
+| **MECHANICAL** | A faithful equivalent exists and the conversion is deterministic | Convert it |
+| **SCAFFOLD** | Partly automatable; the remainder is a design decision | Emit an incomplete artifact, clearly marked, plus a report item |
+| **REPORT-ONLY** | No equivalent, or the substitute changes the guarantee | Do not touch. Report with the recommended path |
+
+---
+
+## MECHANICAL
+
+### `DeploymentConfig` → `apps/v1 Deployment`
+
+| DC field | Deployment equivalent |
+|---|---|
+| `spec.replicas`, `spec.selector`, `spec.template` | identical |
+| `strategy.type: Rolling` | `strategy.type: RollingUpdate` |
+| `strategy.type: Recreate` | `strategy.type: Recreate` |
+| `strategy.rollingParams.{maxSurge,maxUnavailable}` | `strategy.rollingUpdate.{maxSurge,maxUnavailable}` |
+| `spec.selector` (map) | `spec.selector.matchLabels` (the DC form is a bare map; wrap it) |
+| `triggers[].ImageChange` | **no equivalent** → report (see below) |
+| `strategy.rollingParams.{pre,mid,post}` | **no equivalent** → report + `TODO(migration)` |
+
+Two traps: the DC `selector` is a bare map and `Deployment.spec.selector` needs
+`matchLabels`, and `Deployment.spec.selector` is **immutable** after creation, so it must match
+the template labels exactly on the first apply.
+
+**Lifecycle hooks** (`pre`/`mid`/`post`) are the reason this is not a pure rename. A `pre` hook
+running a database migration becomes an init container or a Job with ordering; a `post` hook
+becomes a separate step. Emitting a `Deployment` and dropping the hook silently changes startup
+behaviour, so the hook body is copied into the report verbatim with a `TODO(migration)` at the
+site.
+
+### `ImageStreamTag` reference → fully qualified registry URI
+
+```yaml
+# before: resolves via ImageStream, no registry host, unresolvable off-cluster
+image: payments-api:latest
+
+# after
+image: <registry>/payments-api:latest
+```
+
+`<registry>` comes from `additionalPlanContext.registry`. **If it is absent, do not guess an
+account id or region** - emit `TODO(migration): set registry` and a report item. A fabricated
+ECR URI fails at pull time in a way that looks like a permissions problem.
+
+Also rewrite: `image-registry.openshift-image-registry.svc:5000/<ns>/<name>` and any
+`docker-registry.default.svc` form. Leave `registry.redhat.io` and
+`registry.access.redhat.com` references **in place** but report them - they need a pull secret
+tied to a Red Hat subscription, which is a licensing decision, not a rewrite.
+
+### `Route` → Gateway API `HTTPRoute`, or `Ingress` + ALB
+
+Driven by `additionalPlanContext.ingress_strategy` (default `gateway-api`).
+
+| Route field | `HTTPRoute` | `Ingress` + ALB |
+|---|---|---|
+| `spec.host` | `spec.hostnames[]` | `spec.rules[].host` |
+| `spec.to.name` + `spec.port` | `backendRefs[].{name,port}` | `backend.service.{name,port}` |
+| `spec.path` | `rules[].matches[].path` | `rules[].http.paths[].path` |
+| `tls.termination: edge` | Gateway listener TLS terminate | `alb.ingress.kubernetes.io/certificate-arn` |
+| `tls.termination: reencrypt` | listener terminate **plus** `BackendTLSPolicy` | `alb.ingress.kubernetes.io/backend-protocol: HTTPS` |
+| `tls.termination: passthrough` | listener `mode: Passthrough` | **not expressible on ALB** → NLB, report |
+| `insecureEdgeTerminationPolicy: Redirect` | a second listener with a redirect filter | `alb.ingress.kubernetes.io/ssl-redirect` |
+| `haproxy.router.openshift.io/timeout` | `spec.rules[].timeouts` | `alb.ingress.kubernetes.io/...` attributes |
+| `haproxy.router.openshift.io/balance` | **no equivalent** → report | target-group attribute, report |
+
+**`reencrypt` is the trap.** Converting it to plain `edge` silently drops encryption between the
+load balancer and the pod. Nothing fails; the endpoint still answers HTTPS. When the target
+cannot preserve re-encryption, **do not downgrade silently** - emit the edge form with a
+`TODO(migration)` and a HIGH-risk report entry naming the lost property.
+
+`spec.host` on OpenShift is usually an internal wildcard domain
+(`*.apps.ocp-prod.example.internal`) that will not exist on EKS. Carry it into the report as a
+DNS action item rather than emitting a hostname that cannot resolve.
+
+### `Template` → Helm chart or Kustomize
+
+`parameters[]` become `values.yaml` entries with the same defaults. `objects[]` become
+`templates/`. Two OpenShift-specific behaviours have no Helm equivalent and go to the report:
+`generate: expression` (server-side random generation - becomes a Secret the pipeline creates,
+never a value committed to `values.yaml`) and `required: true` (Helm has no required-parameter
+gate; use a `fail` guard in the template).
+
+### PVC `storageClassName`
+
+| OpenShift class | EKS |
+|---|---|
+| `gp2`, `gp2-csi`, `gp3-csi`, `thin`, `thin-csi` | `gp3` (EBS CSI) |
+| `ocs-storagecluster-cephfs`, `managed-nfs-storage`, anything with `accessModes: [ReadWriteMany]` | `efs` (EFS CSI) |
+| `ocs-storagecluster-ceph-rbd` | `gp3` |
+
+**RWX decides, not the class name.** An RWX PVC mapped to `gp3` leaves the second pod
+unschedulable, so check `accessModes` before the name. A `StatefulSet` with
+`volumeClaimTemplates` also gets a report entry: EBS volumes are **zonal**, so the pod cannot
+move across AZs and reattach - that constraint did not exist on the source platform.
+
+### OpenShift-only node labels
+
+`node-role.kubernetes.io/infra`, `node-role.kubernetes.io/worker-*` and
+`machine.openshift.io/*` selectors have no EKS counterpart. Rewrite them to labels on the
+emitted Karpenter `NodePool` (Phase 3) and keep the selector pointing at the new label. Leaving
+the original label produces pods stuck `Pending`, which is loud - but leaving it and NOT
+reporting is the failure, because the reader assumes it converted.
+
+---
+
+## SCAFFOLD
+
+### `SecurityContextConstraints` → Pod Security Admission, plus Kyverno only for the residue
+
+Split the SCC's capabilities. **PSA first**; a policy engine only for what PSA cannot express.
+
+| SCC capability | PSA covers it? |
+|---|---|
+| `runAsUser: RunAsAny` (the `anyuid` case) | **yes** - namespace label `pod-security.kubernetes.io/enforce: baseline` |
+| `allowPrivilegedContainer: false`, dropped capabilities, no host namespaces | **yes** - `restricted` |
+| `allowPrivilegedContainer: true`, `hostNetwork`, `hostPID` | **yes** - `privileged`, but this is a decision to re-authorise, not to carry over |
+| `seLinuxContext: MustRunAs` with a specific level | **no** - needs an admission policy |
+| per-field allow-lists, conditional rules, mutation | **no** - needs Kyverno or Gatekeeper |
+
+Emit the namespace labels always. Emit a Kyverno policy **only if** the residue is non-empty,
+and say so in the report. A repository using only `anyuid` needs PSA and nothing else; adding a
+policy engine there imports a platform component the customer does not need and did not ask for.
+
+### `BuildConfig` → build scaffold
+
+`dockerStrategy` ports almost directly: the `Dockerfile` already exists, so emit a CodeBuild
+`buildspec.yml` or a workflow that builds and pushes to ECR.
+
+`sourceStrategy` (S2I) does **not**. The build logic lives in the builder image's
+`assemble`/`run` contract, not in the repository. Emit a multi-stage `Dockerfile` skeleton that
+copies the `.s2i/assemble` steps in as **comments**, marked `TODO(migration)`, and a report entry
+stating that the builder image behaviour has to be reproduced explicitly. Do not attempt to
+translate `assemble` into `RUN` lines - it depends on the builder image's environment.
+
+### `PerformanceProfile`, `MachineConfig`, `Tuned` → Karpenter `NodePool` scaffold
+
+Emit a `NodePool` plus `EC2NodeClass` carrying the observed constraints **as comments**, never as
+asserted equivalents: isolated/reserved CPU sets, hugepages counts, NUMA policy, sysctl values
+from `MachineConfig` ignition files. Mark HIGH risk. Under `eks-auto-mode` the node cannot be
+customised at all, so this becomes REPORT-ONLY - state that in the report rather than emitting a
+NodePool that will not be honoured.
+
+---
+
+## REPORT-ONLY
+
+| Construct | Why not transformed | What to report |
+|---|---|---|
+| `ClusterResourceQuota` | No Kubernetes equivalent. Per-namespace quotas give a **sum of maximums**, not a shared pool - substituting them silently removes a ceiling the customer believes still exists | The options ranked by whether they preserve the aggregate: vCluster (yes), a policy engine computing the aggregate at admission (yes, with a race window), per-namespace quotas (**no**, state the gap). Not AAQ - its API is namespaced only |
+| `SriovNetwork`, `SriovNetworkNodePolicy`, `NetworkAttachmentDefinition` | Hardware coupling. Multus needs self-managed nodes; SR-IOV needs specific instance types | Whether the target supports it at all, and that under Auto Mode it does not |
+| `Subscription`, `CatalogSource`, `OperatorGroup` | Availability is per operator | One entry **per bucket**: community (Helm chart exists), certified-with-upstream (validate parity), openshift-only (blocking) |
+| `EgressIP`, `EgressFirewall`, `EgressRouter` | A VPC and firewall design decision | That downstream partners may allow-list the current egress address, so the new NAT address has to be coordinated before cutover |
+| `OAuth`, `OAuthClient`, `oauth-proxy` sidecar | EKS has no integrated OAuth server | That application-level auth needs Cognito, an external IdP, or an explicitly deployed proxy |
+| `Config` (`imageregistry.operator.openshift.io`) | ECR replaces the component | That a component the customer was operating disappears - a saving, not a risk |
+| `Project`, `ProjectRequest` | A Namespace with defaults attached | That the self-service creation path needs replacing; the defaults themselves are covered by the quota, RBAC and NetworkPolicy items |
+
+---
+
+## The portable set: do not touch
+
+These are already correct for EKS and **must come out byte-identical**: `Deployment`, `Service`,
+`ConfigMap`, `Secret`, `ServiceAccount`, `Role`, `RoleBinding`, `NetworkPolicy`,
+`HorizontalPodAutoscaler`, `PodDisruptionBudget`, probes, `resources`, `topologySpreadConstraints`.
+
+A diff touching any of them is a defect. The paired Lens has a control resource for exactly this
+reason: a transformation that rewrites already-portable Kubernetes is doing damage while
+appearing productive.

--- a/community-sourced-transformations/openshift-to-eks/references/02-report-template.md
+++ b/community-sourced-transformations/openshift-to-eks/references/02-report-template.md
@@ -1,0 +1,118 @@
+# Migration Report Template
+
+> Loaded in Phase 5. The report is the deliverable for everything the transformation could not
+> do, and it is what a reviewer reads before accepting the diff.
+
+The report **renders** the Phase 1 inventory and the Phase 2-3 outcomes. It never re-derives a
+classification: if a construct was REPORT-ONLY in the inventory, it is REPORT-ONLY here.
+
+---
+
+## Structure
+
+```markdown
+# OpenShift to Amazon EKS - Migration Report
+
+**Repository:** <name>
+**Transformed:** <ISO-8601 UTC>
+**Migration target:** <eks-standard | eks-auto-mode | eks-hybrid>
+**Ingress strategy:** <gateway-api | alb-ingress>
+**Registry:** <the ECR base URI, or NOT SET with the consequence stated>
+
+## Inventory
+
+Every construct found, with its classification. This table is the contract: a construct absent
+from it was not considered, which is a defect.
+
+| Construct | Count | Files | Classification | Outcome |
+|---|---|---|---|---|
+| DeploymentConfig | 2 | ... | MECHANICAL | converted |
+| BuildConfig (sourceStrategy) | 1 | ... | SCAFFOLD | Dockerfile skeleton emitted |
+| ClusterResourceQuota | 1 | ... | REPORT-ONLY | see Manual Actions |
+
+## Summary
+
+| | |
+|---|---|
+| Converted automatically | <n> constructs across <m> files |
+| Scaffolds emitted | <n> (incomplete by design) |
+| Report-only | <n> |
+| Manual action items | <n> |
+| Files added under `eks/` | <n> |
+| Original files modified | **0** |
+
+## Automatic Changes
+
+<per file, what changed and why. Cite line ranges. Group by construct, not by file, so a
+reviewer checking "did every Route convert" reads one section.>
+
+### <construct> - <n> occurrences
+
+| File | Before | After | Risk |
+|---|---|---|---|
+
+## Scaffolds Emitted (incomplete by design)
+
+<one subsection per scaffold. Each MUST state what is missing and what decision the reader has
+to make. A scaffold presented as finished is worse than no scaffold.>
+
+### <path> - <what it covers>
+
+**Complete:** <what is genuinely done>
+**Missing:** <the decision the reader must make>
+**Risk:** <low|medium|high>
+
+## Manual Action Items
+
+<one entry per REPORT-ONLY construct. Ordered by risk.>
+
+### <construct> - <risk>
+
+**Found in:** `<file>:<lines>`
+**Why it was not transformed:** <the specific reason, not "not supported">
+**What breaks if ignored:** <concrete failure mode, and whether it is loud or silent>
+**Recommended path:** <the options, with the trade-off named>
+**Lens question:** <the question id from openshift-to-eks-migration-readiness, so an estate
+that ran the assessment can join the two>
+
+## Risk Assessment
+
+| Change | Risk | Why |
+|---|---|---|
+
+Risk is per change, never a single figure for the repository. `reencrypt` losing in-cluster TLS
+is HIGH even in a repository where everything else converted cleanly.
+
+## Validation Performed
+
+| Check | Result |
+|---|---|
+| Original manifests byte-identical | PASS / FAIL |
+| Emitted YAML parses | PASS / FAIL |
+| `kubectl apply --dry-run=client` | PASS / FAIL / not available |
+| `helm template` / `kustomize build` | PASS / FAIL / not applicable |
+| Zero `*.openshift.io` in `eks/` | PASS / FAIL |
+
+## Residual Blockers
+
+<what still prevents this application running on EKS after the diff is merged. If the list is
+empty, say so explicitly - "no residual blockers" is information.>
+```
+
+---
+
+## Rules
+
+1. **Never write "not supported".** State the specific reason. "ClusterResourceQuota has no
+   Kubernetes equivalent; per-namespace quotas give a sum of maximums rather than a shared pool"
+   is actionable. "Not supported" is not.
+2. **Distinguish loud from silent failure** in every manual action item. A PVC referencing a
+   missing StorageClass stays `Pending` (loud). A `reencrypt` Route downgraded to `edge` keeps
+   answering HTTPS (silent). The reader triages differently.
+3. **A scaffold always states what is missing.** The scaffold section exists to prevent a
+   half-finished artifact being read as finished.
+4. **Cross-reference the Lens question ids.** A customer who ran the assessment across 1.000
+   apps needs to join this report to that one.
+5. **No emoji.** Customer-facing.
+6. **The inventory is complete or the report is wrong.** A construct found in Phase 1 and absent
+   from the report table is a silent skip - the failure mode this template exists to prevent.


### PR DESCRIPTION
Transforms a Red Hat OpenShift application repository into portable Kubernetes for Amazon EKS: converts DeploymentConfig, ImageStream references, Route and OpenShift Template; scaffolds SecurityContextConstraints to Pod Security Admission; and reports every construct that has no safe equivalent. Additive by design - originals untouched, output under eks/.

Follows the same README.md / SKILL.md / BENCHMARKS.md / references/ structure as eks-version-upgrade-readiness.

Validation (see BENCHMARKS.md): executed end-to-end via `atx custom def exec` against 2 real pinned OpenShift repos (sclorg/nodejs-ex and sclorg/cakephp-ex) - 2/2 pass, source integrity 0 files changed, all 7 emitted Helm charts render under helm template, zero *.openshift.io apiVersion surviving in output, 30 TODO(migration) markers all covered by the report.