### PR TITLE
Add azure-devops-pipelines-migration custom transformation

### DIFF
--- a/community-sourced-transformations/azure-devops-pipelines-migration/BENCHMARKS.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/BENCHMARKS.md
@@ -1,0 +1,90 @@
+# Benchmark Results - Azure DevOps Pipelines Migration
+
+## Executive Summary
+
+| Metric | Result |
+|--------|--------|
+| Repository tested | `OfqualGovUK/ofqual-register-api` (real production repo, pinned) |
+| Targets exercised | **both** - `github-actions` and `codepipeline`, same repo, same baseline |
+| Transformation success rate | **2/2 COMPLETE** |
+| **Source integrity** | **0 files modified outside `cicd-migration/` and the report, in both runs** |
+| Azure macro syntax (`$(Build...)`) surviving in output | **0** in both runs |
+| `task:` keys surviving in output | **0** in both runs |
+| Unpinned `uses:` (GitHub target) | **0** |
+| CloudFormation template lint (codepipeline target) | PASS - 4 stages (Source, StaticAnalysis, RunTests, BuildAndPackage), 4 CodeBuild projects, every stage has actions |
+| Buildspecs with `phases` | 4/4 |
+| Invented values (secrets, ARNs, account ids) | 0 - every external value is `TODO(migration)` |
+| Report at root with `## Manual Action Items` | 2/2 (name pinned by the contract) |
+| Em dash (U+2014) in emitted output | 0 (forbidden by the contract) |
+| Agent minutes | 88.59 (44.61 + 43.98) |
+| Estimated cost | ~US$ 3.10 (at US$ 0.035 / agent minute) |
+
+### Methodology
+
+The fixture is a **real production repository**, not a hand-written one, pinned:
+
+| Repo | Licence | Commit |
+|---|---|---|
+| `OfqualGovUK/ofqual-register-api` | not declared in-repo (used for validation only) | `ea4df609e4ab3c812028798fdfdf6aeec4495269` |
+
+It was chosen because its single `azure-pipelines.yml` exercises the constructs that break
+naive conversions: a **variable group** (`Register-API-Dev-Variables` - values live in the
+Azure DevOps Library), a **cron schedule** targeting a branch (a semantic GitHub Actions does
+not have), **mixed pools** (ubuntu and windows), a **marketplace task with no cataloged
+equivalent** (`SnykSecurityScan@1`), **multi-stage with `dependsOn`** and **stage/job
+conditions** over `Build.Reason`.
+
+Each run: commit baseline, then
+
+```bash
+atx custom def exec -n azure-devops-pipelines-migration -p . -x -t \
+  --configuration file://cfg.json --limit 70
+```
+
+with `additionalPlanContext` carrying `target: github-actions` and `target: codepipeline`
+respectively. Assertions are invariants (`assert_def_run.py` with
+`OUT_DIR=cicd-migration`, plus the Phase 4 greps and the CloudFormation structural lint).
+
+## At-a-Glance Results
+
+| # | Target | Status | Files emitted | Source changed | Macros | Tasks | Agent Min | Cost |
+|---|---|---|---|---|---|---|---|---|
+| 1 | `github-actions` | COMPLETE | 1 workflow (`ci.yml`) | **0** | 0 | 0 | 44.61 | $1.56 |
+| 2 | `codepipeline` | COMPLETE | 1 CFN template + 4 buildspecs | **0** | 0 | 0 | 43.98 | $1.54 |
+| | **TOTALS** | **2/2** | **6** | **0** | **0** | **0** | **88.59** | **$3.10** |
+
+## What the conversion got right (spot-checked)
+
+1. **Variable group degraded correctly.** The GitHub workflow references the group as a
+   `TODO(migration)` block that NAMES the two variables the pipeline actually consumes
+   (`SNYK_ENDPOINT`, `SNYK_TOKEN`, discovered from the steps) and states that the rest of the
+   group is unknowable from the repository. No invented value.
+2. **Schedule semantics flagged, not silently changed.** Azure cron targeted the `master`
+   branch; the emitted `on.schedule` carries a comment stating GitHub always runs schedules
+   on the default branch.
+3. **Conditions converted:** `ne(variables['Build.Reason'], 'Schedule')` became
+   `if: github.event_name != 'schedule'` at the right jobs.
+4. **Marketplace task degraded:** `SnykSecurityScan@1` is report-only with its raw inputs
+   quoted and the closest candidate action named - not guessed.
+5. **CodePipeline sequential-stage constraint respected:** Azure stage order preserved as
+   Source → StaticAnalysis → RunTests → BuildAndPackage, one CodeBuild project per job,
+   artifacts wired between stages.
+
+## Exit Criteria Compliance (per SKILL.md)
+
+| # | Exit criterion | github-actions | codepipeline |
+|---|---|---|---|
+| 1 | Every pipeline YAML in the inventory with per-construct classification | PASS | PASS |
+| 2 | Originals byte-identical; output under `cicd-migration/`; report at root; nothing else at root | PASS | PASS |
+| 3 | Zero `$(...)` macros and zero `task:` keys in output | PASS | PASS |
+| 4 | Every variable group / service connection / environment has a report entry + TODO where referenced | PASS (6 TODOs paired) | PASS |
+| 5 | YAML parses; `runs-on` + pinned `uses:` / CFN lints + buildspecs have `phases` | PASS | PASS |
+| 6 | TODO(migration) paired with Manual Action Items, and vice versa | PASS | PASS |
+| 7 | Report states the resolved target and why | PASS (explicit) | PASS (explicit) |
+
+## Tooling note found while validating
+
+Plain `yaml.safe_load` REJECTS a correct CloudFormation template: the short-form intrinsics
+(`!Ref`, `!Sub`, `!GetAtt`) are valid YAML with custom tags the default loader does not know.
+The validation lint registers a no-op multi-constructor for `!` before parsing - the same
+family of false positive as Helm templates under a plain YAML parser.

