### PR TITLE
docs(tanzu-to-eks): SKILL v0.2.0 and BENCHMARKS round 3

### DIFF
--- a/community-sourced-transformations/tanzu-to-eks/BENCHMARKS.md
+++ b/community-sourced-transformations/tanzu-to-eks/BENCHMARKS.md
@@ -5,19 +5,21 @@
 | Metric | Result |
 |--------|--------|
 | Repositories tested | 2 real upstream Cloud Foundry sample repos, pinned to a commit |
-| Rounds | 2 - round 1 found 2 defects, both fixed in `SKILL.md` and re-validated in round 2 |
-| Transformation success rate (round 2) | **2/2 COMPLETE** |
-| **Source integrity** | **0 files modified outside `eks/` and the report, in both round-2 runs** |
-| Files emitted (round 2) | 5 (`spring-music`) and 5 (`cf-sample-app-nodejs`) |
-| `MIGRATION_REPORT.md` at repository ROOT | **2/2** (the round-1 defect - report inside `eks/` - is fixed) |
-| `.dockerignore` under `eks/`, never at the root | **2/2** (the round-1 defect - root `.dockerignore` - is fixed) |
+| Rounds | 3 - rounds 1 and 2 found 2 contract defects each, all fixed in `SKILL.md` and re-validated |
+| Transformation success rate (round 3) | **2/2 COMPLETE** |
+| **Source integrity** | **0 files modified outside `eks/` and the report, in both round-3 runs** |
+| Files emitted (round 3) | 5 (`spring-music`) and 5 (`cf-sample-app-nodejs`) |
+| `MIGRATION_REPORT.md` at repository ROOT | **2/2** |
+| `.dockerignore` under `eks/`, never at the root | **2/2** |
+| `## Manual Action Items` as the report section name | **2/2** (the round-2 variance - three names across three runs - is fixed) |
+| Em dash (U+2014) in emitted output | **0 in both runs** (the round-2 variance is fixed) |
 | `*.openshift.io` surviving in output | 0 in both runs |
-| `TODO(migration)` markers | 4 and 5, all paired with report entries |
+| `TODO(migration)` markers in emitted files | 6 and 7, each paired 1:1 with a `## Manual Action Items` row |
 | Invented credentials in stubs | 0 |
 | `kubectl apply --dry-run=client` | clean in both runs |
-| Total agent minutes (round 2) | 88.74 (47.85 + 40.89) |
-| Total estimated cost (round 2) | ~US$ 3.11 (at US$ 0.035 / agent minute) |
-| Cumulative incl. round 1 | ~179.36 agent minutes, ~US$ 6.28 |
+| Total agent minutes (round 3) | 84.68 (43.40 + 41.28) |
+| Total estimated cost (round 3) | ~US$ 2.96 (at US$ 0.035 / agent minute) |
+| Cumulative across 3 rounds | ~264.04 agent minutes, ~US$ 9.24 |
 
 ### Methodology
 
@@ -50,20 +52,25 @@ modified at the root, zero OpenShift `apiVersion` leakage, YAML validity, `--dry
 
 ---
 
-## At-a-Glance Results (round 2, 2026-08-28)
+## At-a-Glance Results (round 3, 2026-08-30, `SKILL.md` v0.2.0)
 
-| # | Repository | Status | Files emitted | Report at root | Root untouched | Source changed | TODOs | Agent Min | Cost |
-|---|---|---|---|---|---|---|---|---|---|
-| 1 | `spring-music` | COMPLETE | 5 (294 lines) | PASS (11.1 KB) | PASS | **0** | 4 | 47.85 | $1.67 |
-| 2 | `cf-sample-app-nodejs` | COMPLETE | 5 | PASS (8.4 KB) | PASS | **0** | 5 | 40.89 | $1.43 |
-| | **TOTALS** | **2/2** | **10** | **2/2** | **2/2** | **0** | **9** | **88.74** | **$3.11** |
+| # | Repository | Status | Files emitted | Report at root | Root untouched | Source changed | TODOs | Wall clock | Agent Min | Cost |
+|---|---|---|---|---|---|---|---|---|---|---|
+| 1 | `spring-music` | COMPLETE | 5 | PASS (11.8 KB) | PASS | **0** | 6 | 8m43s | 43.40 | $1.52 |
+| 2 | `cf-sample-app-nodejs` | COMPLETE | 5 | PASS (10.3 KB) | PASS | **0** | 7 | 7m10s | 41.28 | $1.44 |
+| | **TOTALS** | **2/2** | **10** | **2/2** | **2/2** | **0** | **13** | **15m53s** | **84.68** | **$2.96** |
+
+Both runs emitted the same 5 files under `eks/`: `deployment.yaml`, `service.yaml`, `ingress.yaml`,
+`project.toml`, `.dockerignore`, plus `MIGRATION_REPORT.md` at the repository root.
 
 ---
 
-## Round 1 → Round 2: the two defects and their fixes
+## Round history: 4 defects found, 4 fixed
 
-Round 1 (2026-08-21, 90.62 agent minutes across the same two repos) surfaced two contract
-violations, both fixed in `SKILL.md` and re-validated in round 2 on both repos:
+Each round ran both repos, so every fix is validated on both workload shapes before the next
+`SKILL.md` revision.
+
+### Round 1 (2026-08-21, 90.62 agent minutes) to round 2
 
 | # | Round-1 defect | Fix in SKILL.md | Round-2 evidence |
 |---|---|---|---|
@@ -74,30 +81,38 @@ An incidental defect in the `spring-music` run self-corrected: a `.DS_Store` was
 root in Step 1 and removed by the run's own Step 2 fix - the final tree is clean and the source
 integrity assertion passes against the baseline.
 
-## Exit Criteria Compliance (per SKILL.md)
+### Round 2 (2026-08-28, 88.74 agent minutes) to round 3
+
+Round 2 passed every integrity assertion but left two report-cosmetic variances open, both of
+which needed a contract decision rather than a validator change. `SKILL.md` v0.2.0 pinned both,
+and round 3 confirms them closed:
+
+| # | Round-2 variance | Fix in SKILL.md v0.2.0 | Round-3 evidence |
+|---|---|---|---|
+| 3 | The manual-action section name was not pinned, so three runs produced three names: `Manual Action`, `TODO(migration) Checklist`, `TODO(migration) Cross-Reference`. The pairing was correct every time, but a validator can only gate on a known name. | "**The manual-action section of the report is named exactly `## Manual Action Items`.**" plus exit criterion 6 reworded to name that section | `## Manual Action Items` in 2/2 runs, verbatim |
+| 4 | Em dash (U+2014) used as a table separator in generated report prose. No definition in this collection forbade it; the surrounding ecosystem standard does. | "**No em dash (U+2014) anywhere in emitted output** - use a hyphen." | 0 occurrences of U+2014 in 2/2 reports |
+
+Neither variance affected source integrity or the emitted manifests, which is why they were
+batched into one `SKILL.md` revision and validated together instead of shipped as unmeasured
+edits.
+
+## Exit Criteria Compliance, round 3 (per `SKILL.md` v0.2.0)
 
 | # | Exit criterion | spring-music | cf-sample-app-nodejs |
 |---|---|---|---|
 | 1 | Every manifest field, present or absent, in the report inventory | PASS | PASS |
 | 2 | Originals byte-identical; output under `eks/`; report at root; no other root file | PASS | PASS |
 | 3 | Secret stubs with empty values + `TODO(migration)` | PASS (no invented credential) | PASS |
-| 4 | Emitted YAML parses; `--dry-run=client` clean | PASS (2 YAML) | PASS (3 YAML) |
+| 4 | Emitted YAML parses; `--dry-run=client` clean | PASS (3 YAML) | PASS (3 YAML) |
 | 5 | Every REPORT-ONLY construct has a report entry | PASS | PASS |