--- a/community-sourced-transformations/azure-devops-pipelines-migration/README.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/README.md
@@ -1,0 +1,126 @@
+# Azure DevOps Pipelines Migration (to GitHub Actions or AWS CodePipeline)
+
+Transforms Azure DevOps Pipelines (`azure-pipelines.yml` and template files) into the target CI/CD chosen at run time - **GitHub Actions workflows**, or **AWS CodePipeline with CodeBuild buildspecs**. Converts triggers, stages, jobs, steps, matrices, conditions and the common task catalog; scaffolds what depends on values that live in Azure DevOps (variable groups, service connections, environments); and reports every construct with no counterpart.
+
+**Additive by design: the original files are never modified. Output lands under `cicd-migration/`.**
+
+## Table of Contents
+
+- [Overview](#overview)
+- [The Problem](#the-problem)
+- [One Definition, Two Targets](#one-definition-two-targets)
+- [What This Skill Does](#what-this-skill-does)
+- [Getting Started](#getting-started)
+- [Benchmarks](#benchmarks)
+- [Known Limitations](#known-limitations)
+- [Troubleshooting](#troubleshooting)
+- [Repository Structure](#repository-structure)
+
+## Overview
+
+An Azure DevOps pipeline is only partly in the repository. The YAML carries the structure -
+triggers, stages, jobs, steps, conditions - but the pipeline also consumes **variable groups**
+(values in the Azure DevOps Library), **service connections** (credentials), **environments**
+(approval gates) and **agent pools**, none of which exist in the repo. A conversion that
+ignores that split produces workflows that are syntactically perfect and fail on first run in
+ways that look like conversion bugs.
+
+This transformation converts what maps mechanically, scaffolds every external dependency with
+an explicit `TODO(migration)`, and reports what has no counterpart - each construct classified
+in advance, not decided per run.
+
+## The Problem
+
+Three failure modes make a hand migration expensive:
+
+1. **`$(Build.SourcesDirectory)` and friends are macro syntax the target never expands.** A
+   missed predefined variable survives as a literal string and breaks paths at runtime, not
+   at parse time.
+2. **A variable group reference looks like a normal variable.** `variables: - group: X` pulls
+   values from the Azure DevOps Library; converting it as an empty env var makes the job run
+   with blanks - nothing fails until the deploy step.
+3. **Stage `condition:` semantics narrow in translation.** `ne(variables['Build.Reason'],
+   'Schedule')` has an equivalent (`github.event_name != 'schedule'`), but expressions over
+   stage dependencies and output variables do not map one-to-one - converting them silently
+   changes when jobs run.
+
+## One Definition, Two Targets
+
+The target is resolved from `additionalPlanContext` at run time:
+
+| `target:` | Output |
+|---|---|
+| `github-actions` (default) | One workflow per pipeline under `cicd-migration/github-actions/` |
+| `codepipeline` | A CloudFormation template (pipeline + one CodeBuild project per job) and one buildspec per job under `cicd-migration/codepipeline/` |
+
+Discovery, inventory and classification are shared; only the emission phase differs.
+
+## What This Skill Does
+
+| Phase | Action |
+|---|---|
+| 0 | Reads `additionalPlanContext`: `target`, optional `default_branch` and `aws_region` |
+| 1 | Finds every pipeline YAML and referenced template; inventories every construct AND every external dependency (variable groups, service connections, environments, pools); classifies **MECHANICAL / SCAFFOLD / REPORT-ONLY** |
+| 2 | Converts the mechanical set: triggers, schedules, stages→jobs (`needs`), steps, the common task catalog, predefined variables, conditions, matrices |
+| 3 | Emits scaffolds: variable-group references as secrets with `TODO(migration)`, OIDC credential skeletons for service connections, environment gates, reusable-workflow skeletons for templates |
+| 4 | Validates: YAML parses, zero `$(...)` macro syntax and zero `task:` keys survive, every `uses:` pinned, buildspecs have `phases`, the CloudFormation template lints |
+| 5 | Writes `MIGRATION_REPORT.md` at the repository root: inventory, external-dependency table, `## Manual Action Items`, TODO cross-reference |
+
+Every emitted file carries a provenance header (`migrated-from: azure-pipelines.yml#<stage>/<job>`).
+
+## Getting Started
+
+```bash
+atx custom def exec -n azure-devops-pipelines-migration -p . -x -t \
+  --configuration file://config.json --limit 70
+```
+
+```json
+{"additionalPlanContext": "target: github-actions"}
+```
+
+Use `--configuration file://` - a comma inside an inline `key=value` breaks the CLI parser.
+Assert the artifact count after every run: a low `--limit` truncates the bundle silently.
+
+## Benchmarks
+
+Full evidence in [`BENCHMARKS.md`](BENCHMARKS.md): executed end-to-end via
+`atx custom def exec` against a real production repository with a multi-stage pipeline
+(variable group, cron schedule, mixed ubuntu/windows pools, marketplace task, stage
+conditions), on **both targets**, with source integrity, macro-syntax and pinning assertions
+per run.
+
+## Known Limitations
+
+- **Classic (GUI) pipelines are not in the repository** - the report gives export guidance.
+- **Variable group VALUES cannot be read** - only the names are known; every value is a
+  `TODO(migration)`.
+- **Marketplace tasks without a cataloged equivalent** degrade to report-only with the raw
+  inputs quoted (e.g. third-party security scanners).
+- **Deployment strategies** (`runOnce`/`rolling`/`canary`) have no native equivalent in
+  either target - converted as plain jobs with a report entry.
+- **CodePipeline stages are strictly sequential** - parallel Azure stages become parallel
+  actions inside one stage, noted in the report.
+- **macOS pools** are report-only on the CodePipeline target.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Invalid configuration format` before the run starts | A comma inside an inline `--configuration key=value` | Use `--configuration file://config.json` |
+| Run completes but fewer artifacts than expected | Low `--limit` truncates the bundle silently | Re-run with `--limit 70`; always assert the artifact count |
+| Converted workflow fails with a literal `$(Build...)` string | A predefined variable outside the catalog survived | Check the report's macro table; file the gap - the validation grep in Phase 4 should have caught it |
+| Job runs with empty variable values | Variable group values live in Azure DevOps and were emitted as `TODO(migration)` secrets | Create the secrets/Secrets Manager entries listed in Manual Action Items before running |
+| Workflow not triggering in GitHub | Files were emitted under `cicd-migration/github-actions/`, not `.github/workflows/` (additive contract) | Move them as instructed in the report after review |
+| CloudFormation deploy fails on the CodeBuild role | `ServiceRole` is a `TODO(migration)` placeholder by design | Create the role with the policy sketched in the report |
+
+## Repository Structure
+
+```text
+azure-devops-pipelines-migration/
+├── SKILL.md                              # orchestration spine (discovery → convert → scaffold → validate → report)
+├── BENCHMARKS.md                         # validation evidence, both targets
+└── references/
+    ├── 01-tasks-and-variables.md         # task catalog, predefined variables, pools, conditions, GHA emission
+    └── 02-codepipeline-target.md         # CodePipeline/CodeBuild emission rules + template lint
+```

--- a/community-sourced-transformations/azure-devops-pipelines-migration/README.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/README.md
@@ -118,6 +118,7 @@ per run.
 
 ```text
 azure-devops-pipelines-migration/
+├── README.md                             # this file
 ├── SKILL.md                              # orchestration spine (discovery → convert → scaffold → validate → report)
 ├── BENCHMARKS.md                         # validation evidence, both targets
 └── references/

--- a/community-sourced-transformations/azure-devops-pipelines-migration/SKILL.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: azure-devops-pipelines-migration
+description: >-
+  Transforms Azure DevOps Pipelines (azure-pipelines.yml and template files) into the
+  target CI/CD chosen at run time - GitHub Actions workflows, or AWS CodePipeline with
+  CodeBuild buildspecs. Converts triggers, stages, jobs, steps, matrices, conditions and
+  the common task catalog; scaffolds what depends on values that live in Azure DevOps
+  (variable groups, service connections, environments); and reports every construct with
+  no counterpart (classic GUI pipelines, task groups, gates, Boards integration).
+  Trigger: Azure DevOps migration, azure-pipelines.yml, ADO to GitHub Actions,
+  Azure Pipelines to CodePipeline, VSTS, TFS pipelines, CI/CD migration.
+type: custom
+version: 0.1.0
+---
+
+# Azure DevOps Pipelines Migration (to GitHub Actions or AWS CodePipeline)
+
+## Objective
+
+Convert the CI/CD definition an Azure DevOps repository **does** carry - the YAML pipeline
+files - into the target platform, and report precisely what the pipeline consumes that lives
+**outside the repository** (variable groups, service connections, environment approvals,
+agent pools), because those are exactly the pieces that make a converted pipeline fail on
+first run in ways that look like conversion bugs.
+
+## One definition, two targets
+
+The target is resolved in Phase 0 from `additionalPlanContext`:
+
+| `target:` value | Output |
+|---|---|
+| `github-actions` (default) | One workflow file per pipeline under `cicd-migration/github-actions/` |
+| `codepipeline` | A CloudFormation template for the pipeline plus one CodeBuild buildspec per job under `cicd-migration/codepipeline/` |
+
+The discovery, inventory and classification phases are identical; only the emission phase
+differs. Mapping tables: `references/01-tasks-and-variables.md` (shared catalog + GitHub
+Actions target), `references/02-codepipeline-target.md` (CodePipeline emission rules).
+
+## Scope
+
+### MECHANICAL - converted
+
+| Azure Pipelines construct | GitHub Actions | CodePipeline / CodeBuild |
+|---|---|---|
+| `trigger` (branches/paths) | `on.push.branches` / `paths` | pipeline source trigger + EventBridge note |
+| `pr` | `on.pull_request` | report note (PR builds are a CodeBuild webhook filter) |
+| `schedules` (cron) | `on.schedule` | EventBridge Scheduler rule in the template |
+| `stages` / `dependsOn` | `jobs` + `needs` | pipeline `Stages` in declared order |
+| `jobs` / `steps` | `jobs.<id>.steps` | one CodeBuild project + buildspec per job |
+| `script` / `Bash@3` / `pwsh` | `run` with the right `shell` | buildspec `commands` |
+| `pool.vmImage` | `runs-on` (ubuntu/windows/macos map) | CodeBuild image + `Type` (macOS unsupported: report) |
+| Common task catalog (UseDotNet@2, DotNetCoreCLI@2, NodeTool@0, UsePythonVersion@0, Docker@2, ArchiveFiles@2, CopyFiles@2, PublishBuildArtifacts@1, DownloadBuildArtifacts@0, PublishTestResults@2) | setup-* actions / upload-download-artifact / run equivalents | buildspec phases + artifacts section |
+| Inline `variables` | `env` | buildspec `env.variables` |
+| Predefined variables (`$(Build.SourcesDirectory)`, `$(Build.BuildId)`, `$(Build.SourceBranchName)`, ...) | `${{ github.workspace }}`, `${{ github.run_id }}`, `${{ github.ref_name }}`, ... (full table in reference 01) | `CODEBUILD_SRC_DIR`, `CODEBUILD_BUILD_ID`, ... |
+| `condition:` (succeeded/failed/always, `eq`/`ne` on variables) | `if:` expression | buildspec guard or stage condition, with a report note when semantics narrow |
+| `strategy.matrix` | `strategy.matrix` | one project per matrix leg + report note |
+| `timeoutInMinutes` / `continueOnError` | `timeout-minutes` / `continue-on-error` | project `TimeoutInMinutes` / report note |
+
+### SCAFFOLD - emitted incomplete, clearly marked
+
+1. **Variable groups (`variables: - group:`).** The VALUES live in the Azure DevOps Library
+   and cannot be read from the repository. Emit the reference as `secrets.<NAME>` /
+   Secrets Manager reference with `TODO(migration)` per variable group, and a report entry
+   listing every consuming job. Never invent a value.
+2. **Service connections** (AzureRM, AWS, container registries). Emit the OIDC skeleton
+   (`aws-actions/configure-aws-credentials` with `role-to-assume: TODO(migration)`, or the
+   CodeBuild service role placeholder) plus a report entry naming the connection.
+3. **Environments + approvals.** GitHub `environment:` emitted on the job; the protection
+   rules are repository SETTINGS, not YAML - report entry with the exact settings to create.
+   CodePipeline: a manual approval action inserted where the environment gate was.
+4. **Deployment jobs** (`deployment:` with runOnce/rolling/canary). Converted as a plain job
+   plus a report entry: neither target has native in-YAML deployment strategies.
+5. **Pipeline templates** (`extends`, `template:` includes with parameters). GitHub target:
+   reusable workflow (`workflow_call`) skeleton with the parameter names carried over.
+
+### REPORT-ONLY - never transformed
+
+| Construct | Why |
+|---|---|
+| Classic (GUI) pipelines | Not in the repository; the report gives the export guidance |
+| Marketplace tasks with no cataloged equivalent (e.g. `SnykSecurityScan@1`) | Vendor actions exist but version/config parity is a decision - named per occurrence with the closest candidate |
+| Task groups, gates, manual intervention tasks | Live in Azure DevOps, not in YAML |
+| `self-hosted` agent pools | Runner/fleet provisioning is infrastructure, not conversion |
+| Azure Artifacts feeds | Feed migration (CodeArtifact / GitHub Packages) is its own project |
+| Boards/work-item integration, service hooks | Platform features outside the pipeline |
+| Any `task:` not in the catalog | Degrade to report-only with the raw inputs quoted - never guess an action name |
+
+## Constraints
+
+- **Additive, and that includes files at the repository root.** Originals untouched; ALL
+  output under `cicd-migration/`. **`MIGRATION_REPORT.md` goes at the repository ROOT** -
+  the only file allowed there. GitHub Actions workflows only run from `.github/workflows/`,
+  and that is exactly why they are NOT emitted there: writing into `.github/` mutates the
+  source tree and can collide with existing workflows. The report instructs the operator to
+  move them - a safe artifact plus an instruction beats a mutation.
+- **Never invent a secret value, a role ARN, an account id, a registry URL or a
+  subscription id.** `TODO(migration)` + report entry, every time.
+- **Every emitted workflow/buildspec names its source** (comment header
+  `migrated-from: azure-pipelines.yml#<stage>/<job>`).
+- **The manual-action section of the report is named exactly `## Manual Action Items`.**
+- **No em dash (U+2014) anywhere in emitted output** - use a hyphen.
+- Stay on the current branch; do not commit.
+
+## Workflow
+
+```text
+Phase 0  Read additionalPlanContext: target (github-actions | codepipeline, default
+         github-actions), plus optional default_branch and aws_region (codepipeline).
+Phase 1  Discovery. Find every pipeline YAML (azure-pipelines*.yml, *.yml with the
+         trigger/stages/jobs top-level shape, template files referenced by them).
+         Inventory EVERY construct present AND the external dependencies consumed
+         (variable groups, service connections, environments, pools). Classify
+         MECHANICAL / SCAFFOLD / REPORT-ONLY.
+Phase 2  Convert the MECHANICAL set for the resolved target.
+Phase 3  Emit scaffolds (variable-group references, OIDC skeleton, environments,
+         reusable-workflow skeletons for templates).
+Phase 4  Validate: YAML parses; GitHub target - every job has runs-on and at least one
+         step, every uses: pins a major version, zero $(...) Azure macro syntax survives;
+         CodePipeline target - the CloudFormation template passes a structural lint
+         (Resources present, every stage has actions) and every buildspec has phases.
+Phase 5  MIGRATION_REPORT.md at the root: full inventory (present and absent), external
+         dependency table (variable groups, connections, environments), per-construct
+         classification, Manual Action Items, TODO(migration) cross-reference.
+```
+
+## Exit Criteria
+
+1. Every pipeline YAML and template in the repository appears in the inventory with a
+   classification per construct.
+2. Originals byte-identical. All output under `cicd-migration/`; `MIGRATION_REPORT.md` at
+   the repository root; no other file created or modified at the root.
+3. Zero Azure Pipelines macro syntax (`$(Var)`) and zero `task:` keys survive in emitted
+   output - each is either converted or quoted inside a report entry.
+4. Every variable group, service connection and environment consumed by the pipeline has a
+   report entry and, where referenced in output, a `TODO(migration)`.
+5. Emitted YAML parses. GitHub target: every job has `runs-on`; every `uses:` carries a
+   version. CodePipeline target: template lints, every buildspec has `phases`.
+6. Every `TODO(migration)` has an entry in Manual Action Items, and vice versa.
+7. The report states which target was resolved and why (explicit vs default).
+
+## Non-Goals
+
+1. Migrating repository hosting, branch policies, Boards, Artifacts feeds or wikis.
+2. Provisioning runners, CodeBuild fleets or IAM roles - scaffolds and instructions only.
+3. Classic (GUI) pipeline conversion - export guidance in the report.
+4. Executing the migration or registering anything in GitHub/AWS.

--- a/community-sourced-transformations/azure-devops-pipelines-migration/references/01-tasks-and-variables.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/references/01-tasks-and-variables.md
@@ -1,0 +1,85 @@
+# Tasks, Variables and the GitHub Actions Target
+
+The shared catalog (used by both targets) plus the GitHub Actions emission rules. The rule
+that governs everything: **a `task:` not in this catalog degrades to report-only with its raw
+inputs quoted - never guess an action name.**
+
+## 1. Task catalog
+
+| Azure task | GitHub Actions | Notes |
+|---|---|---|
+| `UseDotNet@2` | `actions/setup-dotnet@v4` | `version` → `dotnet-version` |
+| `DotNetCoreCLI@2` | `run: dotnet <command>` | `projects` glob expands into the command; `publishWebProjects`/`zipAfterPublish` become explicit flags |
+| `NodeTool@0` | `actions/setup-node@v4` | `versionSpec` → `node-version` |
+| `UsePythonVersion@0` | `actions/setup-python@v5` | `versionSpec` → `python-version` |
+| `Bash@3` | `run:` with `shell: bash` | `targetType: inline` → the script block; `filePath` → `run: ./<path>` |
+| `PowerShell@2` / `pwsh` | `run:` with `shell: pwsh` | |
+| `CmdLine@2` | `run:` | |
+| `Docker@2` | `run: docker build/push` or `docker/build-push-action@v6` | registry login is a service connection → SCAFFOLD |
+| `ArchiveFiles@2` | `run: zip -r ...` | `rootFolderOrFile` / `archiveFile` mapped into the command |
+| `CopyFiles@2` | `run: cp -r ...` | |
+| `PublishBuildArtifacts@1` / `PublishPipelineArtifact@1` | `actions/upload-artifact@v4` | `ArtifactName` → `name`, `PathtoPublish` → `path` |
+| `DownloadBuildArtifacts@0` / `DownloadPipelineArtifact@2` | `actions/download-artifact@v4` | |
+| `PublishTestResults@2` | report note + `if: always()` upload of the results file | GitHub has no native test-report ingestion; the report names the marketplace candidates |
+| `checkout: self` | `actions/checkout@v4` | `submodules`, `fetchDepth` → same-named inputs |
+
+## 2. Predefined variables
+
+| Azure macro | GitHub Actions | CodeBuild |
+|---|---|---|
+| `$(Build.SourcesDirectory)` / `$(System.DefaultWorkingDirectory)` | `${{ github.workspace }}` | `$CODEBUILD_SRC_DIR` |
+| `$(Build.BuildId)` | `${{ github.run_id }}` | `$CODEBUILD_BUILD_ID` |
+| `$(Build.BuildNumber)` | `${{ github.run_number }}` | `$CODEBUILD_BUILD_NUMBER` |
+| `$(Build.SourceBranchName)` | `${{ github.ref_name }}` | `$CODEBUILD_WEBHOOK_HEAD_REF` (trimmed) + note |
+| `$(Build.SourceVersion)` | `${{ github.sha }}` | `$CODEBUILD_RESOLVED_SOURCE_VERSION` |
+| `$(Build.Repository.Name)` | `${{ github.repository }}` | report note |
+| `$(Build.ArtifactStagingDirectory)` | a job-local `mkdir` (e.g. `${{ runner.temp }}/staging`) | `artifacts.base-directory` |
+| `$(Agent.OS)` | `${{ runner.os }}` | report note |
+| `$(Build.Reason)` | `${{ github.event_name }}` with a mapping note (`Schedule` → `schedule`, `PullRequest` → `pull_request`, `IndividualCI` → `push`) | `$CODEBUILD_INITIATOR` + note |
+| User variable `$(name)` | `${{ env.name }}` (inline) or `${{ secrets.NAME }}` / `${{ vars.NAME }}` (variable group → SCAFFOLD) | `env.variables` / Secrets Manager reference |
+
+## 3. Pools
+
+| `vmImage` | `runs-on` | CodeBuild |
+|---|---|---|
+| `ubuntu-latest` / `ubuntu-*` | same string | `aws/codebuild/standard:7.0` (Linux) |
+| `windows-latest` / `windows-*` | same string | `aws/codebuild/windows-base:2019-3.0` + report note |
+| `macOS-*` | same string | REPORT-ONLY (no CodeBuild macOS in most regions) |
+| `pool: name:` (self-hosted) | `runs-on: [self-hosted]` + report entry | REPORT-ONLY (fleet provisioning) |
+
+## 4. Conditions
+
+| Azure | GitHub Actions |
+|---|---|
+| `succeeded()` (default) | omitted (`if: success()` is the default) |
+| `always()` | `if: always()` |
+| `failed()` | `if: failure()` |
+| `eq(variables['X'], 'y')` / `ne(...)` | `if: env.X == 'y'` / `!=` |
+| `ne(variables['Build.Reason'], 'Schedule')` | `if: github.event_name != 'schedule'` |
+| Compound `and()`/`or()` | `&&` / `||`, converted recursively |
+| Anything referencing stage-level `dependencies.*.outputs` | SCAFFOLD: `needs.<job>.outputs` requires the producing step to declare the output - both sides emitted with `TODO(migration)` |
+
+## 5. Structure mapping (GitHub Actions target)
+
+- One Azure **pipeline file** → one workflow file, kebab-cased from the pipeline file name
+  (`azure-pipelines.yml` → `ci.yml`; `azure-pipelines-release.yml` → `release.yml`).
+- **Stages flatten into jobs.** A stage's `dependsOn` becomes `needs` on every job of the
+  stage. Stage-level `condition` is ANDed into each job's `if`.
+- Job ids keep the Azure `job` name, kebab-cased; `displayName` → `name`.
+- Every workflow starts with the provenance header comment:
+  `# migrated-from: <pipeline file>#<stage>` and carries `permissions: contents: read`
+  (least privilege by default; widened only when a converted step needs more, with a report
+  entry).
+
+## 6. Validation greps (Phase 4)
+
+```bash
+# zero Azure macro syntax in emitted output
+grep -rE '\$\((Build|System|Agent|Pipeline)\.' cicd-migration/ && exit 1
+
+# zero unconverted task keys
+grep -rE '^\s*-?\s*task:' cicd-migration/ && exit 1
+
+# every uses: pinned to a major version
+grep -rE 'uses:.*@' cicd-migration/github-actions/ | grep -vE '@v[0-9]+' && exit 1
+```

--- a/community-sourced-transformations/azure-devops-pipelines-migration/references/02-codepipeline-target.md
+++ b/community-sourced-transformations/azure-devops-pipelines-migration/references/02-codepipeline-target.md
@@ -1,0 +1,85 @@
+# CodePipeline Target - Emission Rules
+
+Selected with `additionalPlanContext: "target: codepipeline"`. Discovery and classification
+are identical to the GitHub Actions target; this reference covers only what is emitted.
+
+## Output layout
+
+```text
+cicd-migration/codepipeline/
+├── pipeline.yaml            # CloudFormation: the CodePipeline + one CodeBuild project per job
+└── buildspecs/
+    └── <stage>-<job>.yml    # one buildspec per Azure job
+```
+
+## Structure mapping
+
+| Azure construct | CodePipeline emission |
+|---|---|
+| Pipeline | one `AWS::CodePipeline::Pipeline` resource |
+| `stages` (ordered by `dependsOn`) | pipeline `Stages`, topologically sorted - CodePipeline stages are strictly sequential, so parallel Azure stages become parallel ACTIONS inside one stage, with a report note |
+| `job` | one `AWS::CodeBuild::Project` + one buildspec |
+| `steps` | buildspec `phases.build.commands` (setup tasks land in `phases.install`) |
+| `trigger` branches | the pipeline source action's branch config; extra branches → report note (one pipeline per branch or a trigger filter) |
+| `schedules` cron | `AWS::Scheduler::Schedule` targeting the pipeline, cron translated (Azure cron is 5-field UTC; EventBridge is 6-field - the conversion appends `?`/year and states the assumption) |
+| `pr:` | report note: PR validation in CodeBuild is a webhook `FILTER_GROUPS` config on the project, emitted commented |
+| environment approvals | a Manual Approval action inserted before the deploy stage |
+| `strategy.matrix` | one CodeBuild project per matrix leg, suffixed with the leg name |
+
+## Buildspec shape
+
+```yaml
+# migrated-from: azure-pipelines.yml#BuildAndPackage/Build
+version: 0.2
+env:
+  variables:
+    dotnetVersion: "8.x"        # from inline variables
+  secrets-manager: {}            # variable groups land here as TODO(migration) entries
+phases:
+  install:
+    commands:
+      - echo "setup tasks (UseDotNet@2 -> runtime image or install commands)"
+  build:
+    commands:
+      - dotnet restore
+      - dotnet build --configuration Release
+artifacts:
+  base-directory: out            # from Build.ArtifactStagingDirectory usage
+  files: ["**/*"]
+```
+
+Rules:
+
+- Setup tasks (`UseDotNet@2`, `NodeTool@0`, `UsePythonVersion@0`) prefer selecting a CodeBuild
+  image that ships the runtime; when the version is not in any standard image, emit install
+  commands with a report note.
+- `PublishBuildArtifacts@1` → the buildspec `artifacts` section + pipeline artifact wiring
+  between stages (`InputArtifacts`/`OutputArtifacts`).
+- Variable groups → `env.secrets-manager` keys with `TODO(migration): create the secret and
+  set the ARN` - never a fabricated ARN.
+- Service connections → the CodeBuild project `ServiceRole` placeholder
+  `TODO(migration): role ARN` plus a report entry describing the minimum policy.
+- Windows jobs get `Type: WINDOWS_SERVER_2019_CONTAINER` and a report note on image parity;
+  macOS jobs are REPORT-ONLY.
+
+## Template lint (Phase 4, codepipeline target)
+
+```bash
+python3 - <<'PY'
+import yaml, sys
+# CloudFormation short-form (!Ref, !Sub) is valid YAML with custom tags - register a
+# no-op constructor, plain safe_load would reject a correct template.
+class L(yaml.SafeLoader): pass
+L.add_multi_constructor("!", lambda l, s, n: None)
+t = yaml.load(open("cicd-migration/codepipeline/pipeline.yaml"), Loader=L)
+assert "Resources" in t, "no Resources"
+pipes = [r for r in t["Resources"].values() if r.get("Type") == "AWS::CodePipeline::Pipeline"]
+assert pipes, "no pipeline resource"
+for p in pipes:
+    for s in p["Properties"]["Stages"]:
+        assert s.get("Actions"), f"stage {s.get('Name')} has no actions"
+PY
+```
+
+Every buildspec must parse and contain `phases`; every `secrets-manager` value that is not a
+real ARN must carry `TODO(migration)` on the same line.


### PR DESCRIPTION
Transforms Azure DevOps Pipelines (azure-pipelines.yml and template files) into the target CI/CD chosen at run time via additionalPlanContext: GitHub Actions workflows (default), or AWS CodePipeline with CodeBuild buildspecs. Converts triggers, stages, jobs, steps, matrices, conditions and the common task catalog; scaffolds variable groups, service connections and environments with explicit TODO(migration) markers (values live in Azure DevOps and are never invented); reports every construct with no counterpart (classic GUI pipelines, task groups, gates, uncataloged marketplace tasks).

Follows the same README.md / SKILL.md / BENCHMARKS.md / references/ structure as eks-version-upgrade-readiness.

Validation (see BENCHMARKS.md): executed end-to-end via `atx custom def exec` against a real production repository with a multi-stage pipeline (variable group, cron schedule, mixed ubuntu/windows pools, marketplace task, stage conditions), on BOTH targets - source integrity 0 files changed in both runs, zero Azure macro syntax or task: keys surviving, every uses: pinned, the CloudFormation template lints (4 stages, 4 CodeBuild projects) and all 4 buildspecs parse with phases.