-| 6 | Every `TODO(migration)` paired with a report entry, and vice versa | PASS (4/4, `TODO(migration) Checklist` section) | PASS (5/5, `TODO(migration) Cross-Reference` table) |
+| 6 | Every `TODO(migration)` has an entry in `## Manual Action Items`, and vice versa | PASS (6/6 markers mapped to rows 1-6; rows 7-14 are report-only constructs) | PASS (7/7 markers mapped to rows 1-7; rows 8-10 are report-only constructs) |
 | 7 | `memory` translation carries the HIGH-risk JVM note when a JVM language is detected | PASS (Java 17 detected, OOMKill-loop risk documented) | N/A (Node.js) |
 
-## Known variance (open, needs a SKILL.md decision before the next publish)
+## Measurement notes
 
-1. **The manual-action section name is not pinned by the contract.** Three runs produced three
-   names: `Manual Action` (round 1), `TODO(migration) Checklist` (spring-music round 2),
-   `TODO(migration) Cross-Reference` (cf round 2). The pairing was correct every time, but
-   `assert_def_run.py` can only gate on a known name - it currently accepts the first two and
-   flags the third. Fix belongs in `SKILL.md` (pin one name), NOT in loosening the validator.
-2. **Em dashes in generated report prose.** The cf round-2 report uses the em dash character
-   (U+2014) as a table separator. No definition in this collection currently forbids it; the
-   ecosystem standard does. Same
-   decision point: add the constraint to `SKILL.md` and re-validate.
-
-Both are report-cosmetic - neither affects source integrity nor the emitted manifests - and both
-require a republish, so they are batched for the next SKILL.md revision rather than shipped as
-an unvalidated edit.
+- **Agent minutes** come from the `atx` CLI run summary (`Agent Minutes used: 43.40 / 70.00`).
+  Cost is derived at US$ 0.035 per agent minute and is an estimate, not a billed figure.
+- **Wall clock** is measured from the run log timestamps and is reported separately because it
+  includes local fixture setup and is not the billing unit.
+- The `atx` conversation log does not record per-run token counts, so token-level cost is not
+  captured here.

--- a/community-sourced-transformations/tanzu-to-eks/README.md
+++ b/community-sourced-transformations/tanzu-to-eks/README.md
@@ -149,12 +149,14 @@ MIGRATION_REPORT.md       inventory (present AND absent fields), scaffolds, manu
 
 ## Benchmarks
 
-See [`BENCHMARKS.md`](BENCHMARKS.md). Summary: two rounds against two real Cloud Foundry sample
+See [`BENCHMARKS.md`](BENCHMARKS.md). Summary: three rounds against two real Cloud Foundry sample
 repositories (`cloudfoundry-samples/spring-music`, `cloudfoundry-samples/cf-sample-app-nodejs`),
-both pinned. Round 1 surfaced 2 contract defects, both fixed in `SKILL.md` and re-validated in
-round 2 on both repos. Round 2: 2/2 COMPLETE, source integrity 0 files modified outside `eks/`
-and the report, `MIGRATION_REPORT.md` at the repository root in 2/2 runs,
-`kubectl apply --dry-run=client` clean, every `TODO(migration)` paired with a report entry.
+both pinned. Round 1 surfaced 2 contract defects and round 2 surfaced 2 report-cosmetic variances;
+all 4 are fixed in `SKILL.md` and re-validated on both repos before publishing. Round 3, on
+`SKILL.md` v0.2.0: 2/2 COMPLETE, source integrity 0 files modified outside `eks/` and the report,
+`MIGRATION_REPORT.md` at the repository root in 2/2 runs, `kubectl apply --dry-run=client` clean,
+`## Manual Action Items` as the report section name in 2/2, zero em dash in emitted output, and
+every `TODO(migration)` paired 1:1 with a row in that section.
 
 The paired assessment has been validated separately against the same two repositories:
 31/31 question coverage, counts reconciled, read-only verified, and every cited evidence file

--- a/community-sourced-transformations/tanzu-to-eks/SKILL.md
+++ b/community-sourced-transformations/tanzu-to-eks/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   reconstructed from the repository. Not for Tanzu Kubernetes Grid (TKG).
   Trigger: Cloud Foundry migration, TAS to EKS, PCF to EKS, manifest.yml, VCAP_SERVICES, cf push.
 type: custom
-version: 0.1.0
+version: 0.2.0
 ---
 
 # Tanzu / Cloud Foundry to Amazon EKS
@@ -97,6 +97,8 @@ common cause of an OOMKill loop after a CF migration.
   where, the TODO shows what, the report shows why.
 - **Absence is reported, not filled.** If the repository has no health check, no CPU value and no
   Dockerfile, say so for each - do not quietly supply defaults that look like decisions someone made.
+- **The manual-action section of the report is named exactly `## Manual Action Items`.**
+- **No em dash (U+2014) anywhere in emitted output** - use a hyphen.
 - Stay on the current branch; do not commit.
 
 ## Workflow
@@ -124,7 +126,7 @@ Phase 5  MIGRATION_REPORT.md, cross-referenced to the Lens question ids.
    is a defect, not a convenience.
 4. Emitted YAML parses; `--dry-run=client` clean; charts render under `helm template`.
 5. Every REPORT-ONLY construct has a report entry naming the construct, the reason, and the path.
-6. Every `TODO(migration)` has a report entry, and vice versa.
+6. Every `TODO(migration)` has an entry in the report's `## Manual Action Items`, and vice versa.
 7. The `memory` translation carries its HIGH-risk JVM note whenever a JVM language is detected.
 
 ## Non-Goals


### PR DESCRIPTION
Follow-up to #85, docs only. No change to the transformation logic beyond two new constraints in `SKILL.md`.

#85 merged while benchmark round 3 was still running, so `main` currently carries `SKILL.md` v0.1.0 alongside a `BENCHMARKS.md` section titled *Known variance (open, needs a SKILL.md decision before the next publish)*. Both of those variances are now closed and measured, so the published docs describe a decision as pending when it is not. This PR brings the three docs into agreement.

## What changed

| File | Change |
|---|---|
| `SKILL.md` | v0.1.0 to v0.2.0. Adds two constraints and rewords exit criterion 6 to name the section, so the constraint and the criterion cannot drift apart. |
| `BENCHMARKS.md` | Adds round 3, removes the resolved variance section, adds measurement notes. |
| `README.md` | The Benchmarks summary said "two rounds" and stopped at round 2. |

The two new constraints:

- **The manual-action section of the report is named exactly `## Manual Action Items`.** Three earlier runs produced three different names (`Manual Action`, `TODO(migration) Checklist`, `TODO(migration) Cross-Reference`). The pairing was correct every time, but a validator can only gate on a known name, so the fix belongs in the contract rather than in loosening the validator.
- **No em dash (U+2014) anywhere in emitted output.** A round-2 report used it as a table separator. No definition in this collection forbade it.

## How it was tested

Round 3 ran the published v0.2.0 definition against the same two pinned upstream fixtures used in rounds 1 and 2, so both fixes are validated on both CF workload shapes (JVM and Node.js) rather than on one.

| Repository | Status | Files emitted | Report at root | Source changed | Section name | Em dash | TODOs paired | Agent Min |
|---|---|---|---|---|---|---|---|---|
| `cloudfoundry-samples/spring-music` | COMPLETE | 5 | PASS | 0 | `## Manual Action Items` | 0 | 6/6 | 43.40 |
| `cloudfoundry-samples/cf-sample-app-nodejs` | COMPLETE | 5 | PASS | 0 | `## Manual Action Items` | 0 | 7/7 | 41.28 |

Source integrity is measured as `git diff` against a pinned baseline commit, and `kubectl apply --dry-run=client` is clean in both runs. Full detail, including the round history and the measurement caveats, is in `BENCHMARKS.md`.

The `TODO` counts differ from round 2 (4 and 5) because the pinned section now cross-references every marker explicitly. Each of the 6 and 7 markers in the emitted files maps 1:1 to a row in `## Manual Action Items`; the remaining rows in that table are report-only constructs that have no file to carry a marker.

## Not included

`openshift-to-eks` also lacks the pinned-section constraint. I left it alone deliberately: adding the constraint without a benchmark round would put its `SKILL.md` ahead of its `BENCHMARKS.md`, which is the same inconsistency this PR is fixing. Happy to do it as a separate benchmarked PR if you want the four definitions uniform.